### PR TITLE
chore: reorganize builtin targets

### DIFF
--- a/src/lib/targets/builtins.ts
+++ b/src/lib/targets/builtins.ts
@@ -1,76 +1,14 @@
+import { claudeTarget } from "./builtins/claude-code/target.js";
+import { codexTarget } from "./builtins/codex/target.js";
+import { copilotTarget } from "./builtins/copilot-cli/target.js";
+import { geminiTarget } from "./builtins/gemini-cli/target.js";
 import type { TargetDefinition } from "./config-types.js";
 
 export const BUILTIN_TARGETS: TargetDefinition[] = [
-	{
-		id: "codex",
-		displayName: "OpenAI Codex",
-		outputs: {
-			skills: "{repoRoot}/.codex/skills/{itemName}",
-			subagents: {
-				path: "{repoRoot}/.codex/skills/{itemName}",
-				fallback: { mode: "convert", targetType: "skills" },
-			},
-			commands: {
-				userPath: "{homeDir}/.codex/prompts/{itemName}.md",
-			},
-			instructions: {
-				filename: "AGENTS.md",
-				group: "agents",
-			},
-		},
-	},
-	{
-		id: "claude",
-		displayName: "Claude Code",
-		outputs: {
-			skills: "{repoRoot}/.claude/skills/{itemName}",
-			subagents: "{repoRoot}/.claude/agents/{itemName}.md",
-			commands: {
-				projectPath: "{repoRoot}/.claude/commands/{itemName}.md",
-				userPath: "{homeDir}/.claude/commands/{itemName}.md",
-			},
-			instructions: {
-				filename: "CLAUDE.md",
-			},
-		},
-	},
-	{
-		id: "gemini",
-		displayName: "Gemini CLI",
-		outputs: {
-			skills: "{repoRoot}/.gemini/skills/{itemName}",
-			subagents: {
-				path: "{repoRoot}/.gemini/skills/{itemName}",
-				fallback: { mode: "convert", targetType: "skills" },
-			},
-			commands: {
-				projectPath: "{repoRoot}/.gemini/commands/{itemName}.toml",
-				userPath: "{homeDir}/.gemini/commands/{itemName}.toml",
-			},
-			instructions: {
-				filename: "GEMINI.md",
-			},
-		},
-	},
-	{
-		id: "copilot",
-		displayName: "GitHub Copilot CLI",
-		outputs: {
-			skills: "{repoRoot}/.github/skills/{itemName}",
-			subagents: {
-				path: "{repoRoot}/.github/skills/{itemName}",
-				fallback: { mode: "convert", targetType: "skills" },
-			},
-			commands: {
-				projectPath: "{repoRoot}/.github/skills/{itemName}",
-				fallback: { mode: "convert", targetType: "skills" },
-			},
-			instructions: {
-				filename: "AGENTS.md",
-				group: "agents",
-			},
-		},
-	},
+	codexTarget,
+	claudeTarget,
+	geminiTarget,
+	copilotTarget,
 ];
 
 export const BUILTIN_TARGET_IDS = Object.freeze(BUILTIN_TARGETS.map((target) => target.id));

