### PR TITLE
Add sync profiles for per-developer agent customization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ TypeScript 5.x, Node.js 18+: Enforced by Biome (formatting and linting)
   syncable template surfaces (skills, subagents, slash commands, and instruction templates).
 - Any future syncable surface must integrate with the shared template-script runtime instead of
   introducing surface-specific script execution behavior.
+- For GitHub actions, use `gh` CLI.
 - Keep ignore and publish rules aligned with tool-specific directories so package publishes stay
   clean.
 - CLI shim E2E docs: `docs/cli-shim-e2e.md`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ npx omniagent@latest sync --agentsDir ./my-custom-agents
 # Show local-only overrides and exit
 npx omniagent@latest sync --list-local
 
+# Apply a sync profile (see docs/profiles.md)
+npx omniagent@latest sync --profile code-reviewer
+
 # Shim mode (no subcommand)
 omniagent --agent codex
 omniagent -p "Summarize this repo" --agent codex --output json
@@ -155,6 +158,7 @@ Example usage:
 - CLI shim details: [`docs/cli-shim.md`](docs/cli-shim.md)
 - Custom targets (custom agents): [`docs/custom-targets.md`](docs/custom-targets.md)
 - Local overrides: [`docs/local-overrides.md`](docs/local-overrides.md)
+- Sync profiles: [`docs/profiles.md`](docs/profiles.md)
 - Templating and dynamic scripts: [`docs/templating.md`](docs/templating.md)
 - Command reference: [`docs/reference.md`](docs/reference.md)
 - Troubleshooting: [`docs/troubleshooting.md`](docs/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,43 @@ agents/.local/
 agents/**/*.local*
 ```
 
+## Sync Profiles
+
+Profiles let each dev pick a named, checked-in filter that `sync` applies to
+the shared `agents/` directory — so a ten-person team can share one source of
+truth while each member opts in to exactly the skills, subagents, commands,
+and targets they want.
+
+```jsonc
+// agents/profiles/code-reviewer.json
+{
+  "description": "Focused setup for PR reviews",
+  "extends": "base",
+  "targets": { "claude": { "enabled": true }, "codex": { "enabled": true } },
+  "enable": {
+    "skills":    ["code-review", "security-review"],
+    "subagents": ["reviewer"],
+    "commands":  ["review", "diff-summary"]
+  },
+  "variables": { "REVIEW_STYLE": "terse" }
+}
+```
+
+```bash
+omniagent sync                                   # uses agents/profiles/default.json when present
+omniagent sync --profile code-reviewer
+omniagent sync --profile base,code-reviewer     # merge multiple (later wins)
+omniagent sync --var REVIEW_STYLE=thorough      # override a variable from the CLI
+```
+
+Profiles support `extends` chains, `.local` overrides (personal, gitignored),
+glob-based `enable`/`disable` lists, per-target toggles, and template
+variables. Discover and validate profiles with `omniagent profiles`,
+`omniagent profiles show <name>`, and `omniagent profiles validate`.
+
+See [`docs/profiles.md`](docs/profiles.md) for the full schema, resolution
+order, and examples.
+
 ## Basic Templating
 
 Use `<agents ...>` blocks when some text should render only for specific targets.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use the pages below when you need deeper behavior or advanced configuration.
 - CLI shim details: [`docs/cli-shim.md`](cli-shim.md)
 - Custom targets (custom agents): [`docs/custom-targets.md`](custom-targets.md)
 - Local overrides: [`docs/local-overrides.md`](local-overrides.md)
+- Sync profiles: [`docs/profiles.md`](profiles.md)
 - Templating and dynamic scripts: [`docs/templating.md`](templating.md)
 - Command reference: [`docs/reference.md`](reference.md)
 - Troubleshooting: [`docs/troubleshooting.md`](troubleshooting.md)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,200 @@
+# Sync profiles
+
+Profiles let individual developers — or the same developer across different
+contexts (code review, incident response, docs writing) — pick a named,
+checked-in filter that the `sync` command applies to the shared `agents/`
+directory. Ten devs share one source of truth; each dev opts in to exactly the
+skills, subagents, commands, and targets they want.
+
+```bash
+omniagent sync                                  # uses agents/profiles/default.json when present
+omniagent sync --profile code-reviewer
+omniagent sync --profile base,code-reviewer     # merge multiple (later wins)
+```
+
+## File layout
+
+```text
+agents/
+  profiles/
+    default.json              # team default (committed, used when no --profile flag)
+    base.json                 # optional shared base extended by others
+    code-reviewer.json        # named profile (committed)
+    default.local.json        # sibling .local override (personal, gitignored)
+  .local/
+    profiles/
+      default.json            # dedicated-dir .local override (personal, gitignored)
+      my-experiments.json     # personal-only profile (no shared counterpart)
+```
+
+Both `.local` paths are honoured. When a file exists at both, the
+`.local/profiles/<name>.json` form wins on conflicting keys; `omniagent sync -v`
+emits a one-line notice so the choice is never silent.
+
+## Schema
+
+```jsonc
+{
+  "$schema": "./profile.v1.json",
+
+  "description": "Focused setup for PR reviews",
+  "extends": "base",
+
+  "targets": {
+    "claude":  { "enabled": true },
+    "codex":   { "enabled": true },
+    "gemini":  { "enabled": false }
+  },
+
+  // Allowlist. Values are glob patterns matched against canonical item names.
+  "enable": {
+    "skills":    ["code-review", "security-review"],
+    "subagents": ["reviewer"],
+    "commands":  ["review", "diff-summary"]
+  },
+
+  // Denylist. Wins over enable.
+  "disable": {
+    "skills":   ["ppt"],
+    "commands": ["*-legacy"]
+  }
+}
+```
+
+The full JSON Schema ships at [`schemas/profile.v1.json`](../schemas/profile.v1.json)
+and is referenced by `$schema` for editor autocomplete.
+
+## Resolution order
+
+For `omniagent sync --profile A,B`:
+
+1. Each profile's `extends` chain is resolved first (grandparent → parent → profile),
+   with cycles failing loudly and printing the full chain.
+2. `.local` layers apply on top of each profile in order:
+   sibling `profiles/<name>.local.json` → dedicated `.local/profiles/<name>.json`
+   (dedicated wins on conflict).
+3. Profiles layer in CLI order: fully-resolved `A` → fully-resolved `B`
+   (later wins on key conflicts).
+4. CLI flags (`--skip`, `--only`, `--exclude-local`) apply last.
+
+`enable.<type>` and `disable.<type>` arrays are concatenated across layers.
+`targets.<name>` is a deep object merge.
+
+## Canonical item names
+
+Patterns match the canonical item name, which is:
+
+- **Skills** — `frontmatter.name` when set, otherwise the skill directory name.
+- **Subagents** — `frontmatter.name` when set, otherwise the Markdown filename
+  without extension.
+- **Commands** — the Markdown filename without extension.
+
+Glob syntax: `*` matches any run of non-slash characters, `?` matches one.
+
+## `enable` + `disable`
+
+- If `enable` is **omitted**, every item is included by default and `disable`
+  acts as a pure denylist (mirrors the old "ignore file" mental model).
+- If `enable` is **present**, only matching items are included, minus anything
+  `disable` carves out.
+
+## Unknown references
+
+A bare name (no wildcards) that matches zero items prints a warning:
+
+```text
+Warning: profile "code-reviewer" references unknown skill "missing-one"
+```
+
+A glob (`*-legacy`) that matches zero items is silent — zero matches are a
+valid outcome for a pattern. `omniagent profiles validate` promotes every
+warning to an error with a non-zero exit, suitable for CI or a pre-commit hook.
+
+## Default profile behaviour
+
+- No `--profile` flag and **no** `agents/profiles/default.json`: sync behaves
+  exactly as before — no filtering, no warnings. Profiles are opt-in.
+- No `--profile` flag **and** `agents/profiles/default.json` exists: the default
+  profile is applied automatically.
+- `--profile X` passed explicitly: the default profile is **not** implicitly
+  prepended. If you want both, list them: `--profile default,X`, or model it in
+  the file via `"extends": "default"`.
+
+## Discovery commands
+
+```bash
+omniagent profiles                       # list profiles with descriptions
+omniagent profiles show code-reviewer    # print the fully-resolved merged profile
+omniagent profiles validate              # strict validation, non-zero on issues (CI-friendly)
+```
+
+Example list output:
+
+```text
+  default                  (active by default) [local override]
+  base                     Shared defaults extended by other profiles
+  code-reviewer            Focused setup for PR reviews
+  my-experiments           [local-only]
+```
+
+## Examples
+
+### Base + role-specific
+
+`agents/profiles/base.json`:
+
+```json
+{
+  "description": "Shared defaults across all profiles",
+  "targets": { "claude": { "enabled": true }, "codex": { "enabled": true } },
+  "disable": { "skills": ["ppt", "brand-guidelines"] }
+}
+```
+
+`agents/profiles/code-reviewer.json`:
+
+```json
+{
+  "description": "Focused setup for PR reviews",
+  "extends": "base",
+  "enable": {
+    "skills":    ["code-review", "security-review"],
+    "subagents": ["reviewer"],
+    "commands":  ["review", "diff-summary"]
+  }
+}
+```
+
+### Personal tweaks via `.local`
+
+`agents/profiles/code-reviewer.local.json` (gitignored):
+
+```json
+{
+  "disable": { "skills": ["security-review"] }
+}
+```
+
+The dev keeps the team's `code-reviewer` profile but drops `security-review`
+for themselves — no fork, no duplication.
+
+### Personal-only profile
+
+`agents/.local/profiles/my-experiments.json`:
+
+```json
+{
+  "description": "Personal tinkering setup",
+  "targets": { "claude": { "enabled": true } },
+  "enable":  { "skills": ["experimental-*"] }
+}
+```
+
+Activated with `omniagent sync --profile my-experiments`. Never committed,
+not shared.
+
+## Future work
+
+The v1 profile surface intentionally omits `variables`, `overrides`,
+`mcpServers`, and `hooks`. See issue #40 for the broader proposal and deferred
+items.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -193,8 +193,83 @@ for themselves — no fork, no duplication.
 Activated with `omniagent sync --profile my-experiments`. Never committed,
 not shared.
 
+## Variables
+
+Profiles can define **template variables** that are substituted anywhere in
+rendered template content (skills, subagents, slash commands, and instruction
+templates) and also exposed to `<nodejs>` / `<shell>` script blocks as
+environment variables.
+
+```jsonc
+{
+  "description": "Reviewer setup",
+  "variables": {
+    "REVIEW_STYLE": "terse",
+    "LOG_SOURCE":   "datadog"
+  }
+}
+```
+
+**Variable names** must match `[A-Z_][A-Z0-9_]*` (uppercase ASCII, digits,
+underscores — env-var-safe).
+
+### Placeholders in template content
+
+Anywhere in a template file, use `{{NAME}}` to substitute the variable. Provide
+an inline default with `{{NAME=fallback}}`:
+
+```md
+You are a {{REVIEW_STYLE=thorough}} code reviewer. Log source is {{LOG_SOURCE}}.
+```
+
+- `{{NAME}}` with no default and no matching variable — the placeholder is left
+  literal and a `profile_warning` is emitted so the typo is surfaced.
+- `{{NAME=default}}` — the default is used if the variable is unset. An empty
+  string value is a valid substitution (it does *not* fall through to the
+  default).
+- Whitespace around the name is tolerated (`{{ NAME }}`). The default value
+  runs until the closing `}}` and may contain spaces.
+
+### Variables in `<nodejs>` / `<shell>` blocks
+
+Every variable is also injected into the child process environment as
+`OMNIAGENT_VAR_<NAME>`, so script blocks can read them programmatically:
+
+```md
+<nodejs>
+return `Style is ${process.env.OMNIAGENT_VAR_REVIEW_STYLE}`;
+</nodejs>
+```
+
+Placeholders inside a script block's **output** are also substituted, so you
+can emit `{{VAR}}` from a script and have it resolved normally.
+
+### CLI overrides
+
+Variables can be set or overridden at the CLI with `--var KEY=VALUE`
+(repeatable). CLI values apply after profile resolution, so they win over any
+profile value:
+
+```bash
+omniagent sync --profile reviewer --var REVIEW_STYLE=thorough --var LOG_SOURCE=stdout
+```
+
+Malformed values (missing `=`, or a name that doesn't match the allowed
+pattern) fail loudly with a non-zero exit.
+
+### Merge precedence
+
+Variables merge per-key using the same layering as other profile fields:
+
+1. `extends` chain (grandparent → parent → profile).
+2. `.local` overrides (sibling, then dedicated).
+3. Multiple `--profile` entries in CLI order.
+4. `--var KEY=VALUE` CLI flags.
+
+Later layers win on conflicting keys.
+
 ## Future work
 
-The v1 profile surface intentionally omits `variables`, `overrides`,
-`mcpServers`, and `hooks`. See issue #40 for the broader proposal and deferred
-items.
+The v1 profile surface intentionally omits `overrides` (per-item frontmatter
+patches), `mcpServers`, and `hooks`. See issue #40 for the broader proposal
+and deferred items.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -195,10 +195,11 @@ not shared.
 
 ## Variables
 
-Profiles can define **template variables** that are substituted anywhere in
-rendered template content (skills, subagents, slash commands, and instruction
-templates) and also exposed to `<nodejs>` / `<shell>` script blocks as
-environment variables.
+Profiles can define a `variables` map that feeds the template substitution
+system. Substitution syntax (`{{NAME}}`, `{{NAME=default}}`) and env-var
+exposure (`OMNIAGENT_VAR_<NAME>`) are documented in
+[`docs/templating.md`](templating.md#variable-substitution) — this section
+focuses on how variables flow through profiles.
 
 ```jsonc
 {
@@ -210,63 +211,21 @@ environment variables.
 }
 ```
 
-**Variable names** must match `[A-Z_][A-Z0-9_]*` (uppercase ASCII, digits,
-underscores — env-var-safe).
-
-### Placeholders in template content
-
-Anywhere in a template file, use `{{NAME}}` to substitute the variable. Provide
-an inline default with `{{NAME=fallback}}`:
-
-```md
-You are a {{REVIEW_STYLE=thorough}} code reviewer. Log source is {{LOG_SOURCE}}.
-```
-
-- `{{NAME}}` with no default and no matching variable — the placeholder is left
-  literal and a `profile_warning` is emitted so the typo is surfaced.
-- `{{NAME=default}}` — the default is used if the variable is unset. An empty
-  string value is a valid substitution (it does *not* fall through to the
-  default).
-- Whitespace around the name is tolerated (`{{ NAME }}`). The default value
-  runs until the closing `}}` and may contain spaces.
-
-### Variables in `<nodejs>` / `<shell>` blocks
-
-Every variable is also injected into the child process environment as
-`OMNIAGENT_VAR_<NAME>`, so script blocks can read them programmatically:
-
-```md
-<nodejs>
-return `Style is ${process.env.OMNIAGENT_VAR_REVIEW_STYLE}`;
-</nodejs>
-```
-
-Placeholders inside a script block's **output** are also substituted, so you
-can emit `{{VAR}}` from a script and have it resolved normally.
-
-### CLI overrides
-
-Variables can be set or overridden at the CLI with `--var KEY=VALUE`
-(repeatable). CLI values apply after profile resolution, so they win over any
-profile value:
-
-```bash
-omniagent sync --profile reviewer --var REVIEW_STYLE=thorough --var LOG_SOURCE=stdout
-```
-
-Malformed values (missing `=`, or a name that doesn't match the allowed
-pattern) fail loudly with a non-zero exit.
+Variable names must match `[A-Z_][A-Z0-9_]*`.
 
 ### Merge precedence
 
-Variables merge per-key using the same layering as other profile fields:
+Variables merge per-key across layers, later wins:
 
 1. `extends` chain (grandparent → parent → profile).
 2. `.local` overrides (sibling, then dedicated).
 3. Multiple `--profile` entries in CLI order.
-4. `--var KEY=VALUE` CLI flags.
+4. `--var KEY=VALUE` CLI flags (always applied last; win over any profile
+   value, and work even when no profile is active).
 
-Later layers win on conflicting keys.
+```bash
+omniagent sync --profile reviewer --var REVIEW_STYLE=thorough
+```
 
 ## Future work
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -19,6 +19,52 @@ Everyone except Claude and Gemini sees this.
 </agents>
 ```
 
+## Variable substitution
+
+Anywhere in a template, `{{NAME}}` is replaced with the matching variable value.
+Provide an inline default with `{{NAME=fallback}}`:
+
+```md
+You are a {{REVIEW_STYLE=thorough}} code reviewer. Log source is {{LOG_SOURCE}}.
+```
+
+Variable names must match `[A-Z_][A-Z0-9_]*` (uppercase ASCII, digits,
+underscores — env-var-safe).
+
+### Where values come from
+
+1. **Profile `variables`** — defined inside a profile and merged across its
+   `extends` chain, `.local` overrides, and multiple `--profile` entries in CLI
+   order. See [`docs/profiles.md`](profiles.md#variables).
+2. **`--var KEY=VALUE` CLI flag** (repeatable) — applied last, wins over any
+   profile value. Works with or without a profile.
+
+### Substitution rules
+
+- `{{NAME}}` with no default and no matching variable: the placeholder is left
+  literal in the output and a `profile_warning` is emitted so the typo is
+  surfaced.
+- `{{NAME=default}}` with no matching variable: the default is used.
+- `{{NAME}}` or `{{NAME=default}}` with a matching variable: the variable
+  value is used (including empty-string values, which do **not** fall through
+  to the default).
+- Whitespace around the name is tolerated (`{{ NAME }}`). The default value
+  runs until the closing `}}` and may contain spaces.
+
+### Access from scripts
+
+Every variable is also injected into the child process env for `<nodejs>` and
+`<shell>` blocks as `OMNIAGENT_VAR_<NAME>`:
+
+```md
+<nodejs>
+return `Style: ${process.env.OMNIAGENT_VAR_REVIEW_STYLE}`;
+</nodejs>
+```
+
+Substitution applies to script **output** as well, so a script can emit
+`{{VAR}}` and it will be resolved after evaluation.
+
 ## Dynamic template scripts (`<nodejs>` and `<shell>`)
 
 `sync` can execute inline script blocks before agent templating/rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",
+        "minimatch": "^10.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1407,6 +1408,27 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1722,6 +1744,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "jiti": "^2.6.1",
+    "minimatch": "^10.2.5",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -658,6 +661,14 @@ packages:
   ast-v8-to-istanbul@0.3.10:
     resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -757,6 +768,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1370,6 +1385,12 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   chai@6.2.2: {}
 
   cliui@8.0.1:
@@ -1496,6 +1517,10 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
 
   nanoid@3.3.11: {}
 

--- a/schemas/profile.v1.json
+++ b/schemas/profile.v1.json
@@ -51,6 +51,16 @@
 				"subagents": { "$ref": "#/$defs/patternList" },
 				"commands": { "$ref": "#/$defs/patternList" }
 			}
