### PR TITLE
Fix exclude-local skill cleanup

### DIFF
--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1238,6 +1238,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					overrideSkip: overrideSkip as SkillTargetName[] | undefined,
 					validAgents,
 					excludeLocal: excludeLocalSkills,
+					removeMissing: argv.removeMissing,
 				});
 			}
 


### PR DESCRIPTION
## Summary
- remove previously synced local-only skill directories when running sync with --exclude-local (honors --remove-missing)
- avoid parsing local skill frontmatter by deriving local-only paths from directory layout
- add regression test for exclude-local cleanup behavior

## Testing
- npm run check
- npm test
- npm run build

Fixes #9.