--- a/src/lib/targets/builtins/claude-code/target.test.ts
+++ b/src/lib/targets/builtins/claude-code/target.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import {
+	normalizeCommandOutputDefinition,
+	normalizeInstructionOutputDefinition,
+	normalizeOutputDefinition,
+	resolveCommandOutputPath,
+	resolveInstructionFilename,
+	resolveOutputPath,
+} from "../../output-resolver.js";
+import { claudeTarget } from "./target.js";
+
+function expectDefined<T>(value: T | null | undefined, label: string): T {
+	expect(value, `${label} should be defined`).toBeDefined();
+	if (value == null) {
+		throw new Error(`${label} is undefined`);
+	}
+	return value;
+}
+
+describe("claude builtin target", () => {
+	const repoRoot = path.resolve("claude-repo");
+	const homeDir = path.resolve("claude-home");
+	const agentsDir = path.join(repoRoot, "agents");
+	const itemName = "helper";
+	const context = {
+		repoRoot,
+		homeDir,
+		agentsDir,
+		targetId: "claude",
+		itemName,
+	};
+
+	it("defines core metadata", () => {
+		expect(claudeTarget.id).toBe("claude");
+		expect(claudeTarget.displayName).toBe("Claude Code");
+	});
+
+	it("routes skills and subagents to .claude directories", () => {
+		const skills = expectDefined(normalizeOutputDefinition(claudeTarget.outputs?.skills), "skills");
+		expect(skills.path).toBe("{repoRoot}/.claude/skills/{itemName}");
+		const skillsPath = resolveOutputPath({
+			template: skills.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(skillsPath).toBe(path.join(repoRoot, ".claude", "skills", itemName));
+
+		const subagents = expectDefined(
+			normalizeOutputDefinition(claudeTarget.outputs?.subagents),
+			"subagents",
+		);
+		expect(subagents.path).toBe("{repoRoot}/.claude/agents/{itemName}.md");
+		expect(subagents.fallback).toBeUndefined();
+		const subagentPath = resolveOutputPath({
+			template: subagents.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(subagentPath).toBe(path.join(repoRoot, ".claude", "agents", `${itemName}.md`));
+	});
+
+	it("writes commands to project and user command folders", () => {
+		const commands = expectDefined(
+			normalizeCommandOutputDefinition(claudeTarget.outputs?.commands),
+			"commands",
+		);
+		expect(commands.projectPath).toBe("{repoRoot}/.claude/commands/{itemName}.md");
+		expect(commands.userPath).toBe("{homeDir}/.claude/commands/{itemName}.md");
+		const projectPath = expectDefined(commands.projectPath, "commands.projectPath");
+
+		const projectCommandPath = resolveCommandOutputPath({
+			template: projectPath,
+			context: { ...context, commandLocation: "project" },
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(projectCommandPath).toBe(path.join(repoRoot, ".claude", "commands", `${itemName}.md`));
+
+		const userPath = expectDefined(commands.userPath, "commands.userPath");
+		const userCommandPath = resolveCommandOutputPath({
+			template: userPath,
+			context: { ...context, commandLocation: "user" },
+			item: {},
+			baseDir: homeDir,
+		});
+		expect(userCommandPath).toBe(path.join(homeDir, ".claude", "commands", `${itemName}.md`));
+	});
+
+	it("writes instructions to CLAUDE.md", () => {
+		const instructions = expectDefined(
+			normalizeInstructionOutputDefinition(claudeTarget.outputs?.instructions),
+			"instructions",
+		);
+		expect(instructions.filename).toBe("CLAUDE.md");
+		expect(instructions.group).toBeUndefined();
+		const filename = resolveInstructionFilename({
+			template: instructions.filename,
+			context,
+			item: {},
+		});
+		expect(filename).toBe("CLAUDE.md");
+	});
+});

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -1,0 +1,17 @@
+import type { TargetDefinition } from "../../config-types.js";
+
+export const claudeTarget: TargetDefinition = {
+	id: "claude",
+	displayName: "Claude Code",
+	outputs: {
+		skills: "{repoRoot}/.claude/skills/{itemName}",
+		subagents: "{repoRoot}/.claude/agents/{itemName}.md",
+		commands: {
+			projectPath: "{repoRoot}/.claude/commands/{itemName}.md",
+			userPath: "{homeDir}/.claude/commands/{itemName}.md",
+		},
+		instructions: {
+			filename: "CLAUDE.md",
+		},
+	},
+};

--- a/src/lib/targets/builtins/codex/target.test.ts
+++ b/src/lib/targets/builtins/codex/target.test.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import {
+	normalizeCommandOutputDefinition,
+	normalizeInstructionOutputDefinition,
+	normalizeOutputDefinition,
+	resolveCommandOutputPath,
+	resolveInstructionFilename,
+	resolveOutputPath,
+} from "../../output-resolver.js";
+import { codexTarget } from "./target.js";
+
+function expectDefined<T>(value: T | null | undefined, label: string): T {
+	expect(value, `${label} should be defined`).toBeDefined();
+	if (value == null) {
+		throw new Error(`${label} is undefined`);
+	}
+	return value;
+}
+
+describe("codex builtin target", () => {
+	const repoRoot = path.resolve("codex-repo");
+	const homeDir = path.resolve("codex-home");
+	const agentsDir = path.join(repoRoot, "agents");
+	const itemName = "helper";
+	const context = {
+		repoRoot,
+		homeDir,
+		agentsDir,
+		targetId: "codex",
+		itemName,
+	};
+
+	it("defines core metadata", () => {
+		expect(codexTarget.id).toBe("codex");
+		expect(codexTarget.displayName).toBe("OpenAI Codex");
+	});
+
+	it("routes skills and subagents to .codex/skills with conversion fallback", () => {
+		const skills = expectDefined(normalizeOutputDefinition(codexTarget.outputs?.skills), "skills");
+		expect(skills.path).toBe("{repoRoot}/.codex/skills/{itemName}");
+		const skillsPath = resolveOutputPath({
+			template: skills.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(skillsPath).toBe(path.join(repoRoot, ".codex", "skills", itemName));
+
+		const subagents = expectDefined(
+			normalizeOutputDefinition(codexTarget.outputs?.subagents),
+			"subagents",
+		);
+		expect(subagents.path).toBe("{repoRoot}/.codex/skills/{itemName}");
+		expect(subagents.fallback).toEqual({ mode: "convert", targetType: "skills" });
+		const subagentPath = resolveOutputPath({
+			template: subagents.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(subagentPath).toBe(path.join(repoRoot, ".codex", "skills", itemName));
+	});
+
+	it("writes commands only to user prompts", () => {
+		const commands = expectDefined(
+			normalizeCommandOutputDefinition(codexTarget.outputs?.commands),
+			"commands",
+		);
+		expect(commands.projectPath).toBeUndefined();
+		expect(commands.userPath).toBe("{homeDir}/.codex/prompts/{itemName}.md");
+		const userPath = expectDefined(commands.userPath, "commands.userPath");
+		const commandPath = resolveCommandOutputPath({
+			template: userPath,
+			context: { ...context, commandLocation: "user" },
+			item: {},
+			baseDir: homeDir,
+		});
+		expect(commandPath).toBe(path.join(homeDir, ".codex", "prompts", `${itemName}.md`));
+	});
+
+	it("writes instructions to AGENTS.md in the agents group", () => {
+		const instructions = expectDefined(
+			normalizeInstructionOutputDefinition(codexTarget.outputs?.instructions),
+			"instructions",
+		);
+		expect(instructions.filename).toBe("AGENTS.md");
+		expect(instructions.group).toBe("agents");
+		const filename = resolveInstructionFilename({
+			template: instructions.filename,
+			context,
+			item: {},
+		});
+		expect(filename).toBe("AGENTS.md");
+	});
+});

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -1,0 +1,20 @@
+import type { TargetDefinition } from "../../config-types.js";
+
+export const codexTarget: TargetDefinition = {
+	id: "codex",
+	displayName: "OpenAI Codex",
+	outputs: {
+		skills: "{repoRoot}/.codex/skills/{itemName}",
+		subagents: {
+			path: "{repoRoot}/.codex/skills/{itemName}",
+			fallback: { mode: "convert", targetType: "skills" },
+		},
+		commands: {
+			userPath: "{homeDir}/.codex/prompts/{itemName}.md",
+		},
+		instructions: {
+			filename: "AGENTS.md",
+			group: "agents",
+		},
+	},
+};

--- a/src/lib/targets/builtins/copilot-cli/target.test.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.test.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+import {
+	normalizeCommandOutputDefinition,
+	normalizeInstructionOutputDefinition,
+	normalizeOutputDefinition,
+	resolveCommandOutputPath,
+	resolveInstructionFilename,
+	resolveOutputPath,
+} from "../../output-resolver.js";
+import { copilotTarget } from "./target.js";
+
+function expectDefined<T>(value: T | null | undefined, label: string): T {
+	expect(value, `${label} should be defined`).toBeDefined();
+	if (value == null) {
+		throw new Error(`${label} is undefined`);
+	}
+	return value;
+}
+
+describe("copilot builtin target", () => {
+	const repoRoot = path.resolve("copilot-repo");
+	const homeDir = path.resolve("copilot-home");
+	const agentsDir = path.join(repoRoot, "agents");
+	const itemName = "helper";
+	const context = {
+		repoRoot,
+		homeDir,
+		agentsDir,
+		targetId: "copilot",
+		itemName,
+	};
+
+	it("defines core metadata", () => {
+		expect(copilotTarget.id).toBe("copilot");
+		expect(copilotTarget.displayName).toBe("GitHub Copilot CLI");
+	});
+
+	it("routes skills and subagents to .github/skills with conversion fallback", () => {
+		const skills = expectDefined(
+			normalizeOutputDefinition(copilotTarget.outputs?.skills),
+			"skills",
+		);
+		expect(skills.path).toBe("{repoRoot}/.github/skills/{itemName}");
+		const skillsPath = resolveOutputPath({
+			template: skills.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(skillsPath).toBe(path.join(repoRoot, ".github", "skills", itemName));
+
+		const subagents = expectDefined(
+			normalizeOutputDefinition(copilotTarget.outputs?.subagents),
+			"subagents",
+		);
+		expect(subagents.path).toBe("{repoRoot}/.github/skills/{itemName}");
+		expect(subagents.fallback).toEqual({ mode: "convert", targetType: "skills" });
+		const subagentPath = resolveOutputPath({
+			template: subagents.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(subagentPath).toBe(path.join(repoRoot, ".github", "skills", itemName));
+	});
+
+	it("maps commands to project skills with conversion fallback", () => {
+		const commands = expectDefined(
+			normalizeCommandOutputDefinition(copilotTarget.outputs?.commands),
+			"commands",
+		);
+		expect(commands.projectPath).toBe("{repoRoot}/.github/skills/{itemName}");
+		expect(commands.userPath).toBeUndefined();
+		expect(commands.fallback).toEqual({ mode: "convert", targetType: "skills" });
+		const projectPath = expectDefined(commands.projectPath, "commands.projectPath");
+
+		const projectCommandPath = resolveCommandOutputPath({
+			template: projectPath,
+			context: { ...context, commandLocation: "project" },
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(projectCommandPath).toBe(path.join(repoRoot, ".github", "skills", itemName));
+	});
+
+	it("writes instructions to AGENTS.md in the agents group", () => {
+		const instructions = expectDefined(
+			normalizeInstructionOutputDefinition(copilotTarget.outputs?.instructions),
+			"instructions",
+		);
+		expect(instructions.filename).toBe("AGENTS.md");
+		expect(instructions.group).toBe("agents");
+		const filename = resolveInstructionFilename({
+			template: instructions.filename,
+			context,
+			item: {},
+		});
+		expect(filename).toBe("AGENTS.md");
+	});
+});

--- a/src/lib/targets/builtins/copilot-cli/target.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.ts
@@ -1,0 +1,21 @@
+import type { TargetDefinition } from "../../config-types.js";
+
+export const copilotTarget: TargetDefinition = {
+	id: "copilot",
+	displayName: "GitHub Copilot CLI",
+	outputs: {
+		skills: "{repoRoot}/.github/skills/{itemName}",
+		subagents: {
+			path: "{repoRoot}/.github/skills/{itemName}",
+			fallback: { mode: "convert", targetType: "skills" },
+		},
+		commands: {
+			projectPath: "{repoRoot}/.github/skills/{itemName}",
+			fallback: { mode: "convert", targetType: "skills" },
+		},
+		instructions: {
+			filename: "AGENTS.md",
+			group: "agents",
+		},
+	},
+};

--- a/src/lib/targets/builtins/gemini-cli/target.test.ts
+++ b/src/lib/targets/builtins/gemini-cli/target.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import {
+	normalizeCommandOutputDefinition,
+	normalizeInstructionOutputDefinition,
+	normalizeOutputDefinition,
+	resolveCommandOutputPath,
+	resolveInstructionFilename,
+	resolveOutputPath,
+} from "../../output-resolver.js";
+import { geminiTarget } from "./target.js";
+
+function expectDefined<T>(value: T | null | undefined, label: string): T {
+	expect(value, `${label} should be defined`).toBeDefined();
+	if (value == null) {
+		throw new Error(`${label} is undefined`);
+	}
+	return value;
+}
+
+describe("gemini builtin target", () => {
+	const repoRoot = path.resolve("gemini-repo");
+	const homeDir = path.resolve("gemini-home");
+	const agentsDir = path.join(repoRoot, "agents");
+	const itemName = "helper";
+	const context = {
+		repoRoot,
+		homeDir,
+		agentsDir,
+		targetId: "gemini",
+		itemName,
+	};
+
+	it("defines core metadata", () => {
+		expect(geminiTarget.id).toBe("gemini");
+		expect(geminiTarget.displayName).toBe("Gemini CLI");
+	});
+
+	it("routes skills and subagents to .gemini/skills with conversion fallback", () => {
+		const skills = expectDefined(normalizeOutputDefinition(geminiTarget.outputs?.skills), "skills");
+		expect(skills.path).toBe("{repoRoot}/.gemini/skills/{itemName}");
+		const skillsPath = resolveOutputPath({
+			template: skills.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(skillsPath).toBe(path.join(repoRoot, ".gemini", "skills", itemName));
+
+		const subagents = expectDefined(
+			normalizeOutputDefinition(geminiTarget.outputs?.subagents),
+			"subagents",
+		);
+		expect(subagents.path).toBe("{repoRoot}/.gemini/skills/{itemName}");
+		expect(subagents.fallback).toEqual({ mode: "convert", targetType: "skills" });
+		const subagentPath = resolveOutputPath({
+			template: subagents.path,
+			context,
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(subagentPath).toBe(path.join(repoRoot, ".gemini", "skills", itemName));
+	});
+
+	it("writes commands to project and user command folders", () => {
+		const commands = expectDefined(
+			normalizeCommandOutputDefinition(geminiTarget.outputs?.commands),
+			"commands",
+		);
+		expect(commands.projectPath).toBe("{repoRoot}/.gemini/commands/{itemName}.toml");
+		expect(commands.userPath).toBe("{homeDir}/.gemini/commands/{itemName}.toml");
+		const projectPath = expectDefined(commands.projectPath, "commands.projectPath");
+
+		const projectCommandPath = resolveCommandOutputPath({
+			template: projectPath,
+			context: { ...context, commandLocation: "project" },
+			item: {},
+			baseDir: repoRoot,
+		});
+		expect(projectCommandPath).toBe(path.join(repoRoot, ".gemini", "commands", `${itemName}.toml`));
+
+		const userPath = expectDefined(commands.userPath, "commands.userPath");
+		const userCommandPath = resolveCommandOutputPath({
+			template: userPath,
+			context: { ...context, commandLocation: "user" },
+			item: {},
+			baseDir: homeDir,
+		});
+		expect(userCommandPath).toBe(path.join(homeDir, ".gemini", "commands", `${itemName}.toml`));
+	});
+
+	it("writes instructions to GEMINI.md", () => {
+		const instructions = expectDefined(
+			normalizeInstructionOutputDefinition(geminiTarget.outputs?.instructions),
+			"instructions",
+		);
+		expect(instructions.filename).toBe("GEMINI.md");
+		expect(instructions.group).toBeUndefined();
+		const filename = resolveInstructionFilename({
+			template: instructions.filename,
+			context,
+			item: {},
+		});
+		expect(filename).toBe("GEMINI.md");
+	});
+});

--- a/src/lib/targets/builtins/gemini-cli/target.ts
+++ b/src/lib/targets/builtins/gemini-cli/target.ts
@@ -1,0 +1,20 @@
+import type { TargetDefinition } from "../../config-types.js";
+
+export const geminiTarget: TargetDefinition = {
+	id: "gemini",
+	displayName: "Gemini CLI",
+	outputs: {
+		skills: "{repoRoot}/.gemini/skills/{itemName}",
+		subagents: {
+			path: "{repoRoot}/.gemini/skills/{itemName}",
+			fallback: { mode: "convert", targetType: "skills" },
+		},
+		commands: {
+			projectPath: "{repoRoot}/.gemini/commands/{itemName}.toml",
+			userPath: "{homeDir}/.gemini/commands/{itemName}.toml",
+		},
+		instructions: {
+			filename: "GEMINI.md",
+		},
+	},
+};

--- a/tests/commands/echo.test.ts
+++ b/tests/commands/echo.test.ts
@@ -1,44 +1,46 @@
-import { runCli } from '../../src/cli/index.js';
+import { runCli } from "../../src/cli/index.js";
 
-describe('echo command', () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+describe("echo command", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  });
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+	});
 
-  afterEach(() => {
-    logSpy.mockRestore();
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
-  });
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+	});
 
-  it('echoes a message once by default', async () => {
-    await runCli(['node', 'omniagent', 'echo', 'test']);
+	it("echoes a message once by default", async () => {
+		await runCli(["node", "omniagent", "echo", "test"]);
 
-    expect(logSpy).toHaveBeenCalledWith('test');
-  });
+		expect(logSpy).toHaveBeenCalledWith("test");
+	});
 
-  it('repeats the message when --times is provided', async () => {
-    await runCli(['node', 'omniagent', 'echo', 'hi', '--times', '3']);
+	it("repeats the message when --times is provided", async () => {
+		await runCli(["node", "omniagent", "echo", "hi", "--times", "3"]);
 
-    expect(logSpy).toHaveBeenCalledWith('hi\nhi\nhi');
-  });
+		expect(logSpy).toHaveBeenCalledWith("hi\nhi\nhi");
+	});
 
-  it('adds a prefix when --prefix is provided', async () => {
-    await runCli(['node', 'omniagent', 'echo', 'msg', '--prefix', '> ']);
+	it("adds a prefix when --prefix is provided", async () => {
+		await runCli(["node", "omniagent", "echo", "msg", "--prefix", "> "]);
 
-    expect(logSpy).toHaveBeenCalledWith('> msg');
-  });
+		expect(logSpy).toHaveBeenCalledWith("> msg");
+	});
 
-  it('errors on invalid --times values', async () => {
-    await runCli(['node', 'omniagent', 'echo', 'x', '--times', '-1']);
+	it("errors on invalid --times values", async () => {
+		await runCli(["node", "omniagent", "echo", "x", "--times", "-1"]);
 
-    expect(errorSpy).toHaveBeenCalledWith('Error: Invalid value for --times: must be positive integer');
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Error: Invalid value for --times: must be positive integer",
+		);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
 });

--- a/tests/commands/greet.test.ts
+++ b/tests/commands/greet.test.ts
@@ -1,38 +1,38 @@
-import { runCli } from '../../src/cli/index.js';
+import { runCli } from "../../src/cli/index.js";
 
-describe('greet command', () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+describe("greet command", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  });
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+	});
 
-  afterEach(() => {
-    logSpy.mockRestore();
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
-  });
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+	});
 
-  it('prints a personalized greeting', async () => {
-    await runCli(['node', 'omniagent', 'greet', 'Alice']);
+	it("prints a personalized greeting", async () => {
+		await runCli(["node", "omniagent", "greet", "Alice"]);
 
-    expect(logSpy).toHaveBeenCalledWith('Hello, Alice!');
-  });
+		expect(logSpy).toHaveBeenCalledWith("Hello, Alice!");
+	});
 
-  it('prints an uppercase greeting', async () => {
-    await runCli(['node', 'omniagent', 'greet', 'Bob', '--uppercase']);
+	it("prints an uppercase greeting", async () => {
+		await runCli(["node", "omniagent", "greet", "Bob", "--uppercase"]);
 
-    expect(logSpy).toHaveBeenCalledWith('HELLO, BOB!');
-  });
+		expect(logSpy).toHaveBeenCalledWith("HELLO, BOB!");
+	});
 
-  it('errors when name is missing', async () => {
-    await runCli(['node', 'omniagent', 'greet']);
+	it("errors when name is missing", async () => {
+		await runCli(["node", "omniagent", "greet"]);
 
-    expect(errorSpy).toHaveBeenCalledWith('Error: Missing required argument: name');
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
+		expect(errorSpy).toHaveBeenCalledWith("Error: Missing required argument: name");
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
 });

--- a/tests/commands/hello.test.ts
+++ b/tests/commands/hello.test.ts
@@ -1,29 +1,29 @@
-import { runCli } from '../../src/cli/index.js';
+import { runCli } from "../../src/cli/index.js";
 
-const joinOutput = (calls: Array<[unknown]>) => calls.map(([arg]) => String(arg)).join('\n');
+const joinOutput = (calls: Array<[unknown]>) => calls.map(([arg]) => String(arg)).join("\n");
 
-describe('hello command', () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
+describe("hello command", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-  });
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	});
 
-  afterEach(() => {
-    logSpy.mockRestore();
-  });
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
 
-  it('prints the default greeting', async () => {
-    await runCli(['node', 'omniagent', 'hello']);
+	it("prints the default greeting", async () => {
+		await runCli(["node", "omniagent", "hello"]);
 
-    expect(logSpy).toHaveBeenCalledWith('Hello, World!');
-  });
+		expect(logSpy).toHaveBeenCalledWith("Hello, World!");
+	});
 
-  it('shows help output', async () => {
-    await runCli(['node', 'omniagent', 'hello', '--help']);
+	it("shows help output", async () => {
+		await runCli(["node", "omniagent", "hello", "--help"]);
 
-    const output = joinOutput(logSpy.mock.calls);
-    expect(output).toContain('omniagent hello');
-    expect(output).toContain('Options');
-  });
+		const output = joinOutput(logSpy.mock.calls);
+		expect(output).toContain("omniagent hello");
+		expect(output).toContain("Options");
+	});
 });

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -1,416 +1,477 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-import { runCli } from '../../src/cli/index.js';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../../src/cli/index.js";
 
 async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'omniagent-sync-'));
-  const homeDir = path.join(root, 'home');
-  await mkdir(homeDir, { recursive: true });
-  const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(homeDir);
-  try {
-    await fn(root);
-  } finally {
-    homeSpy.mockRestore();
-    await rm(root, { recursive: true, force: true });
-  }
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-sync-"));
+	const homeDir = path.join(root, "home");
+	await mkdir(homeDir, { recursive: true });
+	const homeSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+	try {
+		await fn(root);
+	} finally {
+		homeSpy.mockRestore();
+		await rm(root, { recursive: true, force: true });
+	}
 }
 
 async function withCwd(dir: string, fn: () => Promise<void>): Promise<void> {
-  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(dir);
-  try {
-    await fn();
-  } finally {
-    cwdSpy.mockRestore();
-  }
+	const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(dir);
+	try {
+		await fn();
+	} finally {
+		cwdSpy.mockRestore();
+	}
 }
 
 async function pathExists(candidate: string): Promise<boolean> {
-  try {
-    await stat(candidate);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		await stat(candidate);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 async function createRepoRoot(root: string): Promise<void> {
-  await writeFile(path.join(root, 'package.json'), '{}');
+	await writeFile(path.join(root, "package.json"), "{}");
 }
 
 async function createCanonicalSkills(root: string): Promise<string> {
-  const sourceDir = path.join(root, 'agents', 'skills');
-  const skillDir = path.join(sourceDir, 'example');
-  await mkdir(skillDir, { recursive: true });
-  await writeFile(path.join(skillDir, 'SKILL.md'), 'hello');
-  return await realpath(sourceDir);
+	const sourceDir = path.join(root, "agents", "skills");
+	const skillDir = path.join(sourceDir, "example");
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(path.join(skillDir, "SKILL.md"), "hello");
+	return await realpath(sourceDir);
 }
 
-async function writeCanonicalSkillFile(root: string, fileName: string, contents: string): Promise<string> {
-  const sourceDir = path.join(root, 'agents', 'skills');
-  const skillName = path.parse(fileName).name;
-  const skillDir = path.join(sourceDir, skillName);
-  await mkdir(skillDir, { recursive: true });
-  const filePath = path.join(skillDir, 'SKILL.md');
-  await writeFile(filePath, contents, 'utf8');
-  return filePath;
+async function writeCanonicalSkillFile(
+	root: string,
+	fileName: string,
+	contents: string,
+): Promise<string> {
+	const sourceDir = path.join(root, "agents", "skills");
+	const skillName = path.parse(fileName).name;
+	const skillDir = path.join(sourceDir, skillName);
+	await mkdir(skillDir, { recursive: true });
+	const filePath = path.join(skillDir, "SKILL.md");
+	await writeFile(filePath, contents, "utf8");
+	return filePath;
 }
 
 async function createCanonicalCommands(root: string): Promise<string> {
-  const sourceDir = path.join(root, 'agents', 'commands');
-  await mkdir(sourceDir, { recursive: true });
-  await writeFile(path.join(sourceDir, 'example.md'), 'Say hello.');
-  return await realpath(sourceDir);
+	const sourceDir = path.join(root, "agents", "commands");
+	await mkdir(sourceDir, { recursive: true });
+	await writeFile(path.join(sourceDir, "example.md"), "Say hello.");
+	return await realpath(sourceDir);
 }
 
-async function writeCanonicalCommand(root: string, name: string, contents: string): Promise<string> {
-  const sourceDir = path.join(root, 'agents', 'commands');
-  await mkdir(sourceDir, { recursive: true });
-  const filePath = path.join(sourceDir, `${name}.md`);
-  await writeFile(filePath, contents, 'utf8');
-  return filePath;
+async function writeCanonicalCommand(
+	root: string,
+	name: string,
+	contents: string,
+): Promise<string> {
+	const sourceDir = path.join(root, "agents", "commands");
+	await mkdir(sourceDir, { recursive: true });
+	const filePath = path.join(sourceDir, `${name}.md`);
+	await writeFile(filePath, contents, "utf8");
+	return filePath;
 }
 
 async function writeSubagent(root: string, name: string, body: string): Promise<string> {
-  const catalogDir = path.join(root, 'agents', 'agents');
-  await mkdir(catalogDir, { recursive: true });
-  const contents = `---\nname: ${name}\n---\n${body}\n`;
-  const filePath = path.join(catalogDir, `${name}.md`);
-  await writeFile(filePath, contents, 'utf8');
-  return filePath;
+	const catalogDir = path.join(root, "agents", "agents");
+	await mkdir(catalogDir, { recursive: true });
+	const contents = `---\nname: ${name}\n---\n${body}\n`;
+	const filePath = path.join(catalogDir, `${name}.md`);
+	await writeFile(filePath, contents, "utf8");
+	return filePath;
 }
 
 async function writeSubagentWithFrontmatter(
-  root: string,
-  fileName: string,
-  frontmatterLines: string[],
-  body: string,
+	root: string,
+	fileName: string,
+	frontmatterLines: string[],
+	body: string,
 ): Promise<string> {
-  const catalogDir = path.join(root, 'agents', 'agents');
-  await mkdir(catalogDir, { recursive: true });
-  const contents = ['---', ...frontmatterLines, '---', body, ''].join('\n');
-  const filePath = path.join(catalogDir, `${fileName}.md`);
-  await writeFile(filePath, contents, 'utf8');
-  return filePath;
+	const catalogDir = path.join(root, "agents", "agents");
+	await mkdir(catalogDir, { recursive: true });
+	const contents = ["---", ...frontmatterLines, "---", body, ""].join("\n");
+	const filePath = path.join(catalogDir, `${fileName}.md`);
+	await writeFile(filePath, contents, "utf8");
+	return filePath;
 }
 
-async function writeRepoInstruction(root: string, relPath: string, contents: string): Promise<string> {
-  const filePath = path.join(root, relPath);
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, contents, 'utf8');
-  return filePath;
+async function writeRepoInstruction(
+	root: string,
+	relPath: string,
+	contents: string,
+): Promise<string> {
+	const filePath = path.join(root, relPath);
+	await mkdir(path.dirname(filePath), { recursive: true });
+	await writeFile(filePath, contents, "utf8");
+	return filePath;
 }
 
-describe.sequential('sync command', () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+describe.sequential("sync command", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-  });
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+	});
 
-  afterEach(() => {
-    logSpy.mockRestore();
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
-  });
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+	});
 
-  it('syncs all targets from the repo root', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
+	it("syncs all targets from the repo root", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
 
-      const codex = await readFile(path.join(root, '.codex', 'skills', 'example', 'SKILL.md'), 'utf8');
-      const claude = await readFile(path.join(root, '.claude', 'skills', 'example', 'SKILL.md'), 'utf8');
-      const copilot = await readFile(path.join(root, '.github', 'skills', 'example', 'SKILL.md'), 'utf8');
-      const gemini = await readFile(path.join(root, '.gemini', 'skills', 'example', 'SKILL.md'), 'utf8');
-      const claudeCommand = await readFile(path.join(root, '.claude', 'commands', 'example.md'), 'utf8');
+			const codex = await readFile(
+				path.join(root, ".codex", "skills", "example", "SKILL.md"),
+				"utf8",
+			);
+			const claude = await readFile(
+				path.join(root, ".claude", "skills", "example", "SKILL.md"),
+				"utf8",
+			);
+			const copilot = await readFile(
+				path.join(root, ".github", "skills", "example", "SKILL.md"),
+				"utf8",
+			);
+			const gemini = await readFile(
+				path.join(root, ".gemini", "skills", "example", "SKILL.md"),
+				"utf8",
+			);
+			const claudeCommand = await readFile(
+				path.join(root, ".claude", "commands", "example.md"),
+				"utf8",
+			);
 
-      expect(codex).toBe('hello');
-      expect(claude).toBe('hello');
-      expect(copilot).toBe('hello');
-      expect(gemini).toBe('hello');
-      expect(claudeCommand).toContain('Say hello.');
-      expect(exitSpy).not.toHaveBeenCalled();
-    });
-  });
+			expect(codex).toBe("hello");
+			expect(claude).toBe("hello");
+			expect(copilot).toBe("hello");
+			expect(gemini).toBe("hello");
+			expect(claudeCommand).toContain("Say hello.");
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
 
-  it('respects --only filters', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
-      await writeRepoInstruction(root, path.join('docs', 'AGENTS.md'), 'Repo instructions');
+	it("respects --only filters", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
+			await writeRepoInstruction(root, path.join("docs", "AGENTS.md"), "Repo instructions");
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude"]);
+			});
 
-      expect(await pathExists(path.join(root, '.claude', 'skills', 'example', 'SKILL.md'))).toBe(true);
-      expect(await pathExists(path.join(root, '.claude', 'commands', 'example.md'))).toBe(true);
-      expect(await pathExists(path.join(root, '.codex', 'skills'))).toBe(false);
-      expect(await pathExists(path.join(root, '.github', 'skills'))).toBe(false);
-      expect(await pathExists(path.join(root, '.gemini', 'skills'))).toBe(false);
-      expect(await pathExists(path.join(root, '.gemini', 'commands'))).toBe(false);
-      expect(await pathExists(path.join(root, 'docs', 'CLAUDE.md'))).toBe(true);
-      expect(await pathExists(path.join(root, 'docs', 'GEMINI.md'))).toBe(false);
-    });
-  });
+			expect(await pathExists(path.join(root, ".claude", "skills", "example", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "commands", "example.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".codex", "skills"))).toBe(false);
+			expect(await pathExists(path.join(root, ".github", "skills"))).toBe(false);
+			expect(await pathExists(path.join(root, ".gemini", "skills"))).toBe(false);
+			expect(await pathExists(path.join(root, ".gemini", "commands"))).toBe(false);
+			expect(await pathExists(path.join(root, "docs", "CLAUDE.md"))).toBe(true);
+			expect(await pathExists(path.join(root, "docs", "GEMINI.md"))).toBe(false);
+		});
+	});
 
-  it('errors on unknown targets without syncing', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
+	it("errors on unknown targets without syncing", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--skip', 'unknown']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--skip", "unknown"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Error: Unknown target name(s): unknown.'));
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.codex', 'skills'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Error: Unknown target name(s): unknown."),
+			);
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".codex", "skills"))).toBe(false);
+		});
+	});
 