+		},
+		"variables": {
+			"type": "object",
+			"description": "Template variables. Keys must match [A-Z_][A-Z0-9_]*. Values substitute `{{KEY}}` (or `{{KEY=default}}`) anywhere in rendered template content and are exposed to `<nodejs>` / `<shell>` blocks as `OMNIAGENT_VAR_KEY` env vars.",
+			"additionalProperties": {
+				"type": "string"
+			},
+			"propertyNames": {
+				"pattern": "^[A-Z_][A-Z0-9_]*$"
+			}
 		}
 	},
 	"$defs": {

--- a/schemas/profile.v1.json
+++ b/schemas/profile.v1.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://omniagent.dev/schema/profile.v1.json",
+	"title": "omniagent sync profile",
+	"description": "A named configuration that filters and customizes what `omniagent sync` writes to targets.",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "Optional reference to this JSON Schema for editor autocomplete."
+		},
+		"description": {
+			"type": "string",
+			"description": "Human-readable summary shown in `omniagent profiles`."
+		},
+		"extends": {
+			"type": "string",
+			"description": "Name of another profile to inherit from. Chains are supported; cycles are detected."
+		},
+		"targets": {
+			"type": "object",
+			"description": "Per-target enablement map. Keys are target ids or configured aliases.",
+			"additionalProperties": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"enabled": {
+						"type": "boolean",
+						"description": "When false, this target is skipped for the profile (equivalent to --skip <target>)."
+					}
+				}
+			}
+		},
+		"enable": {
+			"type": "object",
+			"description": "Allowlist of items to include. Values are glob patterns matched against canonical item names.",
+			"additionalProperties": false,
+			"properties": {
+				"skills": { "$ref": "#/$defs/patternList" },
+				"subagents": { "$ref": "#/$defs/patternList" },
+				"commands": { "$ref": "#/$defs/patternList" }
+			}
+		},
+		"disable": {
+			"type": "object",
+			"description": "Denylist applied after `enable`. Values are glob patterns matched against canonical item names.",
+			"additionalProperties": false,
+			"properties": {
+				"skills": { "$ref": "#/$defs/patternList" },
+				"subagents": { "$ref": "#/$defs/patternList" },
+				"commands": { "$ref": "#/$defs/patternList" }
+			}
+		}
+	},
+	"$defs": {
+		"patternList": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"minLength": 1
+			},
+			"description": "List of glob patterns. `*` and `?` are supported. Exact names (no wildcards) emit a warning when they match zero items."
+		}
+	}
+}

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -1,16 +1,26 @@
 import type { CommandModule } from "yargs";
 import { DEFAULT_AGENTS_DIR, resolveAgentsDir, validateAgentsDir } from "../../lib/agents-dir.js";
 import {
+	createProfileItemFilter,
 	DEFAULT_PROFILE_NAME,
 	formatValidationIssues,
 	listProfileDirectory,
 	listProfiles,
 	loadProfileFiles,
 	profileExists,
+	type ResolvedProfile,
 	resolveProfiles,
 	validateProfile,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
+import { loadSkillCatalog } from "../../lib/skills/catalog.js";
+import { loadCommandCatalog } from "../../lib/slash-commands/catalog.js";
+import { loadSubagentCatalog } from "../../lib/subagents/catalog.js";
+import { createTargetNameResolver } from "../../lib/sync-targets.js";
+import { BUILTIN_TARGETS } from "../../lib/targets/builtins.js";
+import { loadTargetConfig } from "../../lib/targets/config-loader.js";
+import { validateTargetConfig } from "../../lib/targets/config-validate.js";
+import { resolveTargets } from "../../lib/targets/resolve-targets.js";
 
 type BaseArgs = {
 	agentsDir?: string;
@@ -27,6 +37,13 @@ type ValidateArgs = BaseArgs & {
 
 type ListArgs = BaseArgs & {
 	json?: boolean;
+};
+
+type ProfileValidationCatalog = {
+	resolveTargetName: (value: string) => string | null;
+	skillNames: string[];
+	commandNames: string[];
+	subagentNames: string[];
 };
 
 async function resolveRepoAndAgentsDir(
@@ -70,6 +87,61 @@ function formatAnnotations(entry: {
 		annotations.push("[local override]");
 	}
 	return annotations;
+}
+
+async function loadProfileValidationCatalog(
+	repoRoot: string,
+	agentsDir: string,
+): Promise<ProfileValidationCatalog> {
+	const { config } = await loadTargetConfig({ repoRoot, agentsDir });
+	const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+	if (!validation.valid) {
+		throw new Error(`Invalid target configuration:\n- ${validation.errors.join("\n- ")}`);
+	}
+
+	const resolvedTargets = resolveTargets({
+		config: validation.config,
+		builtIns: BUILTIN_TARGETS,
+	});
+	const { resolveTargetName } = createTargetNameResolver(resolvedTargets.targets);
+	const [skillCatalog, commandCatalog, subagentCatalog] = await Promise.all([
+		loadSkillCatalog(repoRoot, { agentsDir, resolveTargetName }),
+		loadCommandCatalog(repoRoot, { agentsDir, resolveTargetName }),
+		loadSubagentCatalog(repoRoot, { agentsDir, resolveTargetName }),
+	]);
+
+	return {
+		resolveTargetName,
+		skillNames: skillCatalog.skills.map((skill) => skill.name),
+		commandNames: commandCatalog.commands.map((command) => command.name),
+		subagentNames: subagentCatalog.subagents.map((subagent) => subagent.resolvedName),
+	};
+}
+
+function collectProfileReferenceIssues(
+	profileName: string,
+	resolvedProfile: ResolvedProfile,
+	catalog: ProfileValidationCatalog,
+): string[] {
+	const filter = createProfileItemFilter(resolvedProfile);
+	for (const skillName of catalog.skillNames) {
+		filter.includes("skills", skillName);
+	}
+	for (const commandName of catalog.commandNames) {
+		filter.includes("commands", commandName);
+	}
+	for (const subagentName of catalog.subagentNames) {
+		filter.includes("subagents", subagentName);
+	}
+
+	const issues = filter.collectUnknownWarnings();
+	for (const targetName of Object.keys(resolvedProfile.targets)) {
+		if (catalog.resolveTargetName(targetName)) {
+			continue;
+		}
+		issues.push(`profile "${profileName}" references unknown target "${targetName}"`);
+	}
+	return issues;
 }
 
 const listSubcommand: CommandModule = {
@@ -157,6 +229,7 @@ const showSubcommand: CommandModule = {
 				targets: resolvedProfile.targets,
 				enable: resolvedProfile.enable,
 				disable: resolvedProfile.disable,
+				variables: resolvedProfile.variables,
 				notices: resolvedProfile.notices,
 			};
 			console.log(JSON.stringify(output, null, 2));
@@ -187,6 +260,14 @@ const validateSubcommand: CommandModule = {
 			return;
 		}
 		let hasIssues = false;
+		let validationCatalog: ProfileValidationCatalog | null = null;
+		try {
+			validationCatalog = await loadProfileValidationCatalog(resolved.repoRoot, resolved.agentsDir);
+		} catch (error) {
+			hasIssues = true;
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`Error: Failed to load catalogs for profile validation: ${message}`);
+		}
 		for (const entry of listing) {
 			const loaded = await loadProfileFiles(resolved.repoRoot, entry.name, resolved.agentsDir);
 			if (!profileExists(loaded)) {
@@ -212,6 +293,20 @@ const validateSubcommand: CommandModule = {
 					repoRoot: resolved.repoRoot,
 					agentsDir: resolved.agentsDir,
 				});
+				if (validationCatalog) {
+					const issues = collectProfileReferenceIssues(
+						entry.name,
+						resolvedProfile,
+						validationCatalog,
+					);
+					if (issues.length > 0) {
+						hasIssues = true;
+						console.error(`Profile "${entry.name}":`);
+						for (const issue of issues) {
+							console.error(`  - ${issue}`);
+						}
+					}
+				}
 				for (const notice of resolvedProfile.notices) {
 					console.error(`Profile "${entry.name}" notice: ${notice}`);
 				}

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -1,0 +1,245 @@
+import type { CommandModule } from "yargs";
+import { DEFAULT_AGENTS_DIR, resolveAgentsDir, validateAgentsDir } from "../../lib/agents-dir.js";
+import {
+	DEFAULT_PROFILE_NAME,
+	formatValidationIssues,
+	listProfileDirectory,
+	listProfiles,
+	loadProfileFiles,
+	profileExists,
+	resolveProfiles,
+	validateProfile,
+} from "../../lib/profiles/index.js";
+import { findRepoRoot } from "../../lib/repo-root.js";
+
+type BaseArgs = {
+	agentsDir?: string;
+};
+
+type ShowArgs = BaseArgs & {
+	name: string;
+	json?: boolean;
+};
+
+type ValidateArgs = BaseArgs & {
+	strict?: boolean;
+};
+
+type ListArgs = BaseArgs & {
+	json?: boolean;
+};
+
+async function resolveRepoAndAgentsDir(
+	argv: BaseArgs,
+): Promise<{ repoRoot: string; agentsDir: string } | null> {
+	const startDir = process.cwd();
+	const repoRoot = await findRepoRoot(startDir);
+	if (!repoRoot) {
+		console.error(
+			`Error: Repository root not found starting from ${startDir}. Looked for .git or package.json.`,
+		);
+		process.exit(1);
+		return null;
+	}
+	const agentsDirResolution = resolveAgentsDir(repoRoot, argv.agentsDir);
+	if (agentsDirResolution.source === "override") {
+		const validation = await validateAgentsDir(repoRoot, argv.agentsDir);
+		if (validation.validationStatus !== "valid") {
+			console.error(`Error: ${validation.errorMessage}`);
+			process.exit(1);
+			return null;
+		}
+	}
+	return { repoRoot, agentsDir: agentsDirResolution.resolvedPath };
+}
+
+function formatAnnotations(entry: {
+	isDefault: boolean;
+	hasShared: boolean;
+	hasLocalSibling: boolean;
+	hasLocalDedicated: boolean;
+	isLocalOnly: boolean;
+}): string[] {
+	const annotations: string[] = [];
+	if (entry.isDefault) {
+		annotations.push("(active by default)");
+	}
+	if (entry.isLocalOnly) {
+		annotations.push("[local-only]");
+	} else if (entry.hasLocalSibling || entry.hasLocalDedicated) {
+		annotations.push("[local override]");
+	}
+	return annotations;
+}
+
+const listSubcommand: CommandModule = {
+	command: "$0",
+	describe: "List available sync profiles",
+	builder: (yargs) =>
+		yargs
+			.option("agentsDir", {
+				type: "string",
+				describe: "Override the agents directory (relative paths resolve from the project root)",
+				defaultDescription: DEFAULT_AGENTS_DIR,
+			})
+			.option("json", {
+				type: "boolean",
+				default: false,
+				describe: "Output JSON",
+			}),
+	handler: async (argv) => {
+		const typed = argv as unknown as ListArgs;
+		const resolved = await resolveRepoAndAgentsDir(typed);
+		if (!resolved) return;
+		const entries = await listProfiles(resolved.repoRoot, resolved.agentsDir);
+		if (typed.json) {
+			console.log(JSON.stringify(entries, null, 2));
+			return;
+		}
+		if (entries.length === 0) {
+			console.log(
+				"No profiles found. Create agents/profiles/<name>.json to define a sync profile.",
+			);
+			return;
+		}
+		const nameWidth = Math.max(8, ...entries.map((entry) => entry.name.length));
+		for (const entry of entries) {
+			const padded = entry.name.padEnd(nameWidth + 2, " ");
+			const description = entry.description ?? "";
+			const annotations = formatAnnotations(entry).join(" ");
+			const parts = [padded, description, annotations].filter((part) => part.length > 0);
+			console.log(parts.join(" ").trimEnd());
+		}
+	},
+};
+
+const showSubcommand: CommandModule = {
+	command: "show <name>",
+	describe: "Print the fully-resolved merged profile",
+	builder: (yargs) =>
+		yargs
+			.positional("name", {
+				type: "string",
+				demandOption: true,
+				describe: "Profile name (or comma-separated names)",
+			})
+			.option("agentsDir", {
+				type: "string",
+				describe: "Override the agents directory",
+				defaultDescription: DEFAULT_AGENTS_DIR,
+			})
+			.option("json", {
+				type: "boolean",
+				default: false,
+				describe: "Output JSON",
+			}),
+	handler: async (argv) => {
+		const typed = argv as unknown as ShowArgs;
+		const resolved = await resolveRepoAndAgentsDir(typed);
+		if (!resolved) return;
+		const names = typed.name
+			.split(",")
+			.map((part) => part.trim())
+			.filter(Boolean);
+		if (names.length === 0) {
+			console.error("Error: No profile name provided.");
+			process.exit(1);
+			return;
+		}
+		try {
+			const resolvedProfile = await resolveProfiles(names, {
+				repoRoot: resolved.repoRoot,
+				agentsDir: resolved.agentsDir,
+			});
+			const output = {
+				names: resolvedProfile.names,
+				description: resolvedProfile.description,
+				targets: resolvedProfile.targets,
+				enable: resolvedProfile.enable,
+				disable: resolvedProfile.disable,
+				notices: resolvedProfile.notices,
+			};
+			console.log(JSON.stringify(output, null, 2));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`Error: ${message}`);
+			process.exit(1);
+		}
+	},
+};
+
+const validateSubcommand: CommandModule = {
+	command: "validate",
+	describe: "Validate all profile files (non-zero exit on warnings or errors)",
+	builder: (yargs) =>
+		yargs.option("agentsDir", {
+			type: "string",
+			describe: "Override the agents directory",
+			defaultDescription: DEFAULT_AGENTS_DIR,
+		}),
+	handler: async (argv) => {
+		const typed = argv as unknown as ValidateArgs;
+		const resolved = await resolveRepoAndAgentsDir(typed);
+		if (!resolved) return;
+		const listing = await listProfileDirectory(resolved.repoRoot, resolved.agentsDir);
+		if (listing.length === 0) {
+			console.log(`No profiles found (default: ${DEFAULT_PROFILE_NAME}).`);
+			return;
+		}
+		let hasIssues = false;
+		for (const entry of listing) {
+			const loaded = await loadProfileFiles(resolved.repoRoot, entry.name, resolved.agentsDir);
+			if (!profileExists(loaded)) {
+				continue;
+			}
+			for (const record of [loaded.shared, loaded.localSibling, loaded.localDedicated]) {
+				if (!record) {
+					continue;
+				}
+				const validation = validateProfile(record.profile);
+				if (validation.valid) {
+					continue;
+				}
+				hasIssues = true;
+				const issues = formatValidationIssues(validation.errors);
+				console.error(`Profile "${entry.name}" (${record.filePath}):`);
+				for (const issue of issues) {
+					console.error(`  - ${issue}`);
+				}
+			}
+			try {
+				const resolvedProfile = await resolveProfiles([entry.name], {
+					repoRoot: resolved.repoRoot,
+					agentsDir: resolved.agentsDir,
+				});
+				for (const notice of resolvedProfile.notices) {
+					console.error(`Profile "${entry.name}" notice: ${notice}`);
+				}
+			} catch (error) {
+				hasIssues = true;
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(`Profile "${entry.name}" resolution failed: ${message}`);
+			}
+		}
+		if (hasIssues) {
+			process.exit(1);
+			return;
+		}
+		console.log(`Validated ${listing.length} profile(s).`);
+	},
+};
+
+export const profilesCommand: CommandModule = {
+	command: "profiles",
+	describe: "Inspect and validate sync profiles",
+	builder: (yargs) =>
+		yargs
+			.command(listSubcommand)
+			.command(showSubcommand)
+			.command(validateSubcommand)
+			.demandCommand(0)
+			.strictCommands(),
+	handler: () => {
+		// Subcommand handlers do the work; the default list handler runs when no subcommand is given.
+	},
+};

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -3,14 +3,11 @@ import { DEFAULT_AGENTS_DIR, resolveAgentsDir, validateAgentsDir } from "../../l
 import {
 	createProfileItemFilter,
 	DEFAULT_PROFILE_NAME,
-	formatValidationIssues,
+	inspectProfileFiles,
 	listProfileDirectory,
 	listProfiles,
-	loadProfileFiles,
-	profileExists,
 	type ResolvedProfile,
 	resolveProfiles,
-	validateProfile,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
 import { loadSkillCatalog } from "../../lib/skills/catalog.js";
@@ -269,24 +266,30 @@ const validateSubcommand: CommandModule = {
 			console.error(`Error: Failed to load catalogs for profile validation: ${message}`);
 		}
 		for (const entry of listing) {
-			const loaded = await loadProfileFiles(resolved.repoRoot, entry.name, resolved.agentsDir);
-			if (!profileExists(loaded)) {
+			const inspected = await inspectProfileFiles(
+				resolved.repoRoot,
+				entry.name,
+				resolved.agentsDir,
+			);
+			const sources = [inspected.shared, inspected.localSibling, inspected.localDedicated];
+			const hasExistingSource = sources.some((source) => source.exists);
+			if (!hasExistingSource) {
 				continue;
 			}
-			for (const record of [loaded.shared, loaded.localSibling, loaded.localDedicated]) {
-				if (!record) {
-					continue;
-				}
-				const validation = validateProfile(record.profile);
-				if (validation.valid) {
+			let hasLoadIssues = false;
+			for (const source of sources) {
+				if (!source.exists || source.issues.length === 0) {
 					continue;
 				}
 				hasIssues = true;
-				const issues = formatValidationIssues(validation.errors);
-				console.error(`Profile "${entry.name}" (${record.filePath}):`);
-				for (const issue of issues) {
+				hasLoadIssues = true;
+				console.error(`Profile "${entry.name}" (${source.filePath}):`);
+				for (const issue of source.issues) {
 					console.error(`  - ${issue}`);
 				}
+			}
+			if (hasLoadIssues) {
+				continue;
 			}
 			try {
 				const resolvedProfile = await resolveProfiles([entry.name], {

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -33,6 +33,7 @@ import {
 	DEFAULT_PROFILE_NAME,
 	loadProfileFiles,
 	type ProfileItemFilter,
+	type ProfileTargetSetting,
 	profileExists,
 	type ResolvedProfile,
 	resolveProfiles,
@@ -141,6 +142,40 @@ function parseProfileList(value?: string | string[]): string[] {
 		.flatMap((entry) => entry.split(","))
 		.map((entry) => entry.trim())
 		.filter(Boolean);
+}
+
+type KnownProfileTargetSettings = {
+	targets: Record<string, ProfileTargetSetting>;
+	unknownTargets: string[];
+};
+
+function resolveKnownProfileTargetSettings(
+	profile: ResolvedProfile | null,
+	resolveTargetName: (value: string) => string | null,
+): KnownProfileTargetSettings {
+	if (!profile) {
+		return { targets: {}, unknownTargets: [] };
+	}
+
+	const targets: Record<string, ProfileTargetSetting> = {};
+	const unknownTargets: string[] = [];
+	const seenUnknownTargets = new Set<string>();
+
+	for (const [targetKey, setting] of Object.entries(profile.targets)) {
+		const resolvedTargetName = resolveTargetName(targetKey);
+		if (!resolvedTargetName) {
+			if (!seenUnknownTargets.has(targetKey)) {
+				seenUnknownTargets.add(targetKey);
+				unknownTargets.push(targetKey);
+			}
+			continue;
+		}
+
+		const existing = targets[resolvedTargetName] ?? {};
+		targets[resolvedTargetName] = { ...existing, ...setting };
+	}
+
+	return { targets, unknownTargets };
 }
 
 type ParsedVariables = {
@@ -669,80 +704,75 @@ async function validateTemplatingSources(options: {
 	validAgents: string[];
 	commandsAvailable: boolean;
 	skillsAvailable: boolean;
+	subagentsAvailable: boolean;
 	includeLocalCommands: boolean;
 	includeLocalSkills: boolean;
 	includeLocalAgents: boolean;
 	includeLocalInstructions: boolean;
 	instructionsAvailable: boolean;
+	resolveTargetName?: (value: string) => string | null;
+	includeSkill?: (name: string) => boolean;
+	includeSubagent?: (name: string) => boolean;
+	includeCommand?: (name: string) => boolean;
 }): Promise<void> {
-	const directories: string[] = [];
+	const validateContent = (sourcePath: string, contents: string): void => {
+		validateAgentTemplating({
+			content: contents,
+			validAgents: options.validAgents,
+			sourcePath,
+		});
+	};
+
 	if (options.commandsAvailable) {
-		const commandsPath = resolveSharedCategoryRoot(options.repoRoot, "commands", options.agentsDir);
-		if (await assertSourceDirectory(commandsPath)) {
-			directories.push(commandsPath);
-		}
-	}
-	if (options.skillsAvailable) {
-		const skillsPath = resolveSharedCategoryRoot(options.repoRoot, "skills", options.agentsDir);
-		if (await assertSourceDirectory(skillsPath)) {
-			directories.push(skillsPath);
-		}
-	}
-	if (options.includeLocalCommands) {
-		const localCommandsPath = resolveLocalCategoryRoot(
-			options.repoRoot,
-			"commands",
-			options.agentsDir,
-		);
-		if (await assertSourceDirectory(localCommandsPath)) {
-			directories.push(localCommandsPath);
-		}
-	}
-	if (options.includeLocalSkills) {
-		const localSkillsPath = resolveLocalCategoryRoot(options.repoRoot, "skills", options.agentsDir);
-		if (await assertSourceDirectory(localSkillsPath)) {
-			directories.push(localSkillsPath);
-		}
-	}
-	const subagentsPath = resolveSharedCategoryRoot(options.repoRoot, "agents", options.agentsDir);
-	if (await assertSourceDirectory(subagentsPath)) {
-		directories.push(subagentsPath);
-	}
-	if (options.includeLocalAgents) {
-		const localSubagentsPath = resolveLocalCategoryRoot(
-			options.repoRoot,
-			"agents",
-			options.agentsDir,
-		);
-		if (await assertSourceDirectory(localSubagentsPath)) {
-			directories.push(localSubagentsPath);
+		const commandCatalog = await loadCommandCatalog(options.repoRoot, {
+			includeLocal: options.includeLocalCommands,
+			agentsDir: options.agentsDir,
+			resolveTargetName: options.resolveTargetName,
+		});
+		for (const command of commandCatalog.commands) {
+			if (options.includeCommand && !options.includeCommand(command.name)) {
+				continue;
+			}
+			validateContent(command.sourcePath, command.rawContents);
 		}
 	}
 
-	for (const directory of directories) {
-		const category = path.basename(directory);
-		const excludeLocal =
-			(category === "skills" && !options.includeLocalSkills) ||
-			(category === "commands" && !options.includeLocalCommands) ||
-			(category === "agents" && !options.includeLocalAgents);
-		const files =
-			path.basename(directory) === "skills"
-				? await listFiles(directory)
-				: await listMarkdownFiles(directory);
-		const filesToValidate = excludeLocal
-			? files.filter((filePath) => !hasLocalMarker(filePath))
-			: files;
-		for (const filePath of filesToValidate) {
-			const buffer = await readFile(filePath);
-			const contents = decodeUtf8(buffer);
-			if (contents === null) {
+	if (options.skillsAvailable) {
+		const skillCatalog = await loadSkillCatalog(options.repoRoot, {
+			includeLocal: options.includeLocalSkills,
+			agentsDir: options.agentsDir,
+			resolveTargetName: options.resolveTargetName,
+		});
+		for (const skill of skillCatalog.skills) {
+			if (options.includeSkill && !options.includeSkill(skill.name)) {
 				continue;
 			}
-			validateAgentTemplating({
-				content: contents,
-				validAgents: options.validAgents,
-				sourcePath: filePath,
-			});
+			const files = await listFiles(skill.directoryPath);
+			const filesToValidate = options.includeLocalSkills
+				? files
+				: files.filter((filePath) => !hasLocalMarker(filePath));
+			for (const filePath of filesToValidate) {
+				const buffer = await readFile(filePath);
+				const contents = decodeUtf8(buffer);
+				if (contents === null) {
+					continue;
+				}
+				validateContent(filePath, contents);
+			}
+		}
+	}
+
+	if (options.subagentsAvailable) {
+		const subagentCatalog = await loadSubagentCatalog(options.repoRoot, {
+			includeLocal: options.includeLocalAgents,
+			agentsDir: options.agentsDir,
+			resolveTargetName: options.resolveTargetName,
+		});
+		for (const subagent of subagentCatalog.subagents) {
+			if (options.includeSubagent && !options.includeSubagent(subagent.resolvedName)) {
+				continue;
+			}
+			validateContent(subagent.sourcePath, subagent.rawContents);
 		}
 	}
 
@@ -1483,14 +1513,17 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				return;
 			}
 
-			const profileUnknownTargets: string[] = [];
-			if (activeProfile) {
-				for (const targetKey of Object.keys(activeProfile.targets)) {
-					if (!targetResolver.resolveTargetName(targetKey)) {
-						profileUnknownTargets.push(targetKey);
+			const knownProfileTargets = resolveKnownProfileTargetSettings(
+				activeProfile,
+				targetResolver.resolveTargetName,
+			);
+			const profileForTargetSelection = activeProfile
+				? {
+						...activeProfile,
+						targets: knownProfileTargets.targets,
 					}
-				}
-			}
+				: null;
+			const profileUnknownTargets = knownProfileTargets.unknownTargets;
 			for (const name of profileUnknownTargets) {
 				scriptRuntime.warnings.push({
 					code: "profile_warning",
@@ -1507,7 +1540,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				if (skipSet.size > 0 && skipSet.has(target.id)) {
 					return false;
 				}
-				return targetEnabledByProfile(activeProfile, target.id, target.aliases ?? []);
+				return targetEnabledByProfile(profileForTargetSelection, target.id, target.aliases ?? []);
 			});
 			const overrideOnly = resolvedOnly.ids.length > 0 ? resolvedOnly.ids : undefined;
 			const overrideSkip = resolvedSkip.ids.length > 0 ? resolvedSkip.ids : undefined;
@@ -1760,11 +1793,16 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					validAgents,
 					commandsAvailable: hasCommandsToSync,
 					skillsAvailable: hasSkillsToSync,
+					subagentsAvailable: hasSubagentsToSync,
 					includeLocalCommands: includeLocalCommands && hasCommandsToSync,
 					includeLocalSkills: includeLocalSkills && hasSkillsToSync,
 					includeLocalAgents: includeLocalAgents && hasSubagentsToSync,
 					includeLocalInstructions: includeLocalInstructions && hasInstructionsToSync,
 					instructionsAvailable: hasInstructionsToSync,
+					resolveTargetName,
+					includeSkill: includeItemFor("skills"),
+					includeSubagent: includeItemFor("subagents"),
+					includeCommand: includeItemFor("commands"),
 				});
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -36,6 +36,7 @@ import {
 	profileExists,
 	type ResolvedProfile,
 	resolveProfiles,
+	targetEnabledByProfile,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
 import { loadSkillCatalog } from "../../lib/skills/catalog.js";
@@ -1482,20 +1483,11 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				return;
 			}
 
-			const profileDisabledTargets: string[] = [];
 			const profileUnknownTargets: string[] = [];
 			if (activeProfile) {
-				for (const [targetKey, setting] of Object.entries(activeProfile.targets)) {
-					if (setting.enabled !== false) {
-						continue;
-					}
-					const resolvedName = targetResolver.resolveTargetName(targetKey);
-					if (!resolvedName) {
+				for (const targetKey of Object.keys(activeProfile.targets)) {
+					if (!targetResolver.resolveTargetName(targetKey)) {
 						profileUnknownTargets.push(targetKey);
-						continue;
-					}
-					if (!profileDisabledTargets.includes(resolvedName)) {
-						profileDisabledTargets.push(resolvedName);
 					}
 				}
 			}
@@ -1506,7 +1498,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				});
 			}
 
-			const skipSet = new Set([...resolvedSkip.ids, ...profileDisabledTargets]);
+			const skipSet = new Set(resolvedSkip.ids);
 			const onlySet = new Set(resolvedOnly.ids);
 			const filteredTargets = resolved.targets.filter((target) => {
 				if (onlySet.size > 0 && !onlySet.has(target.id)) {
@@ -1515,11 +1507,10 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				if (skipSet.size > 0 && skipSet.has(target.id)) {
 					return false;
 				}
-				return true;
+				return targetEnabledByProfile(activeProfile, target.id, target.aliases ?? []);
 			});
 			const overrideOnly = resolvedOnly.ids.length > 0 ? resolvedOnly.ids : undefined;
-			const effectiveSkip = [...resolvedSkip.ids, ...profileDisabledTargets];
-			const overrideSkip = effectiveSkip.length > 0 ? effectiveSkip : undefined;
+			const overrideSkip = resolvedSkip.ids.length > 0 ? resolvedSkip.ids : undefined;
 			const validAgents = buildSupportedAgentNames(resolved.targets);
 
 			const profileItemFilter: ProfileItemFilter = createProfileItemFilter(activeProfile);

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -102,6 +102,7 @@ type SyncArgs = {
 	excludeLocal?: string | string[] | boolean;
 	listLocal?: boolean;
 	profile?: string | string[];
+	var?: string | string[];
 };
 
 const DEFAULT_SUPPORTED_TARGETS = BUILTIN_TARGETS.map((target) => target.id).join(", ");
@@ -139,6 +140,39 @@ function parseProfileList(value?: string | string[]): string[] {
 		.flatMap((entry) => entry.split(","))
 		.map((entry) => entry.trim())
 		.filter(Boolean);
+}
+
+type ParsedVariables = {
+	variables: Record<string, string>;
+	invalid: string[];
+};
+
+function parseVariableAssignments(value?: string | string[]): ParsedVariables {
+	const variables: Record<string, string> = {};
+	const invalid: string[] = [];
+	if (!value) {
+		return { variables, invalid };
+	}
+	const rawValues = Array.isArray(value) ? value : [value];
+	for (const entry of rawValues) {
+		const trimmed = entry.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const equalsIndex = trimmed.indexOf("=");
+		if (equalsIndex <= 0) {
+			invalid.push(trimmed);
+			continue;
+		}
+		const key = trimmed.slice(0, equalsIndex).trim();
+		const rawValue = trimmed.slice(equalsIndex + 1);
+		if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
+			invalid.push(trimmed);
+			continue;
+		}
+		variables[key] = rawValue;
+	}
+	return { variables, invalid };
 }
 
 type ExcludeLocalSelection = {
@@ -1261,6 +1295,12 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					"Sync profile(s) to apply. Pass a name (or comma-separated names, or repeat the flag). " +
 					"With no value, agents/profiles/default.json is used when present.",
 			})
+			.option("var", {
+				type: "string",
+				array: true,
+				describe:
+					"Set a template variable as KEY=VALUE (repeatable). CLI values override profile variables.",
+			})
 			.option("json", {
 				type: "boolean",
 				default: false,
@@ -1287,6 +1327,10 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			.example(
 				"omniagent sync --profile base,code-reviewer",
 				"Merge multiple profiles (later wins)",
+			)
+			.example(
+				"omniagent sync --var REVIEW_STYLE=terse --var LOG_SOURCE=datadog",
+				"Override or set template variables from the CLI",
 			),
 	handler: async (argv) => {
 		try {
@@ -1394,6 +1438,21 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					}
 				}
 			}
+
+			const cliVars = parseVariableAssignments(argv.var);
+			if (cliVars.invalid.length > 0) {
+				console.error(
+					`Error: Invalid --var value(s): ${cliVars.invalid.join(", ")}. ` +
+						"Expected KEY=VALUE with KEY matching [A-Z_][A-Z0-9_]*.",
+				);
+				process.exit(1);
+				return;
+			}
+			const mergedVariables: Record<string, string> = {
+				...(activeProfile?.variables ?? {}),
+				...cliVars.variables,
+			};
+			scriptRuntime.variables = mergedVariables;
 
 			const resolveSelection = (list: string[]): { ids: string[]; unknown: string[] } => {
 				const ids: string[] = [];

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -28,6 +28,15 @@ import {
 	resolveSharedCategoryRoot,
 	stripLocalPathSuffix,
 } from "../../lib/local-sources.js";
+import {
+	createProfileItemFilter,
+	DEFAULT_PROFILE_NAME,
+	loadProfileFiles,
+	profileExists,
+	resolveProfiles,
+	type ProfileItemFilter,
+	type ResolvedProfile,
+} from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
 import { loadSkillCatalog } from "../../lib/skills/catalog.js";
 import { syncSkills as syncSkillTargets } from "../../lib/skills/sync.js";
@@ -92,6 +101,7 @@ type SyncArgs = {
 	conflicts?: string;
 	excludeLocal?: string | string[] | boolean;
 	listLocal?: boolean;
+	profile?: string | string[];
 };
 
 const DEFAULT_SUPPORTED_TARGETS = BUILTIN_TARGETS.map((target) => target.id).join(", ");
@@ -117,6 +127,17 @@ function parseList(value?: string | string[]): string[] {
 	return rawValues
 		.flatMap((entry) => entry.split(","))
 		.map((entry) => entry.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+function parseProfileList(value?: string | string[]): string[] {
+	if (!value) {
+		return [];
+	}
+	const rawValues = Array.isArray(value) ? value : [value];
+	return rawValues
+		.flatMap((entry) => entry.split(","))
+		.map((entry) => entry.trim())
 		.filter(Boolean);
 }
 
@@ -302,6 +323,9 @@ type ScriptPreflightOptions = {
 	selectedInstructionTargets: ResolvedTarget[];
 	skillsAvailable: boolean;
 	commandsAvailable: boolean;
+	includeSkill?: (name: string) => boolean;
+	includeSubagent?: (name: string) => boolean;
+	includeCommand?: (name: string) => boolean;
 };
 
 function hasTemplateScripts(content: string): boolean {
@@ -364,6 +388,9 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const command of commandCatalog.commands) {
+			if (options.includeCommand && !options.includeCommand(command.name)) {
+				continue;
+			}
 			const effectiveTargets = resolveEffectiveTargets({
 				defaultTargets: command.targetAgents,
 				overrideOnly: options.overrideOnly,
@@ -384,6 +411,9 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const subagent of subagentCatalog.subagents) {
+			if (options.includeSubagent && !options.includeSubagent(subagent.resolvedName)) {
+				continue;
+			}
 			const effectiveTargets = resolveEffectiveTargets({
 				defaultTargets: subagent.targetAgents,
 				overrideOnly: options.overrideOnly,
@@ -425,6 +455,9 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const skill of skillCatalog.skills) {
+			if (options.includeSkill && !options.includeSkill(skill.name)) {
+				continue;
+			}
 			const effectiveTargets = resolveEffectiveTargets({
 				defaultTargets: skill.targetAgents,
 				overrideOnly: options.overrideOnly,
@@ -1221,6 +1254,13 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				default: false,
 				describe: "Show per-script execution telemetry during sync",
 			})
+			.option("profile", {
+				type: "string",
+				array: true,
+				describe:
+					"Sync profile(s) to apply. Pass a name (or comma-separated names, or repeat the flag). " +
+					"With no value, agents/profiles/default.json is used when present.",
+			})
 			.option("json", {
 				type: "boolean",
 				default: false,
@@ -1242,7 +1282,12 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			.example("omniagent sync --list-local", "List detected local items")
 			.example("omniagent sync --yes", "Accept defaults and apply changes")
 			.example("omniagent sync --verbose", "Show per-script execution telemetry")
-			.example("omniagent sync --json", "Output a JSON summary"),
+			.example("omniagent sync --json", "Output a JSON summary")
+			.example("omniagent sync --profile code-reviewer", "Apply a named profile")
+			.example(
+				"omniagent sync --profile base,code-reviewer",
+				"Merge multiple profiles (later wins)",
+			),
 	handler: async (argv) => {
 		try {
 			const skipList = parseList(argv.skip);
@@ -1320,6 +1365,36 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			const globalHooks = validation.config?.hooks;
 			const supportedLabel = buildSupportedTargetLabel(resolved.targets);
 
+			const profileNamesArg = parseProfileList(argv.profile);
+			const profileExplicitlyRequested = profileNamesArg.length > 0;
+			let profileNamesToApply = profileNamesArg;
+			if (!profileExplicitlyRequested) {
+				const defaultLoaded = await loadProfileFiles(repoRoot, DEFAULT_PROFILE_NAME, agentsDir);
+				if (profileExists(defaultLoaded)) {
+					profileNamesToApply = [DEFAULT_PROFILE_NAME];
+				}
+			}
+
+			let activeProfile: ResolvedProfile | null = null;
+			if (profileNamesToApply.length > 0) {
+				try {
+					activeProfile = await resolveProfiles(profileNamesToApply, {
+						repoRoot,
+						agentsDir,
+					});
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					console.error(`Error: ${message}`);
+					process.exit(1);
+					return;
+				}
+				for (const notice of activeProfile.notices) {
+					if (verboseOutput) {
+						logWithChannel(notice, jsonOutput);
+					}
+				}
+			}
+
 			const resolveSelection = (list: string[]): { ids: string[]; unknown: string[] } => {
 				const ids: string[] = [];
 				const unknown: string[] = [];
@@ -1348,7 +1423,31 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				return;
 			}
 
-			const skipSet = new Set(resolvedSkip.ids);
+			const profileDisabledTargets: string[] = [];
+			const profileUnknownTargets: string[] = [];
+			if (activeProfile) {
+				for (const [targetKey, setting] of Object.entries(activeProfile.targets)) {
+					if (setting.enabled !== false) {
+						continue;
+					}
+					const resolvedName = targetResolver.resolveTargetName(targetKey);
+					if (!resolvedName) {
+						profileUnknownTargets.push(targetKey);
+						continue;
+					}
+					if (!profileDisabledTargets.includes(resolvedName)) {
+						profileDisabledTargets.push(resolvedName);
+					}
+				}
+			}
+			for (const name of profileUnknownTargets) {
+				scriptRuntime.warnings.push({
+					code: "profile_warning",
+					message: `profile references unknown target "${name}"`,
+				});
+			}
+
+			const skipSet = new Set([...resolvedSkip.ids, ...profileDisabledTargets]);
 			const onlySet = new Set(resolvedOnly.ids);
 			const filteredTargets = resolved.targets.filter((target) => {
 				if (onlySet.size > 0 && !onlySet.has(target.id)) {
@@ -1360,8 +1459,19 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				return true;
 			});
 			const overrideOnly = resolvedOnly.ids.length > 0 ? resolvedOnly.ids : undefined;
-			const overrideSkip = resolvedSkip.ids.length > 0 ? resolvedSkip.ids : undefined;
+			const effectiveSkip = [...resolvedSkip.ids, ...profileDisabledTargets];
+			const overrideSkip = effectiveSkip.length > 0 ? effectiveSkip : undefined;
 			const validAgents = buildSupportedAgentNames(resolved.targets);
+
+			const profileItemFilter: ProfileItemFilter = createProfileItemFilter(activeProfile);
+			const includeItemFor = (
+				category: "skills" | "subagents" | "commands",
+			): ((name: string) => boolean) | undefined => {
+				if (!profileItemFilter.enabled) {
+					return undefined;
+				}
+				return (name) => profileItemFilter.includes(category, name);
+			};
 
 			if (filteredTargets.length === 0 && !listLocal) {
 				console.error("Error: No targets selected after applying filters.");
@@ -1631,6 +1741,9 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					selectedInstructionTargets,
 					skillsAvailable: hasSkillsToSync,
 					commandsAvailable: hasCommandsToSync,
+					includeSkill: includeItemFor("skills"),
+					includeSubagent: includeItemFor("subagents"),
+					includeCommand: includeItemFor("commands"),
 				});
 				for (const source of scriptSources) {
 					await evaluateTemplateScripts({
@@ -1773,6 +1886,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					resolveTargetName,
 					hooks: globalHooks,
 					templateScriptRuntime: scriptRuntime,
+					includeItem: includeItemFor("commands"),
 				} satisfies CommandSyncRequestV2);
 			}
 
@@ -1798,6 +1912,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				resolveTargetName,
 				hooks: globalHooks,
 				templateScriptRuntime: scriptRuntime,
+				includeItem: includeItemFor("subagents"),
 			} satisfies SubagentSyncRequestV2);
 
 			if (availabilitySubagentSkips.length > 0) {
@@ -1914,6 +2029,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					resolveTargetName,
 					hooks: globalHooks,
 					templateScriptRuntime: scriptRuntime,
+					includeItem: includeItemFor("skills"),
 				});
 			}
 
@@ -1927,6 +2043,12 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					...skillsSummary,
 					results: [...skillsSummary.results, ...availabilitySkillResults],
 				};
+			}
+
+			if (profileItemFilter.enabled) {
+				for (const message of profileItemFilter.collectUnknownWarnings()) {
+					scriptRuntime.warnings.push({ code: "profile_warning", message });
+				}
 			}
 
 			const hadFailures =
@@ -1947,6 +2069,11 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					partialOutputsWritten,
 				}),
 			};
+
+			if (activeProfile && activeProfile.names.length > 0 && !jsonOutput) {
+				const label = activeProfile.names.join(", ");
+				console.log(`Active profile: ${label}`);
+			}
 
 			emitSyncSummary({
 				combined,

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -32,10 +32,10 @@ import {
 	createProfileItemFilter,
 	DEFAULT_PROFILE_NAME,
 	loadProfileFiles,
-	profileExists,
-	resolveProfiles,
 	type ProfileItemFilter,
+	profileExists,
 	type ResolvedProfile,
+	resolveProfiles,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
 import { loadSkillCatalog } from "../../lib/skills/catalog.js";

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -253,6 +253,12 @@ type LocalItemsByCategory = {
 	total: number;
 };
 
+type ProfileTraversalNames = {
+	skills: Set<string>;
+	subagents: Set<string>;
+	commands: Set<string>;
+};
+
 function sortLocalItems(items: LocalItem[]): LocalItem[] {
 	return [...items].sort((left, right) => {
 		const nameCompare = left.name.localeCompare(right.name);
@@ -369,6 +375,46 @@ function formatLocalItemsOutput(
 		}
 	}
 	return lines.join("\n");
+}
+
+function replayTraversedProfileWarnings(
+	profile: ResolvedProfile | null,
+	traversedNames: ProfileTraversalNames,
+): string[] {
+	if (!profile || profile.names.length === 0) {
+		return [];
+	}
+
+	const hasTraversedSkills = traversedNames.skills.size > 0;
+	const hasTraversedSubagents = traversedNames.subagents.size > 0;
+	const hasTraversedCommands = traversedNames.commands.size > 0;
+	if (!hasTraversedSkills && !hasTraversedSubagents && !hasTraversedCommands) {
+		return [];
+	}
+
+	const warningFilter = createProfileItemFilter({
+		...profile,
+		enable: {
+			skills: hasTraversedSkills ? profile.enable.skills : [],
+			subagents: hasTraversedSubagents ? profile.enable.subagents : [],
+			commands: hasTraversedCommands ? profile.enable.commands : [],
+		},
+		disable: {
+			skills: hasTraversedSkills ? profile.disable.skills : [],
+			subagents: hasTraversedSubagents ? profile.disable.subagents : [],
+			commands: hasTraversedCommands ? profile.disable.commands : [],
+		},
+	});
+	for (const name of traversedNames.skills) {
+		warningFilter.includes("skills", name);
+	}
+	for (const name of traversedNames.subagents) {
+		warningFilter.includes("subagents", name);
+	}
+	for (const name of traversedNames.commands) {
+		warningFilter.includes("commands", name);
+	}
+	return warningFilter.collectUnknownWarnings();
 }
 
 type TemplateScriptSource = {
@@ -1547,13 +1593,21 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			const validAgents = buildSupportedAgentNames(resolved.targets);
 
 			const profileItemFilter: ProfileItemFilter = createProfileItemFilter(activeProfile);
+			const traversedProfileNames: ProfileTraversalNames = {
+				skills: new Set(),
+				subagents: new Set(),
+				commands: new Set(),
+			};
 			const includeItemFor = (
 				category: "skills" | "subagents" | "commands",
 			): ((name: string) => boolean) | undefined => {
 				if (!profileItemFilter.enabled) {
 					return undefined;
 				}
-				return (name) => profileItemFilter.includes(category, name);
+				return (name) => {
+					traversedProfileNames[category].add(name);
+					return profileItemFilter.includes(category, name);
+				};
 			};
 
 			if (filteredTargets.length === 0 && !listLocal) {
@@ -2134,7 +2188,10 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			}
 
 			if (profileItemFilter.enabled) {
-				for (const message of profileItemFilter.collectUnknownWarnings()) {
+				for (const message of replayTraversedProfileWarnings(
+					activeProfile,
+					traversedProfileNames,
+				)) {
 					scriptRuntime.warnings.push({ code: "profile_warning", message });
 				}
 			}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { devCommand } from "./commands/dev.js";
 import { echoCommand } from "./commands/echo.js";
 import { greetCommand } from "./commands/greet.js";
 import { helloCommand } from "./commands/hello.js";
+import { profilesCommand } from "./commands/profiles.js";
 import { syncCommand } from "./commands/sync.js";
 import { runShim } from "./shim/index.js";
 
@@ -34,7 +35,7 @@ function resolveVersion(): string {
 }
 
 const VERSION = resolveVersion();
-const KNOWN_COMMANDS = new Set(["hello", "greet", "echo", "sync", "dev"]);
+const KNOWN_COMMANDS = new Set(["hello", "greet", "echo", "sync", "dev", "profiles"]);
 const SHIM_CAPABILITIES = [
 	"Capabilities by agent:",
 	"  codex: approval, sandbox, output, model, web",
@@ -112,6 +113,7 @@ export function runCli(argv = process.argv, options: RunCliOptions = {}) {
 		.command(echoCommand)
 		.command(syncCommand)
 		.command(devCommand)
+		.command(profilesCommand)
 		.command(
 			"$0",
 			"omniagent CLI",

--- a/src/lib/ignore-rules.ts
+++ b/src/lib/ignore-rules.ts
@@ -2,7 +2,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { resolveAgentsDirRelativePath } from "./agents-dir.js";
 
-export const LOCAL_OVERRIDE_IGNORE_RULES = ["**/*.local/", "**/*.local.md"] as const;
+export const LOCAL_OVERRIDE_IGNORE_RULES = [
+	"**/*.local/",
+	"**/*.local.md",
+	"**/*.local.json",
+] as const;
 
 export type IgnoreRuleStatus = {
 	ignoreFilePath: string;

--- a/src/lib/profiles/filter.ts
+++ b/src/lib/profiles/filter.ts
@@ -1,30 +1,16 @@
+import { Minimatch } from "minimatch";
 import { PROFILE_CATEGORIES, type ProfileCategory, type ResolvedProfile } from "./types.js";
 
-function isBareName(pattern: string): boolean {
-	return !pattern.includes("*") && !pattern.includes("?");
-}
-
-function globToRegExp(pattern: string): RegExp {
-	let regex = "^";
-	for (let i = 0; i < pattern.length; i += 1) {
-		const char = pattern[i];
-		if (char === "*") {
-			regex += "[^/]*";
-			continue;
-		}
-		if (char === "?") {
-			regex += "[^/]";
-			continue;
-		}
-		regex += char.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&");
-	}
-	regex += "$";
-	return new RegExp(regex);
-}
+const MATCH_OPTIONS = {
+	dot: true,
+	magicalBraces: true,
+	nocomment: true,
+	nonegate: true,
+} as const;
 
 type CompiledPattern = {
 	raw: string;
-	regex: RegExp;
+	matcher: Minimatch;
 	bare: boolean;
 	matched: boolean;
 };
@@ -33,18 +19,21 @@ function compilePatterns(list: string[] | undefined): CompiledPattern[] {
 	if (!list || list.length === 0) {
 		return [];
 	}
-	return list.map((raw) => ({
-		raw,
-		regex: globToRegExp(raw),
-		bare: isBareName(raw),
-		matched: false,
-	}));
+	return list.map((raw) => {
+		const matcher = new Minimatch(raw, MATCH_OPTIONS);
+		return {
+			raw,
+			matcher,
+			bare: !matcher.hasMagic(),
+			matched: false,
+		};
+	});
 }
 
 function matchAny(name: string, patterns: CompiledPattern[]): boolean {
 	let matched = false;
 	for (const pattern of patterns) {
-		if (pattern.regex.test(name)) {
+		if (pattern.matcher.match(name)) {
 			pattern.matched = true;
 			matched = true;
 		}
@@ -150,13 +139,27 @@ export function targetEnabledByProfile(
 		return true;
 	}
 	const candidates = [targetId, ...targetAliases].map((v) => v.toLowerCase());
+	const hasExplicitEnabledTarget = Object.values(resolved.targets).some(
+		(setting) => setting.enabled === true,
+	);
+	let explicitlyEnabled = false;
+	let explicitlyDisabled = false;
 	for (const [key, setting] of Object.entries(resolved.targets)) {
 		if (!candidates.includes(key.toLowerCase())) {
 			continue;
 		}
 		if (setting.enabled === false) {
-			return false;
+			explicitlyDisabled = true;
 		}
+		if (setting.enabled === true) {
+			explicitlyEnabled = true;
+		}
+	}
+	if (explicitlyDisabled) {
+		return false;
+	}
+	if (hasExplicitEnabledTarget) {
+		return explicitlyEnabled;
 	}
 	return true;
 }

--- a/src/lib/profiles/filter.ts
+++ b/src/lib/profiles/filter.ts
@@ -1,0 +1,162 @@
+import { PROFILE_CATEGORIES, type ProfileCategory, type ResolvedProfile } from "./types.js";
+
+function isBareName(pattern: string): boolean {
+	return !pattern.includes("*") && !pattern.includes("?");
+}
+
+function globToRegExp(pattern: string): RegExp {
+	let regex = "^";
+	for (let i = 0; i < pattern.length; i += 1) {
+		const char = pattern[i];
+		if (char === "*") {
+			regex += "[^/]*";
+			continue;
+		}
+		if (char === "?") {
+			regex += "[^/]";
+			continue;
+		}
+		regex += char.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&");
+	}
+	regex += "$";
+	return new RegExp(regex);
+}
+
+type CompiledPattern = {
+	raw: string;
+	regex: RegExp;
+	bare: boolean;
+	matched: boolean;
+};
+
+function compilePatterns(list: string[] | undefined): CompiledPattern[] {
+	if (!list || list.length === 0) {
+		return [];
+	}
+	return list.map((raw) => ({
+		raw,
+		regex: globToRegExp(raw),
+		bare: isBareName(raw),
+		matched: false,
+	}));
+}
+
+function matchAny(name: string, patterns: CompiledPattern[]): boolean {
+	let matched = false;
+	for (const pattern of patterns) {
+		if (pattern.regex.test(name)) {
+			pattern.matched = true;
+			matched = true;
+		}
+	}
+	return matched;
+}
+
+export type ProfileItemFilter = {
+	enabled: boolean;
+	includes(category: ProfileCategory, canonicalName: string): boolean;
+	collectUnknownWarnings(): string[];
+};
+
+/**
+ * Build a predicate that applies a ResolvedProfile's enable/disable rules to
+ * canonical item names. When no rules target a given category, every name
+ * passes through.
+ */
+export function createProfileItemFilter(resolved: ResolvedProfile | null): ProfileItemFilter {
+	if (!resolved || resolved.names.length === 0) {
+		return {
+			enabled: false,
+			includes: () => true,
+			collectUnknownWarnings: () => [],
+		};
+	}
+
+	const enablePatternsByCategory = new Map<ProfileCategory, CompiledPattern[]>();
+	const disablePatternsByCategory = new Map<ProfileCategory, CompiledPattern[]>();
+
+	for (const category of PROFILE_CATEGORIES) {
+		enablePatternsByCategory.set(category, compilePatterns(resolved.enable[category]));
+		disablePatternsByCategory.set(category, compilePatterns(resolved.disable[category]));
+	}
+
+	return {
+		enabled: true,
+		includes(category, canonicalName) {
+			const enablePatterns = enablePatternsByCategory.get(category) ?? [];
+			const disablePatterns = disablePatternsByCategory.get(category) ?? [];
+			const enableApplies = enablePatterns.length > 0;
+			if (enableApplies && !matchAny(canonicalName, enablePatterns)) {
+				return false;
+			}
+			if (matchAny(canonicalName, disablePatterns)) {
+				return false;
+			}
+			// Also record matches against empty filters so zero-match bare names can warn.
+			if (!enableApplies) {
+				// still call matchAny so patterns (if any) track state; harmless when empty.
+			}
+			return true;
+		},
+		collectUnknownWarnings() {
+			const warnings: string[] = [];
+			for (const category of PROFILE_CATEGORIES) {
+				const enablePatterns = enablePatternsByCategory.get(category) ?? [];
+				for (const pattern of enablePatterns) {
+					if (pattern.bare && !pattern.matched) {
+						warnings.push(
+							`profile ${formatProfileLabel(resolved.names)} references unknown ${singular(category)} "${pattern.raw}"`,
+						);
+					}
+				}
+				const disablePatterns = disablePatternsByCategory.get(category) ?? [];
+				for (const pattern of disablePatterns) {
+					if (pattern.bare && !pattern.matched) {
+						warnings.push(
+							`profile ${formatProfileLabel(resolved.names)} references unknown ${singular(category)} "${pattern.raw}"`,
+						);
+					}
+				}
+			}
+			return warnings;
+		},
+	};
+}
+
+function singular(category: ProfileCategory): string {
+	switch (category) {
+		case "skills":
+			return "skill";
+		case "subagents":
+			return "subagent";
+		case "commands":
+			return "command";
+	}
+}
+
+function formatProfileLabel(names: string[]): string {
+	if (names.length === 1) {
+		return `"${names[0]}"`;
+	}
+	return `[${names.map((name) => `"${name}"`).join(", ")}]`;
+}
+
+export function targetEnabledByProfile(
+	resolved: ResolvedProfile | null,
+	targetId: string,
+	targetAliases: readonly string[] = [],
+): boolean {
+	if (!resolved || resolved.names.length === 0) {
+		return true;
+	}
+	const candidates = [targetId, ...targetAliases].map((v) => v.toLowerCase());
+	for (const [key, setting] of Object.entries(resolved.targets)) {
+		if (!candidates.includes(key.toLowerCase())) {
+			continue;
+		}
+		if (setting.enabled === false) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/lib/profiles/index.ts
+++ b/src/lib/profiles/index.ts
@@ -1,0 +1,17 @@
+export * from "./types.js";
+export * from "./validate.js";
+export * from "./paths.js";
+export {
+	listProfileDirectory,
+	loadProfileFiles,
+	profileExists,
+	toProfile,
+	type ProfileDirectoryListing,
+} from "./load.js";
+export { resolveProfiles, resolveSingleProfileRaw } from "./resolve.js";
+export {
+	createProfileItemFilter,
+	targetEnabledByProfile,
+	type ProfileItemFilter,
+} from "./filter.js";
+export { listProfiles, DEFAULT_PROFILE_NAME, type ProfileListEntry } from "./list.js";

--- a/src/lib/profiles/index.ts
+++ b/src/lib/profiles/index.ts
@@ -1,17 +1,17 @@
-export * from "./types.js";
-export * from "./validate.js";
-export * from "./paths.js";
+export {
+	createProfileItemFilter,
+	type ProfileItemFilter,
+	targetEnabledByProfile,
+} from "./filter.js";
+export { DEFAULT_PROFILE_NAME, listProfiles, type ProfileListEntry } from "./list.js";
 export {
 	listProfileDirectory,
 	loadProfileFiles,
+	type ProfileDirectoryListing,
 	profileExists,
 	toProfile,
-	type ProfileDirectoryListing,
 } from "./load.js";
+export * from "./paths.js";
 export { resolveProfiles, resolveSingleProfileRaw } from "./resolve.js";
-export {
-	createProfileItemFilter,
-	targetEnabledByProfile,
-	type ProfileItemFilter,
-} from "./filter.js";
-export { listProfiles, DEFAULT_PROFILE_NAME, type ProfileListEntry } from "./list.js";
+export * from "./types.js";
+export * from "./validate.js";

--- a/src/lib/profiles/index.ts
+++ b/src/lib/profiles/index.ts
@@ -5,9 +5,12 @@ export {
 } from "./filter.js";
 export { DEFAULT_PROFILE_NAME, listProfiles, type ProfileListEntry } from "./list.js";
 export {
+	inspectProfileFiles,
 	listProfileDirectory,
 	loadProfileFiles,
 	type ProfileDirectoryListing,
+	type ProfileFileInspection,
+	type ProfileInspectionLoadResult,
 	profileExists,
 	toProfile,
 } from "./load.js";

--- a/src/lib/profiles/index.ts
+++ b/src/lib/profiles/index.ts
@@ -13,5 +13,11 @@ export {
 } from "./load.js";
 export * from "./paths.js";
 export { resolveProfiles, resolveSingleProfileRaw } from "./resolve.js";
+export {
+	hasVariablePlaceholders,
+	substituteVariables,
+	type VariableSubstitutionIssue,
+	type VariableSubstitutionResult,
+} from "./substitute.js";
 export * from "./types.js";
 export * from "./validate.js";

--- a/src/lib/profiles/list.ts
+++ b/src/lib/profiles/list.ts
@@ -15,7 +15,7 @@ export type ProfileListEntry = {
 };
 
 function pickPrimary(result: ProfileLoadResult): ProfileFileRecord | null {
-	return result.shared ?? result.localSibling ?? result.localDedicated ?? null;
+	return result.localDedicated ?? result.localSibling ?? result.shared ?? null;
 }
 
 function descriptionOf(profile: Profile): string | null {

--- a/src/lib/profiles/list.ts
+++ b/src/lib/profiles/list.ts
@@ -1,5 +1,5 @@
-import { listProfileDirectory, loadProfileFiles } from "./load.js";
-import type { Profile, ProfileFileRecord, ProfileLoadResult } from "./types.js";
+import { listProfileDirectory } from "./load.js";
+import { resolveProfiles } from "./resolve.js";
 
 export const DEFAULT_PROFILE_NAME = "default";
 
@@ -14,12 +14,7 @@ export type ProfileListEntry = {
 	isBothLocalForms: boolean;
 };
 
-function pickPrimary(result: ProfileLoadResult): ProfileFileRecord | null {
-	return result.localDedicated ?? result.localSibling ?? result.shared ?? null;
-}
-
-function descriptionOf(profile: Profile): string | null {
-	const raw = profile.description;
+function descriptionOf(raw: string | null): string | null {
 	if (typeof raw !== "string") {
 		return null;
 	}
@@ -34,11 +29,10 @@ export async function listProfiles(
 	const directory = await listProfileDirectory(repoRoot, agentsDir);
 	const entries: ProfileListEntry[] = [];
 	for (const item of directory) {
-		const loaded = await loadProfileFiles(repoRoot, item.name, agentsDir);
-		const primary = pickPrimary(loaded);
+		const resolved = await resolveProfiles([item.name], { repoRoot, agentsDir });
 		entries.push({
 			name: item.name,
-			description: primary ? descriptionOf(primary.profile) : null,
+			description: descriptionOf(resolved.description),
 			hasShared: item.hasShared,
 			hasLocalSibling: item.hasLocalSibling,
 			hasLocalDedicated: item.hasLocalDedicated,

--- a/src/lib/profiles/list.ts
+++ b/src/lib/profiles/list.ts
@@ -1,0 +1,51 @@
+import { listProfileDirectory, loadProfileFiles } from "./load.js";
+import type { Profile, ProfileFileRecord, ProfileLoadResult } from "./types.js";
+
+export const DEFAULT_PROFILE_NAME = "default";
+
+export type ProfileListEntry = {
+	name: string;
+	description: string | null;
+	hasShared: boolean;
+	hasLocalSibling: boolean;
+	hasLocalDedicated: boolean;
+	isDefault: boolean;
+	isLocalOnly: boolean;
+	isBothLocalForms: boolean;
+};
+
+function pickPrimary(result: ProfileLoadResult): ProfileFileRecord | null {
+	return result.shared ?? result.localSibling ?? result.localDedicated ?? null;
+}
+
+function descriptionOf(profile: Profile): string | null {
+	const raw = profile.description;
+	if (typeof raw !== "string") {
+		return null;
+	}
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function listProfiles(
+	repoRoot: string,
+	agentsDir?: string | null,
+): Promise<ProfileListEntry[]> {
+	const directory = await listProfileDirectory(repoRoot, agentsDir);
+	const entries: ProfileListEntry[] = [];
+	for (const item of directory) {
+		const loaded = await loadProfileFiles(repoRoot, item.name, agentsDir);
+		const primary = pickPrimary(loaded);
+		entries.push({
+			name: item.name,
+			description: primary ? descriptionOf(primary.profile) : null,
+			hasShared: item.hasShared,
+			hasLocalSibling: item.hasLocalSibling,
+			hasLocalDedicated: item.hasLocalDedicated,
+			isDefault: item.name === DEFAULT_PROFILE_NAME,
+			isLocalOnly: !item.hasShared,
+			isBothLocalForms: item.hasLocalSibling && item.hasLocalDedicated,
+		});
+	}
+	return entries;
+}

--- a/src/lib/profiles/load.ts
+++ b/src/lib/profiles/load.ts
@@ -1,0 +1,177 @@
+import { readdir, readFile } from "node:fs/promises";
+import {
+	profileLocalDedicatedPath,
+	profileLocalSiblingPath,
+	profileSharedPath,
+	resolveLocalProfilesDir,
+	resolveProfilesDir,
+} from "./paths.js";
+import type { Profile, ProfileFileRecord, ProfileLoadResult, ProfileSourceKind } from "./types.js";
+import { assertValidProfile } from "./validate.js";
+
+const PROFILE_EXTENSION = ".json";
+const LOCAL_SUFFIX = ".local";
+
+async function readJsonFile(filePath: string): Promise<unknown | null> {
+	let contents: string;
+	try {
+		contents = await readFile(filePath, "utf8");
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			return null;
+		}
+		throw error;
+	}
+	try {
+		return JSON.parse(contents);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in profile at ${filePath}: ${message}`);
+	}
+}
+
+async function readProfileFile(
+	filePath: string,
+	name: string,
+	kind: ProfileSourceKind,
+): Promise<ProfileFileRecord | null> {
+	const raw = await readJsonFile(filePath);
+	if (raw === null) {
+		return null;
+	}
+	const profile = assertValidProfile(raw, name);
+	return {
+		name,
+		filePath,
+		kind,
+		profile,
+	};
+}
+
+export async function loadProfileFiles(
+	repoRoot: string,
+	name: string,
+	agentsDir?: string | null,
+): Promise<ProfileLoadResult> {
+	const [shared, localSibling, localDedicated] = await Promise.all([
+		readProfileFile(profileSharedPath(repoRoot, name, agentsDir), name, "shared"),
+		readProfileFile(profileLocalSiblingPath(repoRoot, name, agentsDir), name, "local-sibling"),
+		readProfileFile(profileLocalDedicatedPath(repoRoot, name, agentsDir), name, "local-dedicated"),
+	]);
+
+	return { shared, localSibling, localDedicated };
+}
+
+export function profileExists(result: ProfileLoadResult): boolean {
+	return result.shared !== null || result.localSibling !== null || result.localDedicated !== null;
+}
+
+export type ProfileDirectoryListing = {
+	name: string;
+	hasShared: boolean;
+	hasLocalSibling: boolean;
+	hasLocalDedicated: boolean;
+};
+
+function parseProfileFilename(
+	fileName: string,
+): { name: string; kind: "shared" | "local-sibling" } | null {
+	if (!fileName.toLowerCase().endsWith(PROFILE_EXTENSION)) {
+		return null;
+	}
+	const base = fileName.slice(0, -PROFILE_EXTENSION.length);
+	if (!base) {
+		return null;
+	}
+	if (base.endsWith(LOCAL_SUFFIX)) {
+		const stripped = base.slice(0, -LOCAL_SUFFIX.length);
+		if (!stripped) {
+			return null;
+		}
+		return { name: stripped, kind: "local-sibling" };
+	}
+	return { name: base, kind: "shared" };
+}
+
+async function readProfileNamesFromDir(
+	dirPath: string,
+): Promise<Array<{ name: string; kind: "shared" | "local-sibling" | "local-dedicated" }>> {
+	let entries: string[] = [];
+	try {
+		entries = await readdir(dirPath);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			return [];
+		}
+		throw error;
+	}
+	const out: Array<{
+		name: string;
+		kind: "shared" | "local-sibling" | "local-dedicated";
+	}> = [];
+	for (const entry of entries) {
+		const parsed = parseProfileFilename(entry);
+		if (!parsed) {
+			continue;
+		}
+		out.push({ name: parsed.name, kind: parsed.kind });
+	}
+	return out;
+}
+
+export async function listProfileDirectory(
+	repoRoot: string,
+	agentsDir?: string | null,
+): Promise<ProfileDirectoryListing[]> {
+	const sharedDir = resolveProfilesDir(repoRoot, agentsDir);
+	const dedicatedDir = resolveLocalProfilesDir(repoRoot, agentsDir);
+
+	const [sharedEntries, dedicatedEntries] = await Promise.all([
+		readProfileNamesFromDir(sharedDir),
+		readProfileNamesFromDir(dedicatedDir).then((list) =>
+			list
+				.filter((entry) => entry.kind === "shared")
+				.map((entry) => ({ name: entry.name, kind: "local-dedicated" as const })),
+		),
+	]);
+
+	const index = new Map<string, ProfileDirectoryListing>();
+	const get = (name: string): ProfileDirectoryListing => {
+		const existing = index.get(name);
+		if (existing) {
+			return existing;
+		}
+		const created: ProfileDirectoryListing = {
+			name,
+			hasShared: false,
+			hasLocalSibling: false,
+			hasLocalDedicated: false,
+		};
+		index.set(name, created);
+		return created;
+	};
+
+	for (const entry of sharedEntries) {
+		const record = get(entry.name);
+		if (entry.kind === "shared") {
+			record.hasShared = true;
+		} else {
+			record.hasLocalSibling = true;
+		}
+	}
+	for (const entry of dedicatedEntries) {
+		const record = get(entry.name);
+		record.hasLocalDedicated = true;
+	}
+
+	return [...index.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function toProfile(record: ProfileFileRecord): Profile {
+	return record.profile;
+}
+
+export { profileSharedPath, profileLocalSiblingPath, profileLocalDedicatedPath };
+export { resolveProfilesDir, resolveLocalProfilesDir };

--- a/src/lib/profiles/load.ts
+++ b/src/lib/profiles/load.ts
@@ -7,7 +7,7 @@ import {
 	resolveProfilesDir,
 } from "./paths.js";
 import type { Profile, ProfileFileRecord, ProfileLoadResult, ProfileSourceKind } from "./types.js";
-import { assertValidProfile } from "./validate.js";
+import { assertValidProfile, formatValidationIssues, validateProfile } from "./validate.js";
 
 const PROFILE_EXTENSION = ".json";
 const LOCAL_SUFFIX = ".local";
@@ -49,6 +49,71 @@ async function readProfileFile(
 	};
 }
 
+export type ProfileFileInspection = {
+	name: string;
+	filePath: string;
+	kind: ProfileSourceKind;
+	exists: boolean;
+	profile: Profile | null;
+	issues: string[];
+};
+
+export type ProfileInspectionLoadResult = {
+	shared: ProfileFileInspection;
+	localSibling: ProfileFileInspection;
+	localDedicated: ProfileFileInspection;
+};
+
+async function inspectProfileFile(
+	filePath: string,
+	name: string,
+	kind: ProfileSourceKind,
+): Promise<ProfileFileInspection> {
+	let raw: unknown | null;
+	try {
+		raw = await readJsonFile(filePath);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			name,
+			filePath,
+			kind,
+			exists: true,
+			profile: null,
+			issues: [message],
+		};
+	}
+	if (raw === null) {
+		return {
+			name,
+			filePath,
+			kind,
+			exists: false,
+			profile: null,
+			issues: [],
+		};
+	}
+	const validation = validateProfile(raw);
+	if (!validation.valid) {
+		return {
+			name,
+			filePath,
+			kind,
+			exists: true,
+			profile: null,
+			issues: formatValidationIssues(validation.errors),
+		};
+	}
+	return {
+		name,
+		filePath,
+		kind,
+		exists: true,
+		profile: raw as Profile,
+		issues: [],
+	};
+}
+
 export async function loadProfileFiles(
 	repoRoot: string,
 	name: string,
@@ -58,6 +123,24 @@ export async function loadProfileFiles(
 		readProfileFile(profileSharedPath(repoRoot, name, agentsDir), name, "shared"),
 		readProfileFile(profileLocalSiblingPath(repoRoot, name, agentsDir), name, "local-sibling"),
 		readProfileFile(profileLocalDedicatedPath(repoRoot, name, agentsDir), name, "local-dedicated"),
+	]);
+
+	return { shared, localSibling, localDedicated };
+}
+
+export async function inspectProfileFiles(
+	repoRoot: string,
+	name: string,
+	agentsDir?: string | null,
+): Promise<ProfileInspectionLoadResult> {
+	const [shared, localSibling, localDedicated] = await Promise.all([
+		inspectProfileFile(profileSharedPath(repoRoot, name, agentsDir), name, "shared"),
+		inspectProfileFile(profileLocalSiblingPath(repoRoot, name, agentsDir), name, "local-sibling"),
+		inspectProfileFile(
+			profileLocalDedicatedPath(repoRoot, name, agentsDir),
+			name,
+			"local-dedicated",
+		),
 	]);
 
 	return { shared, localSibling, localDedicated };

--- a/src/lib/profiles/paths.ts
+++ b/src/lib/profiles/paths.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { resolveAgentsDirPath } from "../agents-dir.js";
+
+export const PROFILES_DIRNAME = "profiles";
+export const LOCAL_DIRNAME = ".local";
+
+export function resolveProfilesDir(repoRoot: string, agentsDir?: string | null): string {
+	const agentsRoot = resolveAgentsDirPath(repoRoot, agentsDir);
+	return path.join(agentsRoot, PROFILES_DIRNAME);
+}
+
+export function resolveLocalProfilesDir(repoRoot: string, agentsDir?: string | null): string {
+	const agentsRoot = resolveAgentsDirPath(repoRoot, agentsDir);
+	return path.join(agentsRoot, LOCAL_DIRNAME, PROFILES_DIRNAME);
+}
+
+export function profileSharedPath(
+	repoRoot: string,
+	name: string,
+	agentsDir?: string | null,
+): string {
+	return path.join(resolveProfilesDir(repoRoot, agentsDir), `${name}.json`);
+}
+
+export function profileLocalSiblingPath(
+	repoRoot: string,
+	name: string,
+	agentsDir?: string | null,
+): string {
+	return path.join(resolveProfilesDir(repoRoot, agentsDir), `${name}.local.json`);
+}
+
+export function profileLocalDedicatedPath(
+	repoRoot: string,
+	name: string,
+	agentsDir?: string | null,
+): string {
+	return path.join(resolveLocalProfilesDir(repoRoot, agentsDir), `${name}.json`);
+}

--- a/src/lib/profiles/resolve.ts
+++ b/src/lib/profiles/resolve.ts
@@ -1,0 +1,162 @@
+import { loadProfileFiles, profileExists } from "./load.js";
+import {
+	PROFILE_CATEGORIES,
+	type Profile,
+	type ProfileCategory,
+	type ProfileFileRecord,
+	type ProfileLoadResult,
+	type ProfileTargetSetting,
+	type ResolvedProfile,
+	emptyResolvedProfile,
+} from "./types.js";
+
+type LoadOptions = {
+	repoRoot: string;
+	agentsDir?: string | null;
+};
+
+async function ensureProfile(
+	name: string,
+	options: LoadOptions,
+	cache: Map<string, ProfileLoadResult>,
+): Promise<ProfileLoadResult> {
+	const existing = cache.get(name);
+	if (existing) {
+		return existing;
+	}
+	const loaded = await loadProfileFiles(options.repoRoot, name, options.agentsDir);
+	cache.set(name, loaded);
+	return loaded;
+}
+
+async function resolveExtendsChain(
+	name: string,
+	options: LoadOptions,
+	cache: Map<string, ProfileLoadResult>,
+	stack: string[] = [],
+): Promise<ProfileFileRecord[]> {
+	if (stack.includes(name)) {
+		const cycle = [...stack, name].join(" -> ");
+		throw new Error(`Profile extends cycle detected: ${cycle}.`);
+	}
+	const loaded = await ensureProfile(name, options, cache);
+	if (!profileExists(loaded)) {
+		if (stack.length === 0) {
+			throw new Error(`Profile "${name}" not found.`);
+		}
+		throw new Error(`Profile "${name}" references missing parent "${name}".`);
+	}
+	const primary = pickPrimaryRecord(loaded);
+	if (!primary) {
+		throw new Error(`Profile "${name}" has no readable source.`);
+	}
+	const parentName = primary.profile.extends;
+	if (!parentName) {
+		return [primary];
+	}
+	const parentChain = await resolveExtendsChain(parentName, options, cache, [...stack, name]);
+	return [...parentChain, primary];
+}
+
+function pickPrimaryRecord(result: ProfileLoadResult): ProfileFileRecord | null {
+	return result.shared ?? result.localSibling ?? result.localDedicated ?? null;
+}
+
+function mergeTargets(
+	into: Record<string, ProfileTargetSetting>,
+	from: Record<string, ProfileTargetSetting> | undefined,
+): void {
+	if (!from) {
+		return;
+	}
+	for (const [name, setting] of Object.entries(from)) {
+		const existing = into[name] ?? {};
+		into[name] = { ...existing, ...setting };
+	}
+}
+
+function mergePatternMap(
+	into: Record<ProfileCategory, string[]>,
+	from: Partial<Record<ProfileCategory, string[]>> | undefined,
+): void {
+	if (!from) {
+		return;
+	}
+	for (const category of PROFILE_CATEGORIES) {
+		const patterns = from[category];
+		if (!patterns || patterns.length === 0) {
+			continue;
+		}
+		into[category].push(...patterns);
+	}
+}
+
+function applyProfileLayer(accumulator: ResolvedProfile, profile: Profile): void {
+	if (profile.description !== undefined) {
+		accumulator.description = profile.description;
+	}
+	mergeTargets(accumulator.targets, profile.targets);
+	mergePatternMap(accumulator.enable, profile.enable);
+	mergePatternMap(accumulator.disable, profile.disable);
+}
+
+async function buildSingleProfileLayers(
+	name: string,
+	options: LoadOptions,
+	cache: Map<string, ProfileLoadResult>,
+	notices: string[],
+): Promise<Profile[]> {
+	const chain = await resolveExtendsChain(name, options, cache);
+	const layers: Profile[] = [];
+	for (const record of chain) {
+		const loaded = cache.get(record.name);
+		if (!loaded) {
+			layers.push(record.profile);
+			continue;
+		}
+		// Canonical order: shared (base) → local sibling → local dedicated.
+		// Each layer wins over the previous on conflict.
+		if (loaded.shared) {
+			layers.push(loaded.shared.profile);
+		}
+		if (loaded.localSibling) {
+			layers.push(loaded.localSibling.profile);
+		}
+		if (loaded.localDedicated) {
+			layers.push(loaded.localDedicated.profile);
+		}
+		if (loaded.localSibling && loaded.localDedicated) {
+			notices.push(
+				`profile "${record.name}" has both .local forms — ` +
+					`agents/.local/profiles/${record.name}.json overrides agents/profiles/${record.name}.local.json`,
+			);
+		}
+	}
+	return layers;
+}
+
+export async function resolveProfiles(
+	profileNames: string[],
+	options: LoadOptions,
+): Promise<ResolvedProfile> {
+	const accumulator = emptyResolvedProfile();
+	if (profileNames.length === 0) {
+		return accumulator;
+	}
+	const cache = new Map<string, ProfileLoadResult>();
+	for (const name of profileNames) {
+		const layers = await buildSingleProfileLayers(name, options, cache, accumulator.notices);
+		for (const layer of layers) {
+			applyProfileLayer(accumulator, layer);
+		}
+		accumulator.names.push(name);
+	}
+	return accumulator;
+}
+
+export async function resolveSingleProfileRaw(
+	name: string,
+	options: LoadOptions,
+): Promise<ResolvedProfile> {
+	return resolveProfiles([name], options);
+}

--- a/src/lib/profiles/resolve.ts
+++ b/src/lib/profiles/resolve.ts
@@ -7,6 +7,7 @@ import {
 	type ProfileFileRecord,
 	type ProfileLoadResult,
 	type ProfileTargetSetting,
+	type ProfileVariables,
 	type ResolvedProfile,
 } from "./types.js";
 
@@ -91,6 +92,15 @@ function mergePatternMap(
 	}
 }
 
+function mergeVariables(into: ProfileVariables, from: ProfileVariables | undefined): void {
+	if (!from) {
+		return;
+	}
+	for (const [key, value] of Object.entries(from)) {
+		into[key] = value;
+	}
+}
+
 function applyProfileLayer(accumulator: ResolvedProfile, profile: Profile): void {
 	if (profile.description !== undefined) {
 		accumulator.description = profile.description;
@@ -98,6 +108,7 @@ function applyProfileLayer(accumulator: ResolvedProfile, profile: Profile): void
 	mergeTargets(accumulator.targets, profile.targets);
 	mergePatternMap(accumulator.enable, profile.enable);
 	mergePatternMap(accumulator.disable, profile.disable);
+	mergeVariables(accumulator.variables, profile.variables);
 }
 
 async function buildSingleProfileLayers(

--- a/src/lib/profiles/resolve.ts
+++ b/src/lib/profiles/resolve.ts
@@ -1,5 +1,6 @@
 import { loadProfileFiles, profileExists } from "./load.js";
 import {
+	emptyResolvedProfile,
 	PROFILE_CATEGORIES,
 	type Profile,
 	type ProfileCategory,
@@ -7,7 +8,6 @@ import {
 	type ProfileLoadResult,
 	type ProfileTargetSetting,
 	type ResolvedProfile,
-	emptyResolvedProfile,
 } from "./types.js";
 
 type LoadOptions = {

--- a/src/lib/profiles/substitute.ts
+++ b/src/lib/profiles/substitute.ts
@@ -1,0 +1,53 @@
+import type { ProfileVariables } from "./types.js";
+
+// Mustache-style placeholder: `{{NAME}}` or `{{NAME=default value}}`.
+// NAME is uppercase ASCII/digits/underscore, may have surrounding whitespace.
+// Default value runs until the closing braces and may contain spaces.
+const PLACEHOLDER_PATTERN = /\{\{\s*([A-Z_][A-Z0-9_]*)\s*(?:=([^}]*))?\}\}/g;
+
+export type VariableSubstitutionIssue = {
+	name: string;
+};
+
+export type VariableSubstitutionResult = {
+	content: string;
+	unresolved: VariableSubstitutionIssue[];
+};
+
+// Substitute `{{VAR}}` placeholders in `content` using `variables`. Falls back
+// to an inline `{{VAR=default}}` when the variable is unset. Unresolved bare
+// placeholders are left literal and reported in `unresolved` so the caller
+// can surface them as warnings.
+export function substituteVariables(
+	content: string,
+	variables: ProfileVariables | null | undefined,
+): VariableSubstitutionResult {
+	const unresolved: VariableSubstitutionIssue[] = [];
+	const vars = variables ?? {};
+	const reported = new Set<string>();
+
+	const substituted = content.replace(
+		PLACEHOLDER_PATTERN,
+		(match, name: string, defaultValue?: string) => {
+			if (Object.hasOwn(vars, name)) {
+				return vars[name];
+			}
+			if (defaultValue !== undefined) {
+				return defaultValue;
+			}
+			if (!reported.has(name)) {
+				reported.add(name);
+				unresolved.push({ name });
+			}
+			return match;
+		},
+	);
+
+	return { content: substituted, unresolved };
+}
+
+// Returns true when `content` has at least one variable placeholder.
+export function hasVariablePlaceholders(content: string): boolean {
+	PLACEHOLDER_PATTERN.lastIndex = 0;
+	return PLACEHOLDER_PATTERN.test(content);
+}

--- a/src/lib/profiles/types.ts
+++ b/src/lib/profiles/types.ts
@@ -7,6 +7,8 @@ export type ProfileTargetSetting = {
 
 export type ProfilePatternMap = Partial<Record<ProfileCategory, string[]>>;
 
+export type ProfileVariables = Record<string, string>;
+
 export type Profile = {
 	$schema?: string;
 	description?: string;
@@ -14,6 +16,7 @@ export type Profile = {
 	targets?: Record<string, ProfileTargetSetting>;
 	enable?: ProfilePatternMap;
 	disable?: ProfilePatternMap;
+	variables?: ProfileVariables;
 };
 
 export type ProfileSourceKind = "shared" | "local-sibling" | "local-dedicated";
@@ -37,6 +40,7 @@ export type ResolvedProfile = {
 	targets: Record<string, ProfileTargetSetting>;
 	enable: Record<ProfileCategory, string[]>;
 	disable: Record<ProfileCategory, string[]>;
+	variables: ProfileVariables;
 	/**
 	 * Notices produced during resolution (e.g. both .local forms present for a profile).
 	 * Printed under `--verbose` in the sync command.
@@ -61,6 +65,13 @@ export function emptyResolvedProfile(): ResolvedProfile {
 		targets: {},
 		enable: { skills: [], subagents: [], commands: [] },
 		disable: { skills: [], subagents: [], commands: [] },
+		variables: {},
 		notices: [],
 	};
+}
+
+export const VARIABLE_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
+export function isValidVariableName(name: string): boolean {
+	return VARIABLE_NAME_PATTERN.test(name);
 }

--- a/src/lib/profiles/types.ts
+++ b/src/lib/profiles/types.ts
@@ -1,0 +1,66 @@
+export const PROFILE_CATEGORIES = ["skills", "subagents", "commands"] as const;
+export type ProfileCategory = (typeof PROFILE_CATEGORIES)[number];
+
+export type ProfileTargetSetting = {
+	enabled?: boolean;
+};
+
+export type ProfilePatternMap = Partial<Record<ProfileCategory, string[]>>;
+
+export type Profile = {
+	$schema?: string;
+	description?: string;
+	extends?: string;
+	targets?: Record<string, ProfileTargetSetting>;
+	enable?: ProfilePatternMap;
+	disable?: ProfilePatternMap;
+};
+
+export type ProfileSourceKind = "shared" | "local-sibling" | "local-dedicated";
+
+export type ProfileFileRecord = {
+	name: string;
+	filePath: string;
+	kind: ProfileSourceKind;
+	profile: Profile;
+};
+
+export type ProfileLoadResult = {
+	shared: ProfileFileRecord | null;
+	localSibling: ProfileFileRecord | null;
+	localDedicated: ProfileFileRecord | null;
+};
+
+export type ResolvedProfile = {
+	names: string[];
+	description: string | null;
+	targets: Record<string, ProfileTargetSetting>;
+	enable: Record<ProfileCategory, string[]>;
+	disable: Record<ProfileCategory, string[]>;
+	/**
+	 * Notices produced during resolution (e.g. both .local forms present for a profile).
+	 * Printed under `--verbose` in the sync command.
+	 */
+	notices: string[];
+};
+
+export type ProfileValidationIssue = {
+	path: string;
+	message: string;
+};
+
+export type ProfileValidationResult = {
+	valid: boolean;
+	errors: ProfileValidationIssue[];
+};
+
+export function emptyResolvedProfile(): ResolvedProfile {
+	return {
+		names: [],
+		description: null,
+		targets: {},
+		enable: { skills: [], subagents: [], commands: [] },
+		disable: { skills: [], subagents: [], commands: [] },
+		notices: [],
+	};
+}

--- a/src/lib/profiles/validate.ts
+++ b/src/lib/profiles/validate.ts
@@ -1,0 +1,139 @@
+import {
+	PROFILE_CATEGORIES,
+	type Profile,
+	type ProfileCategory,
+	type ProfileValidationIssue,
+	type ProfileValidationResult,
+} from "./types.js";
+
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+	"$schema",
+	"description",
+	"extends",
+	"targets",
+	"enable",
+	"disable",
+]);
+const ALLOWED_CATEGORY_KEYS = new Set<ProfileCategory>(PROFILE_CATEGORIES);
+const ALLOWED_TARGET_SETTING_KEYS = new Set(["enabled"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function pushError(errors: ProfileValidationIssue[], path: string, message: string): void {
+	errors.push({ path, message });
+}
+
+function validatePatternMap(
+	value: unknown,
+	pathPrefix: string,
+	errors: ProfileValidationIssue[],
+): void {
+	if (!isPlainObject(value)) {
+		pushError(errors, pathPrefix, "must be an object.");
+		return;
+	}
+	for (const [key, entry] of Object.entries(value)) {
+		if (!ALLOWED_CATEGORY_KEYS.has(key as ProfileCategory)) {
+			pushError(
+				errors,
+				`${pathPrefix}.${key}`,
+				`unsupported category (allowed: ${[...ALLOWED_CATEGORY_KEYS].join(", ")}).`,
+			);
+			continue;
+		}
+		if (!Array.isArray(entry)) {
+			pushError(errors, `${pathPrefix}.${key}`, "must be an array of glob patterns.");
+			continue;
+		}
+		for (const [index, pattern] of entry.entries()) {
+			if (typeof pattern !== "string" || pattern.trim().length === 0) {
+				pushError(errors, `${pathPrefix}.${key}[${index}]`, "must be a non-empty string.");
+			}
+		}
+	}
+}
+
+function validateTargets(value: unknown, errors: ProfileValidationIssue[]): void {
+	if (!isPlainObject(value)) {
+		pushError(errors, "targets", "must be an object.");
+		return;
+	}
+	for (const [targetName, setting] of Object.entries(value)) {
+		if (typeof targetName !== "string" || targetName.trim().length === 0) {
+			pushError(errors, "targets", `target keys must be non-empty strings (got "${targetName}").`);
+			continue;
+		}
+		if (!isPlainObject(setting)) {
+			pushError(errors, `targets.${targetName}`, "must be an object.");
+			continue;
+		}
+		for (const key of Object.keys(setting)) {
+			if (!ALLOWED_TARGET_SETTING_KEYS.has(key)) {
+				pushError(errors, `targets.${targetName}.${key}`, "unsupported key (allowed: enabled).");
+			}
+		}
+		if (setting.enabled !== undefined && typeof setting.enabled !== "boolean") {
+			pushError(errors, `targets.${targetName}.enabled`, "must be a boolean when provided.");
+		}
+	}
+}
+
+export function validateProfile(value: unknown): ProfileValidationResult {
+	const errors: ProfileValidationIssue[] = [];
+	if (!isPlainObject(value)) {
+		return {
+			valid: false,
+			errors: [{ path: "", message: "profile must be a JSON object." }],
+		};
+	}
+	for (const key of Object.keys(value)) {
+		if (!ALLOWED_TOP_LEVEL_KEYS.has(key)) {
+			pushError(
+				errors,
+				key,
+				"unsupported key (allowed: $schema, description, extends, targets, enable, disable).",
+			);
+		}
+	}
+	if (value.$schema !== undefined && typeof value.$schema !== "string") {
+		pushError(errors, "$schema", "must be a string when provided.");
+	}
+	if (value.description !== undefined) {
+		if (typeof value.description !== "string") {
+			pushError(errors, "description", "must be a string when provided.");
+		}
+	}
+	if (value.extends !== undefined) {
+		if (typeof value.extends !== "string" || value.extends.trim().length === 0) {
+			pushError(errors, "extends", "must be a non-empty string when provided.");
+		}
+	}
+	if (value.targets !== undefined) {
+		validateTargets(value.targets, errors);
+	}
+	if (value.enable !== undefined) {
+		validatePatternMap(value.enable, "enable", errors);
+	}
+	if (value.disable !== undefined) {
+		validatePatternMap(value.disable, "disable", errors);
+	}
+	return {
+		valid: errors.length === 0,
+		errors,
+	};
+}
+
+export function formatValidationIssues(issues: ProfileValidationIssue[]): string[] {
+	return issues.map((issue) => (issue.path ? `${issue.path}: ${issue.message}` : issue.message));
+}
+
+export function assertValidProfile(value: unknown, profileName: string): Profile {
+	const result = validateProfile(value);
+	if (!result.valid) {
+		const formatted = formatValidationIssues(result.errors).join("\n- ");
+		throw new Error(`Invalid profile "${profileName}":\n- ${formatted}`);
+	}
+	return value as Profile;
+}

--- a/src/lib/profiles/validate.ts
+++ b/src/lib/profiles/validate.ts
@@ -1,4 +1,5 @@
 import {
+	isValidVariableName,
 	PROFILE_CATEGORIES,
 	type Profile,
 	type ProfileCategory,
@@ -13,6 +14,7 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
 	"targets",
 	"enable",
 	"disable",
+	"variables",
 ]);
 const ALLOWED_CATEGORY_KEYS = new Set<ProfileCategory>(PROFILE_CATEGORIES);
 const ALLOWED_TARGET_SETTING_KEYS = new Set(["enabled"]);
@@ -119,10 +121,32 @@ export function validateProfile(value: unknown): ProfileValidationResult {
 	if (value.disable !== undefined) {
 		validatePatternMap(value.disable, "disable", errors);
 	}
+	if (value.variables !== undefined) {
+		validateVariables(value.variables, errors);
+	}
 	return {
 		valid: errors.length === 0,
 		errors,
 	};
+}
+
+function validateVariables(value: unknown, errors: ProfileValidationIssue[]): void {
+	if (!isPlainObject(value)) {
+		pushError(errors, "variables", "must be an object of string values.");
+		return;
+	}
+	for (const [key, entry] of Object.entries(value)) {
+		if (!isValidVariableName(key)) {
+			pushError(
+				errors,
+				`variables.${key}`,
+				"variable names must match [A-Z_][A-Z0-9_]* (uppercase ASCII, digits, underscores).",
+			);
+		}
+		if (typeof entry !== "string") {
+			pushError(errors, `variables.${key}`, "must be a string.");
+		}
+	}
 }
 
 export function formatValidationIssues(issues: ProfileValidationIssue[]): string[] {

--- a/src/lib/skills/sync.ts
+++ b/src/lib/skills/sync.ts
@@ -53,6 +53,7 @@ export type SkillSyncRequest = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
+	includeItem?: (canonicalName: string) => boolean;
 };
 
 function formatDisplayPath(repoRoot: string, absolutePath: string): string {
@@ -104,6 +105,14 @@ export async function syncSkills(request: SkillSyncRequest): Promise<SyncSummary
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
+	if (request.includeItem) {
+		const includeItem = request.includeItem;
+		const predicate = (skill: SkillDefinition) => includeItem(skill.name);
+		catalog.skills = catalog.skills.filter(predicate);
+		catalog.sharedSkills = catalog.sharedSkills.filter(predicate);
+		catalog.localSkills = catalog.localSkills.filter(predicate);
+		catalog.localEffectiveSkills = catalog.localEffectiveSkills.filter(predicate);
+	}
 	const warnings = buildInvalidTargetWarnings(catalog.skills);
 	const allTargetIds = request.targets.map((target) => target.id);
 	const targetNames = new Set(skillTargets.map((target) => target.id));

--- a/src/lib/slash-commands/sync.ts
+++ b/src/lib/slash-commands/sync.ts
@@ -90,6 +90,7 @@ export type SyncRequestV2 = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
+	includeItem?: (canonicalName: string) => boolean;
 };
 
 export type SyncPlanAction = {
@@ -1348,6 +1349,14 @@ export async function syncSlashCommands(request: SyncRequestV2): Promise<SyncSum
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
+	if (request.includeItem) {
+		const includeItem = request.includeItem;
+		const predicate = (command: SlashCommandDefinition) => includeItem(command.name);
+		catalog.commands = catalog.commands.filter(predicate);
+		catalog.sharedCommands = catalog.sharedCommands.filter(predicate);
+		catalog.localCommands = catalog.localCommands.filter(predicate);
+		catalog.localEffectiveCommands = catalog.localEffectiveCommands.filter(predicate);
+	}
 	const targets = request.targets.filter(
 		(target) => normalizeCommandOutputDefinition(target.outputs.commands) !== null,
 	);

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -89,6 +89,7 @@ export type SubagentSyncRequestV2 = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
+	includeItem?: (canonicalName: string) => boolean;
 };
 
 export type SubagentSyncPlanAction = {
@@ -1025,6 +1026,14 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
+	if (request.includeItem) {
+		const includeItem = request.includeItem;
+		const predicate = (subagent: SubagentDefinition) => includeItem(subagent.resolvedName);
+		catalog.subagents = catalog.subagents.filter(predicate);
+		catalog.sharedSubagents = catalog.sharedSubagents.filter(predicate);
+		catalog.localSubagents = catalog.localSubagents.filter(predicate);
+		catalog.localEffectiveSubagents = catalog.localEffectiveSubagents.filter(predicate);
+	}
 	const targets = request.targets.filter(
 		(target) => normalizeOutputDefinition(target.outputs.subagents) !== null,
 	);

--- a/src/lib/sync-results.ts
+++ b/src/lib/sync-results.ts
@@ -3,7 +3,7 @@ import type { TargetName } from "./sync-targets.js";
 export type SyncStatus = "synced" | "skipped" | "failed";
 export type ScriptExecutionStatus = "pending" | "running" | "succeeded" | "failed";
 export type ScriptResultKind = "string" | "json" | "coerced" | "empty";
-export type RunWarningCode = "still_running" | "sync_warning";
+export type RunWarningCode = "still_running" | "sync_warning" | "profile_warning";
 
 export type SyncSourceCounts = {
 	shared: number;

--- a/src/lib/template-scripts.ts
+++ b/src/lib/template-scripts.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { substituteVariables } from "./profiles/substitute.js";
+import type { ProfileVariables } from "./profiles/types.js";
 import type { RunWarning, ScriptExecution, ScriptResultKind } from "./sync-results.js";
 
 const SCRIPT_TAG_DEFINITIONS = [
@@ -135,6 +137,8 @@ export type TemplateScriptRuntime = {
 	warnings: RunWarning[];
 	failedTemplatePath: string | null;
 	failedBlockId: string | null;
+	variables: ProfileVariables;
+	reportedUnresolvedVariables: Set<string>;
 	onWarning?: (warning: RunWarning) => void;
 	onVerbose?: (message: string) => void;
 };
@@ -144,6 +148,7 @@ export type TemplateScriptRuntimeOptions = {
 	verbose?: boolean;
 	heartbeatIntervalMs?: number;
 	cwd?: string;
+	variables?: ProfileVariables;
 	onWarning?: (warning: RunWarning) => void;
 	onVerbose?: (message: string) => void;
 };
@@ -322,6 +327,7 @@ async function executeNodeJsScriptBlock(options: {
 		cwd: runtime.cwd,
 		env: {
 			...process.env,
+			...buildVariableEnv(runtime.variables),
 			OMNIAGENT_SCRIPT_B64: Buffer.from(block.scriptBody, "utf8").toString("base64"),
 			OMNIAGENT_SCRIPT_SOURCE: options.blockLabel,
 			OMNIAGENT_SCRIPT_TEMPLATE_PATH: block.templatePath,
@@ -394,6 +400,7 @@ async function executeShellScriptBlock(options: {
 		cwd: runtime.cwd,
 		env: {
 			...process.env,
+			...buildVariableEnv(runtime.variables),
 		},
 		stdio: ["ignore", "pipe", "pipe"],
 	});
@@ -479,7 +486,11 @@ async function evaluateTemplateScriptsUncached(request: EvaluateTemplateScriptsR
 	const parsed = parseTemplateScripts(templatePath, content);
 	if (parsed.blocks.length === 0) {
 		return {
-			renderedContent: content,
+			renderedContent: applyVariablesToRenderedContent({
+				templatePath,
+				content,
+				runtime,
+			}),
 			blockIds: [],
 		} satisfies TemplateEvaluation;
 	}
@@ -536,7 +547,11 @@ async function evaluateTemplateScriptsUncached(request: EvaluateTemplateScriptsR
 	output += content.slice(cursor);
 
 	return {
-		renderedContent: output,
+		renderedContent: applyVariablesToRenderedContent({
+			templatePath,
+			content: output,
+			runtime,
+		}),
 		blockIds,
 	} satisfies TemplateEvaluation;
 }
@@ -555,9 +570,41 @@ export function createTemplateScriptRuntime(
 		warnings: [],
 		failedTemplatePath: null,
 		failedBlockId: null,
+		variables: { ...(options.variables ?? {}) },
+		reportedUnresolvedVariables: new Set(),
 		onWarning: options.onWarning,
 		onVerbose: options.onVerbose,
 	};
+}
+
+function buildVariableEnv(variables: ProfileVariables): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(variables)) {
+		env[`OMNIAGENT_VAR_${key}`] = value;
+	}
+	return env;
+}
+
+export function applyVariablesToRenderedContent(options: {
+	templatePath: string;
+	content: string;
+	runtime: TemplateScriptRuntime;
+}): string {
+	const { templatePath, content, runtime } = options;
+	const { content: substituted, unresolved } = substituteVariables(content, runtime.variables);
+	for (const issue of unresolved) {
+		const dedupeKey = `${templatePath}::${issue.name}`;
+		if (runtime.reportedUnresolvedVariables.has(dedupeKey)) {
+			continue;
+		}
+		runtime.reportedUnresolvedVariables.add(dedupeKey);
+		appendWarning(runtime, {
+			code: "profile_warning",
+			message: `unresolved template variable "${issue.name}" in ${templatePath} (use {{${issue.name}=default}} to provide a fallback)`,
+			templatePath,
+		});
+	}
+	return substituted;
 }
 
 export async function evaluateTemplateScripts(

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -121,6 +121,23 @@ describe.sequential("profiles subcommand", () => {
 		});
 	});
 
+	it("retains the shared description when a local override omits that key", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeProfile(root, "profiles/default.json", {
+				description: "Team default",
+			});
+			await writeProfile(root, "profiles/default.local.json", {});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("Team default");
+		});
+	});
+
 	it("shows fully-resolved merged profile as JSON, including variables", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../../src/cli/index.js";
+
+async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-profiles-cli-"));
+	const homeDir = path.join(root, "home");
+	await mkdir(homeDir, { recursive: true });
+	const homeSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+	try {
+		await writeFile(path.join(root, "package.json"), "{}");
+		await fn(root);
+	} finally {
+		homeSpy.mockRestore();
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function withCwd(dir: string, fn: () => Promise<void>): Promise<void> {
+	const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(dir);
+	try {
+		await fn();
+	} finally {
+		cwdSpy.mockRestore();
+	}
+}
+
+async function writeProfile(
+	root: string,
+	relative: string,
+	data: Record<string, unknown>,
+): Promise<void> {
+	const target = path.join(root, "agents", relative);
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, JSON.stringify(data), "utf8");
+}
+
+describe.sequential("profiles subcommand", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		process.exitCode = undefined;
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+		process.exitCode = undefined;
+	});
+
+	it("lists profiles with descriptions and annotations", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/default.json", { description: "Team default" });
+			await writeProfile(root, "profiles/default.local.json", {});
+			await writeProfile(root, "profiles/code-reviewer.json", { description: "Reviews" });
+			await writeProfile(root, ".local/profiles/experiments.json", { description: "Personal" });
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("default");
+			expect(output).toContain("(active by default)");
+			expect(output).toContain("[local override]");
+			expect(output).toContain("code-reviewer");
+			expect(output).toContain("Reviews");
+			expect(output).toContain("experiments");
+			expect(output).toContain("[local-only]");
+		});
+	});
+
+	it("shows fully-resolved merged profile as JSON", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/base.json", {
+				disable: { skills: ["ppt"] },
+			});
+			await writeProfile(root, "profiles/code-reviewer.json", {
+				extends: "base",
+				description: "Review",
+				enable: { skills: ["review"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "show", "code-reviewer"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			const parsed = JSON.parse(output);
+			expect(parsed.description).toBe("Review");
+			expect(parsed.enable.skills).toEqual(["review"]);
+			expect(parsed.disable.skills).toEqual(["ppt"]);
+		});
+	});
+
+	it("validate exits zero when profiles are valid", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/ok.json", { description: "good" });
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("validate exits non-zero on schema violations", async () => {
+		await withTempRepo(async (root) => {
+			const filePath = path.join(root, "agents", "profiles", "bad.json");
+			await mkdir(path.dirname(filePath), { recursive: true });
+			await writeFile(filePath, JSON.stringify({ extends: 42 }), "utf8");
+
+			await withCwd(root, async () => {
+				try {
+					await runCli(["node", "omniagent", "profiles", "validate"]);
+				} catch {
+					// expected — schema errors throw during load
+				}
+			});
+
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("bad");
+		});
+	});
+});

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -101,6 +101,26 @@ describe.sequential("profiles subcommand", () => {
 		});
 	});
 
+	it("prefers the effective local description in profile listings", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeProfile(root, "profiles/reviewer.json", {
+				description: "Shared description",
+			});
+			await writeProfile(root, ".local/profiles/reviewer.json", {
+				description: "Local description",
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("Local description");
+			expect(output).not.toContain("Shared description [local override]");
+		});
+	});
+
 	it("shows fully-resolved merged profile as JSON, including variables", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -195,15 +215,37 @@ describe.sequential("profiles subcommand", () => {
 			await writeFile(filePath, JSON.stringify({ extends: 42 }), "utf8");
 
 			await withCwd(root, async () => {
-				try {
-					await runCli(["node", "omniagent", "profiles", "validate"]);
-				} catch {
-					// expected — schema errors throw during load
-				}
+				await runCli(["node", "omniagent", "profiles", "validate"]);
 			});
 
+			expect(exitSpy).toHaveBeenCalledWith(1);
 			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
 			expect(errOut).toContain("bad");
+			expect(errOut).toContain("extends: must be a non-empty string when provided.");
+		});
+	});
+
+	it("validate continues after malformed profiles and reports later issues", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review");
+			const badJsonPath = path.join(root, "agents", "profiles", "a-bad-json.json");
+			await mkdir(path.dirname(badJsonPath), { recursive: true });
+			await writeFile(badJsonPath, "{ invalid json", "utf8");
+			await writeProfile(root, "profiles/z-unknown-ref.json", {
+				disable: { skills: ["missing-skill"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("a-bad-json");
+			expect(errOut).toContain("Invalid JSON in profile");
+			expect(errOut).toContain("z-unknown-ref");
+			expect(errOut).toContain("missing-skill");
 		});
 	});
 

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -26,6 +26,10 @@ async function withCwd(dir: string, fn: () => Promise<void>): Promise<void> {
 	}
 }
 
+async function createRepoRoot(root: string): Promise<void> {
+	await writeFile(path.join(root, "package.json"), "{}");
+}
+
 async function writeProfile(
 	root: string,
 	relative: string,
@@ -34,6 +38,25 @@ async function writeProfile(
 	const target = path.join(root, "agents", relative);
 	await mkdir(path.dirname(target), { recursive: true });
 	await writeFile(target, JSON.stringify(data), "utf8");
+}
+
+async function writeSkill(root: string, name: string, body = "Skill body"): Promise<void> {
+	const target = path.join(root, "agents", "skills", name, "SKILL.md");
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, body, "utf8");
+}
+
+async function writeCommand(root: string, name: string, body = "Command body"): Promise<void> {
+	const target = path.join(root, "agents", "commands", `${name}.md`);
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, body, "utf8");
+}
+
+async function writeSubagent(root: string, name: string, body = "Subagent body"): Promise<void> {
+	const target = path.join(root, "agents", "agents", `${name}.md`);
+	const contents = `---\nname: ${name}\n---\n${body}\n`;
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, contents, "utf8");
 }
 
 describe.sequential("profiles subcommand", () => {
@@ -57,6 +80,7 @@ describe.sequential("profiles subcommand", () => {
 
 	it("lists profiles with descriptions and annotations", async () => {
 		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
 			await writeProfile(root, "profiles/default.json", { description: "Team default" });
 			await writeProfile(root, "profiles/default.local.json", {});
 			await writeProfile(root, "profiles/code-reviewer.json", { description: "Reviews" });
@@ -77,15 +101,18 @@ describe.sequential("profiles subcommand", () => {
 		});
 	});
 
-	it("shows fully-resolved merged profile as JSON", async () => {
+	it("shows fully-resolved merged profile as JSON, including variables", async () => {
 		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
 			await writeProfile(root, "profiles/base.json", {
 				disable: { skills: ["ppt"] },
+				variables: { LOG_SOURCE: "stdout" },
 			});
 			await writeProfile(root, "profiles/code-reviewer.json", {
 				extends: "base",
 				description: "Review",
 				enable: { skills: ["review"] },
+				variables: { REVIEW_STYLE: "terse" },
 			});
 
 			await withCwd(root, async () => {
@@ -97,23 +124,72 @@ describe.sequential("profiles subcommand", () => {
 			expect(parsed.description).toBe("Review");
 			expect(parsed.enable.skills).toEqual(["review"]);
 			expect(parsed.disable.skills).toEqual(["ppt"]);
+			expect(parsed.variables).toEqual({
+				LOG_SOURCE: "stdout",
+				REVIEW_STYLE: "terse",
+			});
 		});
 	});
 
-	it("validate exits zero when profiles are valid", async () => {
+	it("shows variables merged across multiple profiles in CLI order", async () => {
 		await withTempRepo(async (root) => {
-			await writeProfile(root, "profiles/ok.json", { description: "good" });
+			await createRepoRoot(root);
+			await writeProfile(root, "profiles/reviewer.json", {
+				variables: {
+					LOG_SOURCE: "stdout",
+					REVIEW_STYLE: "terse",
+				},
+			});
+			await writeProfile(root, "profiles/override.json", {
+				variables: {
+					REVIEW_STYLE: "thorough",
+				},
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "show", "reviewer,override"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			const parsed = JSON.parse(output);
+			expect(parsed.variables).toEqual({
+				LOG_SOURCE: "stdout",
+				REVIEW_STYLE: "thorough",
+			});
+		});
+	});
+
+	it("validate exits zero when profile references are valid", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review");
+			await writeCommand(root, "diff-summary");
+			await writeSubagent(root, "reviewer");
+			await writeProfile(root, "profiles/ok.json", {
+				description: "good",
+				targets: { codex: { enabled: false } },
+				enable: {
+					commands: ["diff-summary"],
+					subagents: ["reviewer"],
+				},
+				disable: {
+					skills: ["review"],
+				},
+			});
 
 			await withCwd(root, async () => {
 				await runCli(["node", "omniagent", "profiles", "validate"]);
 			});
 
 			expect(exitSpy).not.toHaveBeenCalled();
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("Validated 1 profile(s).");
 		});
 	});
 
 	it("validate exits non-zero on schema violations", async () => {
 		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
 			const filePath = path.join(root, "agents", "profiles", "bad.json");
 			await mkdir(path.dirname(filePath), { recursive: true });
 			await writeFile(filePath, JSON.stringify({ extends: 42 }), "utf8");
@@ -128,6 +204,95 @@ describe.sequential("profiles subcommand", () => {
 
 			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
 			expect(errOut).toContain("bad");
+		});
+	});
+
+	it("validate exits non-zero on unknown skill references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review");
+			await writeProfile(root, "profiles/typo.json", {
+				disable: { skills: ["missing-skill"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("missing-skill");
+		});
+	});
+
+	it("validate exits non-zero on unknown command references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCommand(root, "review");
+			await writeProfile(root, "profiles/typo.json", {
+				enable: { commands: ["missing-command"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("missing-command");
+		});
+	});
+
+	it("validate exits non-zero on unknown subagent references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "reviewer");
+			await writeProfile(root, "profiles/typo.json", {
+				enable: { subagents: ["missing-subagent"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("missing-subagent");
+		});
+	});
+
+	it("validate exits non-zero on unknown target references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeProfile(root, "profiles/typo.json", {
+				targets: { ghost: { enabled: false } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain('unknown target "ghost"');
+		});
+	});
+
+	it("validate stays silent for zero-match glob references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review");
+			await writeProfile(root, "profiles/ok.json", {
+				disable: { skills: ["*-legacy"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).not.toContain("legacy");
 		});
 	});
 });

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -89,6 +89,12 @@ async function writeProfile(
 	await writeFile(target, JSON.stringify(data), "utf8");
 }
 
+async function writeTargetConfig(root: string, contents: string): Promise<void> {
+	const target = path.join(root, "agents", "omniagent.config.cjs");
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, contents, "utf8");
+}
+
 describe.sequential("sync command with profiles", () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
 	let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -318,6 +324,41 @@ describe.sequential("sync command with profiles", () => {
 
 			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
 			expect(output).toContain("missing-skill");
+		});
+	});
+
+	it("does not warn for valid commands when syncing a skill-only custom target", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeCommand(root, "review");
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["alpha"], commands: ["review"] },
+			});
+			await writeTargetConfig(
+				root,
+				[
+					"module.exports = {",
+					"  targets: [",
+					"    {",
+					'      id: "acme",',
+					'      displayName: "Acme Agent",',
+					"      outputs: {",
+					'        skills: "{repoRoot}/.acme/skills/{itemName}"',
+					"      }",
+					"    }",
+					"  ]",
+					"};",
+				].join("\n"),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "acme", "--profile", "focus"]);
+			});
+
+			expect(await pathExists(path.join(root, ".acme", "skills", "alpha", "SKILL.md"))).toBe(true);
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).not.toContain('unknown command "review"');
 		});
 	});
 

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -215,6 +215,33 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("restricts sync to explicitly enabled targets", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/claude-only.json", {
+				targets: { claude: { enabled: true } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "claude-only"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".codex", "skills", "alpha", "SKILL.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".gemini", "skills", "alpha", "SKILL.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".github", "skills", "alpha", "SKILL.md"))).toBe(
+				false,
+			);
+		});
+	});
+
 	it("merges multiple --profile arguments in CLI order (later wins)", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -1,0 +1,347 @@
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../../src/cli/index.js";
+
+const DEFAULT_CLI_COMMANDS = ["codex", "claude", "gemini", "copilot"];
+
+async function createFakeCliBin(root: string): Promise<string> {
+	const binDir = path.join(root, "bin");
+	await mkdir(binDir, { recursive: true });
+	const isWindows = process.platform === "win32";
+	for (const command of DEFAULT_CLI_COMMANDS) {
+		const basePath = path.join(binDir, command);
+		const contents = isWindows ? "@echo off\r\n" : "#!/usr/bin/env sh\nexit 0\n";
+		await writeFile(basePath, contents, "utf8");
+		await chmod(basePath, 0o755);
+		if (isWindows) {
+			const cmdPath = path.join(binDir, `${command}.cmd`);
+			await writeFile(cmdPath, "@echo off\r\n", "utf8");
+		}
+	}
+	return binDir;
+}
+
+async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-sync-profiles-"));
+	const homeDir = path.join(root, "home");
+	await mkdir(homeDir, { recursive: true });
+	const homeSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+	const originalPath = process.env.PATH;
+	try {
+		const binDir = await createFakeCliBin(root);
+		process.env.PATH = [binDir, originalPath].filter(Boolean).join(path.delimiter);
+		await fn(root);
+	} finally {
+		process.env.PATH = originalPath;
+		homeSpy.mockRestore();
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function withCwd(dir: string, fn: () => Promise<void>): Promise<void> {
+	const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(dir);
+	try {
+		await fn();
+	} finally {
+		cwdSpy.mockRestore();
+	}
+}
+
+async function pathExists(candidate: string): Promise<boolean> {
+	try {
+		await stat(candidate);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function createRepoRoot(root: string): Promise<void> {
+	await writeFile(path.join(root, "package.json"), "{}");
+}
+
+async function writeSkill(root: string, name: string): Promise<void> {
+	const dir = path.join(root, "agents", "skills", name);
+	await mkdir(dir, { recursive: true });
+	await writeFile(path.join(dir, "SKILL.md"), `skill-${name}`, "utf8");
+}
+
+async function writeCommand(root: string, name: string): Promise<void> {
+	const dir = path.join(root, "agents", "commands");
+	await mkdir(dir, { recursive: true });
+	await writeFile(path.join(dir, `${name}.md`), `command-${name}`, "utf8");
+}
+
+async function writeSubagent(root: string, name: string): Promise<void> {
+	const dir = path.join(root, "agents", "agents");
+	await mkdir(dir, { recursive: true });
+	await writeFile(path.join(dir, `${name}.md`), `---\nname: ${name}\n---\nbody`, "utf8");
+}
+
+async function writeProfile(
+	root: string,
+	relative: string,
+	data: Record<string, unknown>,
+): Promise<void> {
+	const target = path.join(root, "agents", relative);
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, JSON.stringify(data), "utf8");
+}
+
+describe.sequential("sync command with profiles", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		process.exitCode = undefined;
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+		process.exitCode = undefined;
+	});
+
+	it("ignores profiles when no default.json exists and no --profile is passed", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+		});
+	});
+
+	it("applies agents/profiles/default.json when present and --profile is not passed", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeSkill(root, "beta");
+			await writeProfile(root, "profiles/default.json", {
+				disable: { skills: ["beta"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "skills", "beta", "SKILL.md"))).toBe(
+				false,
+			);
+		});
+	});
+
+	it("does not prepend default.json when --profile is explicit", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeSkill(root, "beta");
+			await writeProfile(root, "profiles/default.json", {
+				disable: { skills: ["beta"] },
+			});
+			await writeProfile(root, "profiles/other.json", {});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "other"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "skills", "beta", "SKILL.md"))).toBe(true);
+		});
+	});
+
+	it("filters skills and commands using enable globs", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review");
+			await writeSkill(root, "other");
+			await writeCommand(root, "diff-summary");
+			await writeCommand(root, "note");
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["review"], commands: ["diff-*"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "focus"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "review", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "skills", "other", "SKILL.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".claude", "commands", "diff-summary.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "commands", "note.md"))).toBe(false);
+		});
+	});
+
+	it("disables a target via targets.<name>.enabled=false", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/nocodex.json", {
+				targets: { codex: { enabled: false } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "nocodex"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".codex", "skills", "alpha", "SKILL.md"))).toBe(
+				false,
+			);
+		});
+	});
+
+	it("merges multiple --profile arguments in CLI order (later wins)", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/noclaude.json", {
+				targets: { claude: { enabled: false } },
+			});
+			await writeProfile(root, "profiles/yesclaude.json", {
+				targets: { claude: { enabled: true } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "noclaude,yesclaude"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+		});
+	});
+
+	it("layers CLI --skip after profile-driven target selection", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/allon.json", {
+				targets: { claude: { enabled: true }, codex: { enabled: true } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "allon", "--skip", "claude"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".codex", "skills", "alpha", "SKILL.md"))).toBe(true);
+		});
+	});
+
+	it("warns about unknown bare references", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/typo.json", {
+				enable: { skills: ["alpha"] },
+				disable: { skills: ["missing-skill"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "typo"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("missing-skill");
+		});
+	});
+
+	it("errors loudly when --profile names a missing profile", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "ghost"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalled();
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toMatch(/ghost/);
+		});
+	});
+
+	it("emits 'Active profile' in non-JSON output", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/focus.json", {});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "focus"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("Active profile: focus");
+		});
+	});
+
+	it("filters subagents via enable", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "reviewer");
+			await writeSubagent(root, "debugger");
+			await writeProfile(root, "profiles/reviewonly.json", {
+				enable: { subagents: ["reviewer"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "reviewonly"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "agents", "reviewer.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "agents", "debugger.md"))).toBe(false);
+		});
+	});
+
+	it("extends chain applies base disable and child enable together", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "kept");
+			await writeSkill(root, "dropped");
+			await writeProfile(root, "profiles/base.json", {
+				disable: { skills: ["dropped"] },
+			});
+			await writeProfile(root, "profiles/child.json", {
+				extends: "base",
+				enable: { skills: ["kept", "dropped"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "child"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "kept", "SKILL.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "skills", "dropped", "SKILL.md"))).toBe(
+				false,
+			);
+		});
+	});
+});

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -263,6 +263,27 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("warns on unknown enabled targets without turning them into an empty allowlist", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+			await writeProfile(root, "profiles/typo.json", {
+				targets: { claud: { enabled: true } },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "typo", "--only", "claude"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "alpha", "SKILL.md"))).toBe(
+				true,
+			);
+			expect(process.exitCode).toBeUndefined();
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain('unknown target "claud"');
+		});
+	});
+
 	it("layers CLI --skip after profile-driven target selection", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -443,6 +464,25 @@ describe.sequential("sync command with profiles", () => {
 			expect(exitSpy).toHaveBeenCalled();
 			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
 			expect(errOut).toContain("lowercase=nope");
+		});
+	});
+
+	it("skips templating validation for profile-excluded items", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "good", "Good skill");
+			await writeSkill(root, "bad", "<agents claude>\n");
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["good"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "focus", "--only", "claude"]);
+			});
+
+			expect(await pathExists(path.join(root, ".claude", "skills", "good", "SKILL.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "skills", "bad", "SKILL.md"))).toBe(false);
+			expect(process.exitCode).toBeUndefined();
 		});
 	});
 

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { runCli } from "../../src/cli/index.js";
@@ -61,10 +61,10 @@ async function createRepoRoot(root: string): Promise<void> {
 	await writeFile(path.join(root, "package.json"), "{}");
 }
 
-async function writeSkill(root: string, name: string): Promise<void> {
+async function writeSkill(root: string, name: string, body?: string): Promise<void> {
 	const dir = path.join(root, "agents", "skills", name);
 	await mkdir(dir, { recursive: true });
-	await writeFile(path.join(dir, "SKILL.md"), `skill-${name}`, "utf8");
+	await writeFile(path.join(dir, "SKILL.md"), body ?? `skill-${name}`, "utf8");
 }
 
 async function writeCommand(root: string, name: string): Promise<void> {
@@ -318,6 +318,104 @@ describe.sequential("sync command with profiles", () => {
 
 			expect(await pathExists(path.join(root, ".claude", "agents", "reviewer.md"))).toBe(true);
 			expect(await pathExists(path.join(root, ".claude", "agents", "debugger.md"))).toBe(false);
+		});
+	});
+
+	it("substitutes profile variables into skill content", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review", "Review style: {{REVIEW_STYLE}}");
+			await writeProfile(root, "profiles/vars.json", {
+				variables: { REVIEW_STYLE: "terse" },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "vars"]);
+			});
+
+			const output = await readFile(
+				path.join(root, ".claude", "skills", "review", "SKILL.md"),
+				"utf8",
+			);
+			expect(output).toContain("Review style: terse");
+			expect(output).not.toContain("{{REVIEW_STYLE}}");
+		});
+	});
+
+	it("applies an inline default when the variable is not set", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "logger", "Source: {{LOG_SOURCE=stdout}}");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			const output = await readFile(
+				path.join(root, ".claude", "skills", "logger", "SKILL.md"),
+				"utf8",
+			);
+			expect(output).toContain("Source: stdout");
+		});
+	});
+
+	it("CLI --var overrides profile variables", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review", "Style: {{REVIEW_STYLE}}");
+			await writeProfile(root, "profiles/vars.json", {
+				variables: { REVIEW_STYLE: "terse" },
+			});
+
+			await withCwd(root, async () => {
+				await runCli([
+					"node",
+					"omniagent",
+					"sync",
+					"--profile",
+					"vars",
+					"--var",
+					"REVIEW_STYLE=thorough",
+				]);
+			});
+
+			const output = await readFile(
+				path.join(root, ".claude", "skills", "review", "SKILL.md"),
+				"utf8",
+			);
+			expect(output).toContain("Style: thorough");
+		});
+	});
+
+	it("warns when an unresolved bare variable is present", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "review", "Style: {{MISSING_VAR}}");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			const combined = [
+				...logSpy.mock.calls.map(([msg]) => String(msg)),
+				...errorSpy.mock.calls.map(([msg]) => String(msg)),
+			].join("\n");
+			expect(combined).toContain("MISSING_VAR");
+		});
+	});
+
+	it("errors on malformed --var values", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "alpha");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--var", "lowercase=nope"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalled();
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain("lowercase=nope");
 		});
 	});
 

--- a/tests/lib/profiles/filter.test.ts
+++ b/tests/lib/profiles/filter.test.ts
@@ -47,14 +47,15 @@ describe("createProfileItemFilter", () => {
 		expect(filter.includes("skills", "security-review")).toBe(false);
 	});
 
-	it("supports * and ? globs", () => {
+	it("supports minimatch globs", () => {
 		const filter = createProfileItemFilter(
 			profile({
-				enable: { skills: ["review-*"], subagents: [], commands: [] },
+				enable: { skills: ["{review,debug}-*"], subagents: [], commands: [] },
 			}),
 		);
 		expect(filter.includes("skills", "review-pr")).toBe(true);
-		expect(filter.includes("skills", "review")).toBe(false);
+		expect(filter.includes("skills", "debug-shell")).toBe(true);
+		expect(filter.includes("skills", "other")).toBe(false);
 	});
 
 	it("warns for bare unknown names, silent for zero-match globs", () => {
@@ -83,5 +84,15 @@ describe("targetEnabledByProfile", () => {
 	it("matches aliases case-insensitively", () => {
 		const resolved = profile({ targets: { CLAUDE: { enabled: false } } });
 		expect(targetEnabledByProfile(resolved, "claude", ["claude-code"])).toBe(false);
+	});
+
+	it("treats explicit enabled targets as an allowlist", () => {
+		const resolved = profile({
+			targets: {
+				claude: { enabled: true },
+			},
+		});
+		expect(targetEnabledByProfile(resolved, "claude")).toBe(true);
+		expect(targetEnabledByProfile(resolved, "codex")).toBe(false);
 	});
 });

--- a/tests/lib/profiles/filter.test.ts
+++ b/tests/lib/profiles/filter.test.ts
@@ -1,0 +1,87 @@
+import {
+	createProfileItemFilter,
+	emptyResolvedProfile,
+	targetEnabledByProfile,
+	type ResolvedProfile,
+} from "../../../src/lib/profiles/index.js";
+
+function profile(partial: Partial<ResolvedProfile>): ResolvedProfile {
+	return {
+		...emptyResolvedProfile(),
+		...partial,
+		names: partial.names ?? ["test"],
+	};
+}
+
+describe("createProfileItemFilter", () => {
+	it("is a passthrough when no profile is active", () => {
+		const filter = createProfileItemFilter(null);
+		expect(filter.enabled).toBe(false);
+		expect(filter.includes("skills", "anything")).toBe(true);
+		expect(filter.collectUnknownWarnings()).toEqual([]);
+	});
+
+	it("includes everything when enable/disable are empty", () => {
+		const filter = createProfileItemFilter(profile({}));
+		expect(filter.includes("skills", "anything")).toBe(true);
+	});
+
+	it("with enable set, only matching items pass", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["review"], subagents: [], commands: [] },
+			}),
+		);
+		expect(filter.includes("skills", "review")).toBe(true);
+		expect(filter.includes("skills", "other")).toBe(false);
+	});
+
+	it("disable wins over enable", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["code-review", "security-review"], subagents: [], commands: [] },
+				disable: { skills: ["security-review"], subagents: [], commands: [] },
+			}),
+		);
+		expect(filter.includes("skills", "code-review")).toBe(true);
+		expect(filter.includes("skills", "security-review")).toBe(false);
+	});
+
+	it("supports * and ? globs", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["review-*"], subagents: [], commands: [] },
+			}),
+		);
+		expect(filter.includes("skills", "review-pr")).toBe(true);
+		expect(filter.includes("skills", "review")).toBe(false);
+	});
+
+	it("warns for bare unknown names, silent for zero-match globs", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["exists", "missing", "ghost-*"], subagents: [], commands: [] },
+			}),
+		);
+		filter.includes("skills", "exists");
+		const warnings = filter.collectUnknownWarnings();
+		expect(warnings.some((w) => w.includes('"missing"'))).toBe(true);
+		expect(warnings.some((w) => w.includes("ghost-"))).toBe(false);
+	});
+});
+
+describe("targetEnabledByProfile", () => {
+	it("returns true when no profile is active", () => {
+		expect(targetEnabledByProfile(null, "claude")).toBe(true);
+	});
+
+	it("returns false when the profile disables the target", () => {
+		const resolved = profile({ targets: { claude: { enabled: false } } });
+		expect(targetEnabledByProfile(resolved, "claude")).toBe(false);
+	});
+
+	it("matches aliases case-insensitively", () => {
+		const resolved = profile({ targets: { CLAUDE: { enabled: false } } });
+		expect(targetEnabledByProfile(resolved, "claude", ["claude-code"])).toBe(false);
+	});
+});

--- a/tests/lib/profiles/filter.test.ts
+++ b/tests/lib/profiles/filter.test.ts
@@ -1,8 +1,8 @@
 import {
 	createProfileItemFilter,
 	emptyResolvedProfile,
-	targetEnabledByProfile,
 	type ResolvedProfile,
+	targetEnabledByProfile,
 } from "../../../src/lib/profiles/index.js";
 
 function profile(partial: Partial<ResolvedProfile>): ResolvedProfile {

--- a/tests/lib/profiles/resolve.test.ts
+++ b/tests/lib/profiles/resolve.test.ts
@@ -114,4 +114,34 @@ describe("resolveProfiles", () => {
 			expect(resolved.enable.skills).toEqual(["toy"]);
 		});
 	});
+
+	it("merges variables across extends layers with later-wins semantics", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/base.json", {
+				variables: { REVIEW_STYLE: "terse", LOG_SOURCE: "stdout" },
+			});
+			await writeProfile(root, "profiles/override.json", {
+				extends: "base",
+				variables: { REVIEW_STYLE: "thorough" },
+			});
+			const resolved = await resolveProfiles(["override"], { repoRoot: root });
+			expect(resolved.variables).toEqual({
+				REVIEW_STYLE: "thorough",
+				LOG_SOURCE: "stdout",
+			});
+		});
+	});
+
+	it("merges variables across multiple CLI-order profiles, later wins", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/a.json", {
+				variables: { FOO: "a-foo", BAR: "a-bar" },
+			});
+			await writeProfile(root, "profiles/b.json", {
+				variables: { FOO: "b-foo" },
+			});
+			const resolved = await resolveProfiles(["a", "b"], { repoRoot: root });
+			expect(resolved.variables).toEqual({ FOO: "b-foo", BAR: "a-bar" });
+		});
+	});
 });

--- a/tests/lib/profiles/resolve.test.ts
+++ b/tests/lib/profiles/resolve.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveProfiles } from "../../../src/lib/profiles/index.js";
+
+async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-profiles-"));
+	try {
+		await fn(root);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function writeProfile(
+	root: string,
+	relative: string,
+	profile: Record<string, unknown>,
+): Promise<void> {
+	const target = path.join(root, "agents", relative);
+	await mkdir(path.dirname(target), { recursive: true });
+	await writeFile(target, JSON.stringify(profile), "utf8");
+}
+
+describe("resolveProfiles", () => {
+	it("returns empty resolution when no profile names provided", async () => {
+		await withTempRepo(async (root) => {
+			const resolved = await resolveProfiles([], { repoRoot: root });
+			expect(resolved.names).toEqual([]);
+			expect(resolved.enable.skills).toEqual([]);
+		});
+	});
+
+	it("resolves a single profile", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/default.json", {
+				description: "default",
+				enable: { skills: ["hello"] },
+			});
+			const resolved = await resolveProfiles(["default"], { repoRoot: root });
+			expect(resolved.names).toEqual(["default"]);
+			expect(resolved.description).toBe("default");
+			expect(resolved.enable.skills).toEqual(["hello"]);
+		});
+	});
+
+	it("resolves an extends chain, concatenating enable/disable", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/base.json", {
+				description: "base",
+				disable: { skills: ["ppt"] },
+			});
+			await writeProfile(root, "profiles/code-reviewer.json", {
+				extends: "base",
+				enable: { skills: ["review"] },
+			});
+			const resolved = await resolveProfiles(["code-reviewer"], { repoRoot: root });
+			expect(resolved.enable.skills).toEqual(["review"]);
+			expect(resolved.disable.skills).toEqual(["ppt"]);
+		});
+	});
+
+	it("detects cycles and reports the full chain", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/a.json", { extends: "b" });
+			await writeProfile(root, "profiles/b.json", { extends: "a" });
+			await expect(resolveProfiles(["a"], { repoRoot: root })).rejects.toThrow(/cycle/i);
+		});
+	});
+
+	it("layers .local sibling and dedicated overrides, dedicated wins", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/default.json", {
+				targets: { claude: { enabled: true } },
+			});
+			await writeProfile(root, "profiles/default.local.json", {
+				targets: { claude: { enabled: false } },
+			});
+			await writeProfile(root, ".local/profiles/default.json", {
+				targets: { claude: { enabled: true } },
+			});
+			const resolved = await resolveProfiles(["default"], { repoRoot: root });
+			expect(resolved.targets.claude).toEqual({ enabled: true });
+			expect(resolved.notices.length).toBeGreaterThan(0);
+		});
+	});
+
+	it("merges multiple profiles in CLI order, later wins", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, "profiles/base.json", {
+				targets: { claude: { enabled: false } },
+			});
+			await writeProfile(root, "profiles/override.json", {
+				targets: { claude: { enabled: true } },
+			});
+			const resolved = await resolveProfiles(["base", "override"], { repoRoot: root });
+			expect(resolved.targets.claude).toEqual({ enabled: true });
+			expect(resolved.names).toEqual(["base", "override"]);
+		});
+	});
+
+	it("throws when the requested profile is missing", async () => {
+		await withTempRepo(async (root) => {
+			await expect(resolveProfiles(["ghost"], { repoRoot: root })).rejects.toThrow(/not found/);
+		});
+	});
+
+	it("loads a profile that only exists at the dedicated .local path", async () => {
+		await withTempRepo(async (root) => {
+			await writeProfile(root, ".local/profiles/personal.json", {
+				enable: { skills: ["toy"] },
+			});
+			const resolved = await resolveProfiles(["personal"], { repoRoot: root });
+			expect(resolved.enable.skills).toEqual(["toy"]);
+		});
+	});
+});

--- a/tests/lib/profiles/substitute.test.ts
+++ b/tests/lib/profiles/substitute.test.ts
@@ -1,0 +1,59 @@
+import { substituteVariables } from "../../../src/lib/profiles/substitute.js";
+
+describe("substituteVariables", () => {
+	it("leaves content unchanged when there are no placeholders", () => {
+		const result = substituteVariables("plain content", { FOO: "bar" });
+		expect(result.content).toBe("plain content");
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it("substitutes a simple placeholder", () => {
+		const result = substituteVariables("Hello {{NAME}}!", { NAME: "World" });
+		expect(result.content).toBe("Hello World!");
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it("tolerates whitespace around the name", () => {
+		const result = substituteVariables("{{ NAME }}", { NAME: "World" });
+		expect(result.content).toBe("World");
+	});
+
+	it("supports multiple placeholders with repeats", () => {
+		const result = substituteVariables("{{A}}-{{B}}-{{A}}", { A: "1", B: "2" });
+		expect(result.content).toBe("1-2-1");
+	});
+
+	it("substitutes empty-string values correctly (doesn't fall through to default)", () => {
+		const result = substituteVariables("{{FOO=fallback}}", { FOO: "" });
+		expect(result.content).toBe("");
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it("uses default when the variable is unset", () => {
+		const result = substituteVariables("{{FOO=datadog}}", {});
+		expect(result.content).toBe("datadog");
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it("allows spaces inside the default value", () => {
+		const result = substituteVariables("{{GREETING=hello world}}", {});
+		expect(result.content).toBe("hello world");
+	});
+
+	it("reports unresolved bare placeholders once per name", () => {
+		const result = substituteVariables("{{MISSING}}-{{MISSING}}", {});
+		expect(result.content).toBe("{{MISSING}}-{{MISSING}}");
+		expect(result.unresolved).toEqual([{ name: "MISSING" }]);
+	});
+
+	it("does not match lowercase names", () => {
+		const result = substituteVariables("{{foo}}", { foo: "bar" });
+		expect(result.content).toBe("{{foo}}");
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it("handles null variables argument", () => {
+		const result = substituteVariables("{{FOO=fallback}}", null);
+		expect(result.content).toBe("fallback");
+	});
+});

--- a/tests/lib/profiles/validate.test.ts
+++ b/tests/lib/profiles/validate.test.ts
@@ -21,9 +21,9 @@ describe("validateProfile", () => {
 	});
 
 	it("rejects unknown top-level keys", () => {
-		const result = validateProfile({ variables: { A: "b" } });
+		const result = validateProfile({ overrides: { foo: "bar" } });
 		expect(result.valid).toBe(false);
-		expect(result.errors.some((issue) => issue.path === "variables")).toBe(true);
+		expect(result.errors.some((issue) => issue.path === "overrides")).toBe(true);
 	});
 
 	it("rejects non-object profile", () => {
@@ -52,5 +52,24 @@ describe("validateProfile", () => {
 	it("rejects unsupported category key under enable", () => {
 		const result = validateProfile({ enable: { mcpServers: ["foo"] } });
 		expect(result.valid).toBe(false);
+	});
+
+	it("accepts a valid variables object", () => {
+		const result = validateProfile({
+			variables: { REVIEW_STYLE: "terse", LOG_SOURCE: "datadog" },
+		});
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects variable names with lowercase or invalid characters", () => {
+		const result = validateProfile({ variables: { reviewStyle: "terse" } });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "variables.reviewStyle")).toBe(true);
+	});
+
+	it("rejects non-string variable values", () => {
+		const result = validateProfile({ variables: { FOO: 42 } });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "variables.FOO")).toBe(true);
 	});
 });

--- a/tests/lib/profiles/validate.test.ts
+++ b/tests/lib/profiles/validate.test.ts
@@ -1,0 +1,56 @@
+import { validateProfile } from "../../../src/lib/profiles/validate.js";
+
+describe("validateProfile", () => {
+	it("accepts an empty object", () => {
+		const result = validateProfile({});
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	it("accepts a full v1 profile", () => {
+		const result = validateProfile({
+			$schema: "./profile.v1.json",
+			description: "Focused",
+			extends: "base",
+			targets: { claude: { enabled: true }, codex: { enabled: false } },
+			enable: { skills: ["review"], subagents: ["reviewer"], commands: ["diff-*"] },
+			disable: { skills: ["ppt"] },
+		});
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	it("rejects unknown top-level keys", () => {
+		const result = validateProfile({ variables: { A: "b" } });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "variables")).toBe(true);
+	});
+
+	it("rejects non-object profile", () => {
+		const result = validateProfile("not a profile");
+		expect(result.valid).toBe(false);
+	});
+
+	it("rejects non-string extends", () => {
+		const result = validateProfile({ extends: 42 });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "extends")).toBe(true);
+	});
+
+	it("rejects empty strings in pattern lists", () => {
+		const result = validateProfile({ enable: { skills: ["ok", "  "] } });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "enable.skills[1]")).toBe(true);
+	});
+
+	it("rejects non-boolean target.enabled", () => {
+		const result = validateProfile({ targets: { claude: { enabled: "yes" } } });
+		expect(result.valid).toBe(false);
+		expect(result.errors.some((issue) => issue.path === "targets.claude.enabled")).toBe(true);
+	});
+
+	it("rejects unsupported category key under enable", () => {
+		const result = validateProfile({ enable: { mcpServers: ["foo"] } });
+		expect(result.valid).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Implements the v1 sync profile system proposed in #40. Profiles are named JSON files at `agents/profiles/*.json` that filter what `omniagent sync` writes — each developer on a team can opt in to exactly the skills, subagents, commands, and targets they want without forking the shared `agents/` directory.

Closes #40.

```bash
omniagent sync                                   # uses agents/profiles/default.json if present
omniagent sync --profile code-reviewer
omniagent sync --profile base,code-reviewer      # merge multiple (later wins)
```

## What's in this PR

- **Schema** — `schemas/profile.v1.json` published in-repo for IDE autocomplete. Hand-rolled validator in `src/lib/profiles/validate.ts` mirrors the existing `config-validate.ts` style.
- **Profile library** — `src/lib/profiles/` handles disk IO, validation, `extends` chain resolution (with cycle detection), `.local` layering (both sibling `*.local.json` and dedicated `.local/profiles/` paths), multi-profile merge, and glob-based `enable`/`disable` filtering on canonical item names.
- **`--profile` flag on sync** — supports repeated flags and comma-separated names. `default.json` is applied implicitly when present and `--profile` is absent; passing `--profile` explicitly does **not** implicitly prepend `default`.
- **`omniagent profiles` subcommand** — `profiles` (list), `profiles show <name>` (print fully-resolved merged JSON), `profiles validate` (non-zero exit on issues, CI-friendly).
- **Integration points** — `includeItem` predicate threaded into `syncSkills`, `syncSubagentsV2`, `syncSlashCommandsV2`, and `gatherTemplateScriptSources`. Profile-disabled targets merge into the existing `--skip` pipeline so CLI flags still layer last.
- **Ignore rules** — `**/*.local.json` added to `LOCAL_OVERRIDE_IGNORE_RULES` so sibling profile `.local` overrides stay gitignored.
- **Unknown-reference warnings** — bare names (no wildcards) that match zero items warn; glob patterns with zero matches stay silent. `profiles validate` promotes warnings to errors.
- **Docs** — `docs/profiles.md` covers schema, resolution order, `.local` variants, examples, and `enable`/`disable` semantics. Linked from `README.md` and `docs/README.md`.

## Canonical item name rules

Glob patterns in `enable`/`disable` match the canonical item name:

- **Skills / subagents** — `frontmatter.name ?? dirname` (reuses existing catalog identity).
- **Commands** — filename without extension.

## Resolution order (authoritative)

For `omniagent sync --profile A,B`:

1. Each profile's `extends` chain is resolved first (grandparent → parent → profile). Cycles fail loudly with the full path printed.
2. `.local` layers apply to each profile in order: sibling (`profiles/<name>.local.json`) then dedicated (`.local/profiles/<name>.json`, wins on conflict). Under `-v`, a one-line notice prints when both forms exist.
3. Profiles layer in CLI order (A then B).
4. CLI flags (`--skip`, `--only`, `--exclude-local`) apply last.

Array merges (`enable.<type>`, `disable.<type>`) concatenate; `targets.<name>` is a deep object merge.

## Intentional deviations from the issue spec

- **`variables` — not implemented.** The v1 profile schema omits the `variables` block entirely per a pre-implementation decision. Deferred to a later spec.
- **`enable`/`disable` scoped to skills/subagents/commands.** Instructions were considered but dropped since they're path-based (no clean canonical name) and weren't enumerated in the issue spec.
- **`$schema` — real file, relative reference.** Published at `schemas/profile.v1.json`; profiles reference it with `"./profile.v1.json"` for v1. Hosting a live URL is deferred.

## Test plan

- [x] `npm test` — 388 passing (41 new profile-related tests across validator, resolver, filter, sync integration, and profiles subcommand; 347 pre-existing).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint:check` — clean.
- [x] `npm run format` — clean.
- [ ] Manual smoke in a scratch repo:
  - [ ] `omniagent sync` with no profile and no `default.json` → behaves exactly as before.
  - [ ] Create `agents/profiles/default.json` with `disable.skills`, `omniagent sync` → confirm the disabled skill is absent from target outputs.
  - [ ] `omniagent sync --profile child` with `extends: "base"` → confirm layered merge.
  - [ ] `omniagent sync --profile ghost` → friendly error, non-zero exit.
  - [ ] `omniagent profiles`, `omniagent profiles show <name>`, `omniagent profiles validate` → verify output and exit codes.
  - [ ] Drop in `.local.json` at both paths and run `omniagent sync -v` → verify dedicated wins and the notice prints.