-  it('errors on empty skill targets in frontmatter', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalCommands(root);
-      const contents = ['---', 'targets:', '---', 'Hello'].join('\n');
-      await writeCanonicalSkillFile(root, 'empty', contents);
+	it("errors on empty skill targets in frontmatter", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalCommands(root);
+			const contents = ["---", "targets:", "---", "Hello"].join("\n");
+			await writeCanonicalSkillFile(root, "empty", contents);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('has empty targets'));
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.claude', 'skills'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("has empty targets"));
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "skills"))).toBe(false);
+		});
+	});
 
-  it('errors on invalid command targets in frontmatter', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await writeCanonicalCommand(
-        root,
-        'bad-command',
-        ['---', 'targets:', '  - bogus', '---', 'Say hello.'].join('\n'),
-      );
+	it("errors on invalid command targets in frontmatter", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await writeCanonicalCommand(
+				root,
+				"bad-command",
+				["---", "targets:", "  - bogus", "---", "Say hello."].join("\n"),
+			);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported targets'));
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.claude', 'commands'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("unsupported targets"));
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "commands"))).toBe(false);
+		});
+	});
 
-  it('errors on empty subagent targets in frontmatter', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
-      await writeSubagentWithFrontmatter(root, 'helper', ['name: helper', 'targets:'], 'Subagent body.');
+	it("errors on empty subagent targets in frontmatter", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
+			await writeSubagentWithFrontmatter(
+				root,
+				"helper",
+				["name: helper", "targets:"],
+				"Subagent body.",
+			);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('has empty targets'));
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.claude', 'agents'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("has empty targets"));
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "agents"))).toBe(false);
+		});
+	});
 
-  it('applies --only then --skip when both are provided', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
+	it("applies --only then --skip when both are provided", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude,codex', '--skip', 'codex']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude,codex", "--skip", "codex"]);
+			});
 
-      expect(errorSpy).not.toHaveBeenCalled();
-      expect(exitSpy).not.toHaveBeenCalled();
-      expect(await pathExists(path.join(root, '.claude', 'skills', 'example', 'SKILL.md'))).toBe(true);
-      expect(await pathExists(path.join(root, '.codex', 'skills'))).toBe(false);
-    });
-  });
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(await pathExists(path.join(root, ".claude", "skills", "example", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".codex", "skills"))).toBe(false);
+		});
+	});
 
-  it('reports missing source paths as skipped without exiting', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await mkdir(path.join(root, 'subdir'), { recursive: true });
-      const skillsPath = path.join(root, 'agents', 'skills');
-      const commandsPath = path.join(root, 'agents', 'commands');
-      const localCommandsPath = path.join(root, 'agents', '.local', 'commands');
+	it("reports missing source paths as skipped without exiting", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await mkdir(path.join(root, "subdir"), { recursive: true });
+			const skillsPath = path.join(root, "agents", "skills");
+			const commandsPath = path.join(root, "agents", "commands");
+			const localCommandsPath = path.join(root, "agents", ".local", "commands");
 
-      await withCwd(path.join(root, 'subdir'), async () => {
-        await runCli(['node', 'omniagent', 'sync']);
-      });
+			await withCwd(path.join(root, "subdir"), async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
 
-      const loggedMessages = logSpy.mock.calls
-        .map(([message]) => (typeof message === 'string' ? message : ''))
-        .join('\n');
+			const loggedMessages = logSpy.mock.calls
+				.map(([message]) => (typeof message === "string" ? message : ""))
+				.join("\n");
 
-      expect(loggedMessages).toContain(`Canonical config source not found at ${skillsPath}.`);
-      expect(loggedMessages).toContain(
-        `Command catalog directory not found at ${commandsPath} or ${localCommandsPath}.`,
-      );
-      expect(errorSpy).not.toHaveBeenCalled();
-      expect(exitSpy).not.toHaveBeenCalled();
-    });
-  });
+			expect(loggedMessages).toContain(`Canonical config source not found at ${skillsPath}.`);
+			expect(loggedMessages).toContain(
+				`Command catalog directory not found at ${commandsPath} or ${localCommandsPath}.`,
+			);
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
 
-  it('allows subagent-only sync when the catalog is missing', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
+	it("allows subagent-only sync when the catalog is missing", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'codex', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--yes"]);
+			});
 
-      expect(errorSpy).not.toHaveBeenCalled();
-      expect(exitSpy).not.toHaveBeenCalled();
-    });
-  });
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
 
-  it('emits JSON summaries when --json is provided', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      const skillsPath = await createCanonicalSkills(root);
-      const commandsPath = await createCanonicalCommands(root);
-      await writeRepoInstruction(root, path.join('docs', 'AGENTS.md'), 'Instruction content');
+	it("emits JSON summaries when --json is provided", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			const skillsPath = await createCanonicalSkills(root);
+			const commandsPath = await createCanonicalCommands(root);
+			await writeRepoInstruction(root, path.join("docs", "AGENTS.md"), "Instruction content");
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--json']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--json"]);
+			});
 
-      expect(logSpy).toHaveBeenCalled();
-      const output = logSpy.mock.calls[0]?.[0];
-      const parsed = JSON.parse(output);
-      expect(await realpath(parsed.skills.sourcePath)).toBe(skillsPath);
-      expect(await realpath(parsed.commands.sourcePath)).toBe(commandsPath);
-      expect(await realpath(parsed.instructions.sourcePath)).toBe(await realpath(root));
-      expect(parsed.skills.results).toHaveLength(4);
-      expect(parsed.commands.results).toHaveLength(4);
-      expect(parsed.instructions.results).toHaveLength(4);
-      expect(parsed.instructions.sourceCounts).toEqual({
-        shared: 1,
-        local: 0,
-        excludedLocal: false,
-      });
-      expect(parsed.hadFailures).toBe(false);
-    });
-  });
+			expect(logSpy).toHaveBeenCalled();
+			const output = logSpy.mock.calls[0]?.[0];
+			const parsed = JSON.parse(output);
+			expect(await realpath(parsed.skills.sourcePath)).toBe(skillsPath);
+			expect(await realpath(parsed.commands.sourcePath)).toBe(commandsPath);
+			expect(await realpath(parsed.instructions.sourcePath)).toBe(await realpath(root));
+			expect(parsed.skills.results).toHaveLength(4);
+			expect(parsed.commands.results).toHaveLength(4);
+			expect(parsed.instructions.results).toHaveLength(4);
+			expect(parsed.instructions.sourceCounts).toEqual({
+				shared: 1,
+				local: 0,
+				excludedLocal: false,
+			});
+			expect(parsed.hadFailures).toBe(false);
+		});
+	});
 
-  it('prints a plan summary in non-interactive runs', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
+	it("prints a plan summary in non-interactive runs", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--yes"]);
+			});
 
-      const planned = logSpy.mock.calls.find(
-        ([message]) => typeof message === 'string' && message.includes('Planned actions:'),
-      );
-      expect(planned).toBeTruthy();
-    });
-  });
+			const planned = logSpy.mock.calls.find(
+				([message]) => typeof message === "string" && message.includes("Planned actions:"),
+			);
+			expect(planned).toBeTruthy();
+		});
+	});
 
-  it('surfaces Codex scope limitations in non-interactive runs', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await createCanonicalSkills(root);
-      await createCanonicalCommands(root);
+	it("surfaces Codex scope limitations in non-interactive runs", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalSkills(root);
+			await createCanonicalCommands(root);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'kek', 'sync', '--only', 'codex', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "kek", "sync", "--only", "codex", "--yes"]);
+			});
 
-      const warning = logSpy.mock.calls.find(
-        ([message]) => typeof message === 'string' && message.includes('commands are user-only'),
-      );
-      expect(warning).toBeTruthy();
-    });
-  });
+			const warning = logSpy.mock.calls.find(
+				([message]) => typeof message === "string" && message.includes("commands are user-only"),
+			);
+			expect(warning).toBeTruthy();
+		});
+	});
 
-  it('applies templating consistently across skills, commands, and subagents', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await writeCanonicalSkillFile(
-        root,
-        'example.txt',
-        'Skill<agents claude> OK</agents><agents not:claude> NO</agents>',
-      );
-      await writeCanonicalCommand(root, 'example', 'Command<agents claude> OK</agents><agents not:claude> NO</agents>');
-      await writeSubagent(root, 'helper', 'Subagent<agents claude> OK</agents><agents not:claude> NO</agents>');
+	it("applies templating consistently across skills, commands, and subagents", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkillFile(
+				root,
+				"example.txt",
+				"Skill<agents claude> OK</agents><agents not:claude> NO</agents>",
+			);
+			await writeCanonicalCommand(
+				root,
+				"example",
+				"Command<agents claude> OK</agents><agents not:claude> NO</agents>",
+			);
+			await writeSubagent(
+				root,
+				"helper",
+				"Subagent<agents claude> OK</agents><agents not:claude> NO</agents>",
+			);
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      const skillOutput = await readFile(path.join(root, '.claude', 'skills', 'example', 'SKILL.md'), 'utf8');
-      const commandOutput = await readFile(path.join(root, '.claude', 'commands', 'example.md'), 'utf8');
-      const subagentOutput = await readFile(path.join(root, '.claude', 'agents', 'helper.md'), 'utf8');
+			const skillOutput = await readFile(
+				path.join(root, ".claude", "skills", "example", "SKILL.md"),
+				"utf8",
+			);
+			const commandOutput = await readFile(
+				path.join(root, ".claude", "commands", "example.md"),
+				"utf8",
+			);
+			const subagentOutput = await readFile(
+				path.join(root, ".claude", "agents", "helper.md"),
+				"utf8",
+			);
 
-      expect(skillOutput).toContain('OK');
-      expect(skillOutput).not.toContain('NO');
-      expect(commandOutput).toContain('OK');
-      expect(commandOutput).not.toContain('NO');
-      expect(subagentOutput).toContain('OK');
-      expect(subagentOutput).not.toContain('NO');
-    });
-  });
+			expect(skillOutput).toContain("OK");
+			expect(skillOutput).not.toContain("NO");
+			expect(commandOutput).toContain("OK");
+			expect(commandOutput).not.toContain("NO");
+			expect(subagentOutput).toContain("OK");
+			expect(subagentOutput).not.toContain("NO");
+		});
+	});
 
-  it('fails before writing outputs when templating is invalid in commands', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await writeCanonicalCommand(root, 'broken', 'Hi<agents bogus> invalid</agents>');
+	it("fails before writing outputs when templating is invalid in commands", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalCommand(root, "broken", "Hi<agents bogus> invalid</agents>");
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Valid agents: codex, claude, gemini, copilot.'));
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.claude', 'commands'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Valid agents: codex, claude, gemini, copilot."),
+			);
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "commands"))).toBe(false);
+		});
+	});
 
-  it('fails before writing outputs when templating is invalid in skills files', async () => {
-    await withTempRepo(async (root) => {
-      await createRepoRoot(root);
-      await writeCanonicalSkillFile(root, 'bad.txt', 'Hi<agents claude,not:claude> broken</agents>');
-      await writeCanonicalCommand(root, 'ok', 'Say hello.');
+	it("fails before writing outputs when templating is invalid in skills files", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkillFile(
+				root,
+				"bad.txt",
+				"Hi<agents claude,not:claude> broken</agents>",
+			);
+			await writeCanonicalCommand(root, "ok", "Say hello.");
 
-      await withCwd(root, async () => {
-        await runCli(['node', 'omniagent', 'sync', '--only', 'claude', '--yes']);
-      });
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
 
-      expect(errorSpy).toHaveBeenCalled();
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(await pathExists(path.join(root, '.claude', 'commands'))).toBe(false);
-      expect(await pathExists(path.join(root, '.claude', 'skills'))).toBe(false);
-    });
-  });
+			expect(errorSpy).toHaveBeenCalled();
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "commands"))).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "skills"))).toBe(false);
+		});
+	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
     testTimeout: 10000
   }
 })


### PR DESCRIPTION
## Summary
- move builtin target configs into per-agent folders with colocated tests
- update builtin target registry to import per-agent configs
- expand vitest include paths so src co-located tests run

## Testing
- npm run format
- npm run check
- npm run lint:check
- npm test
- npm run build