### PR TITLE
Add profile-overridable item defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ omniagent sync --var REVIEW_STYLE=thorough      # override a variable from the C
 
 Profiles support `extends` chains, `.local` overrides (personal, gitignored),
 glob-based `enable`/`disable` lists, per-target toggles, and template
-variables. Discover and validate profiles with `omniagent profiles`,
+variables. Individual skills, subagents, and commands can also set frontmatter
+`enabled: false` to stay hidden by default until a profile opts them in.
+Discover and validate profiles with `omniagent profiles`,
 `omniagent profiles show <name>`, and `omniagent profiles validate`.
 
 See [`docs/profiles.md`](docs/profiles.md) for the full schema, resolution

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -98,6 +98,18 @@ Glob syntax: `*` matches any run of non-slash characters, `?` matches one.
 - If `enable` is **present**, only matching items are included, minus anything
   `disable` carves out.
 
+## Item defaults
+
+Skills, subagents, and commands can declare frontmatter `enabled: false` to
+stay out of sync by default.
+
+- With no matching profile `enable`, the item stays excluded.
+- A matching profile `enable.<type>` opts it back in.
+- Profile `disable.<type>` still wins last.
+
+`enabled` is repo-side sync metadata, so omniagent strips it from rendered
+target outputs.
+
 ## Unknown references
 
 A bare name (no wildcards) that matches zero items prints a warning:

--- a/docs/sync-basics.md
+++ b/docs/sync-basics.md
@@ -36,6 +36,7 @@ targets: [claude, gemini]
 Supported fields:
 
 - `targets` or `targetAgents`: `claude`, `gemini`, `codex`, `copilot`
+- `enabled`: `false` hides the item by default; profiles can opt it back in
 - `name`: overrides filename where supported
 - `description`: optional metadata
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,7 @@
 - Confirm your canonical sources are under `agents/` (or the directory passed to `--agentsDir`).
 - Use `npx omniagent@latest sync --json` to inspect run output.
 - Check whether `targets` frontmatter filtered the item out.
+- Check whether the item sets frontmatter `enabled: false` and needs a profile to opt it in.
 
 ## Local overrides are unexpectedly winning
 

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -11,8 +11,16 @@ import {
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
 import { loadSkillCatalog } from "../../lib/skills/catalog.js";
-import { loadCommandCatalog } from "../../lib/slash-commands/catalog.js";
-import { loadSubagentCatalog } from "../../lib/subagents/catalog.js";
+import {
+	assertSlashCommandDefinitionUsable,
+	loadCommandCatalog,
+	type SlashCommandDefinition,
+} from "../../lib/slash-commands/catalog.js";
+import {
+	assertSubagentDefinitionUsable,
+	loadSubagentCatalog,
+	type SubagentDefinition,
+} from "../../lib/subagents/catalog.js";
 import { createTargetNameResolver } from "../../lib/sync-targets.js";
 import { BUILTIN_TARGETS } from "../../lib/targets/builtins.js";
 import { loadTargetConfig } from "../../lib/targets/config-loader.js";
@@ -38,9 +46,9 @@ type ListArgs = BaseArgs & {
 
 type ProfileValidationCatalog = {
 	resolveTargetName: (value: string) => string | null;
-	skillNames: string[];
-	commandNames: string[];
-	subagentNames: string[];
+	skills: Array<{ canonicalName: string; enabledByDefault: boolean }>;
+	commands: SlashCommandDefinition[];
+	subagents: SubagentDefinition[];
 };
 
 async function resolveRepoAndAgentsDir(
@@ -109,9 +117,12 @@ async function loadProfileValidationCatalog(
 
 	return {
 		resolveTargetName,
-		skillNames: skillCatalog.skills.map((skill) => skill.name),
-		commandNames: commandCatalog.commands.map((command) => command.name),
-		subagentNames: subagentCatalog.subagents.map((subagent) => subagent.resolvedName),
+		skills: skillCatalog.skills.map((skill) => ({
+			canonicalName: skill.name,
+			enabledByDefault: skill.enabledByDefault,
+		})),
+		commands: commandCatalog.commands,
+		subagents: subagentCatalog.subagents,
 	};
 }
 
@@ -121,17 +132,45 @@ function collectProfileReferenceIssues(
 	catalog: ProfileValidationCatalog,
 ): string[] {
 	const filter = createProfileItemFilter(resolvedProfile);
-	for (const skillName of catalog.skillNames) {
-		filter.includes("skills", skillName);
+	for (const skill of catalog.skills) {
+		filter.includes("skills", skill);
 	}
-	for (const commandName of catalog.commandNames) {
-		filter.includes("commands", commandName);
+	const issues: string[] = [];
+	for (const command of catalog.commands) {
+		const included = filter.includes("commands", {
+			canonicalName: command.name,
+			enabledByDefault: command.enabledByDefault,
+		});
+		if (!included) {
+			continue;
+		}
+		try {
+			assertSlashCommandDefinitionUsable(command);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			issues.push(
+				`profile "${profileName}" includes unusable command "${command.name}": ${message}`,
+			);
+		}
 	}
-	for (const subagentName of catalog.subagentNames) {
-		filter.includes("subagents", subagentName);
+	for (const subagent of catalog.subagents) {
+		const included = filter.includes("subagents", {
+			canonicalName: subagent.resolvedName,
+			enabledByDefault: subagent.enabledByDefault,
+		});
+		if (!included) {
+			continue;
+		}
+		try {
+			assertSubagentDefinitionUsable(subagent);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			issues.push(
+				`profile "${profileName}" includes unusable subagent "${subagent.resolvedName}": ${message}`,
+			);
+		}
 	}
-
-	const issues = filter.collectUnknownWarnings();
+	issues.push(...filter.collectUnknownWarnings());
 	for (const targetName of Object.keys(resolvedProfile.targets)) {
 		if (catalog.resolveTargetName(targetName)) {
 			continue;

--- a/src/cli/commands/profiles.ts
+++ b/src/cli/commands/profiles.ts
@@ -10,7 +10,11 @@ import {
 	resolveProfiles,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
-import { loadSkillCatalog } from "../../lib/skills/catalog.js";
+import {
+	assertSkillDefinitionUsable,
+	loadSkillCatalog,
+	type SkillDefinition,
+} from "../../lib/skills/catalog.js";
 import {
 	assertSlashCommandDefinitionUsable,
 	loadCommandCatalog,
@@ -46,7 +50,7 @@ type ListArgs = BaseArgs & {
 
 type ProfileValidationCatalog = {
 	resolveTargetName: (value: string) => string | null;
-	skills: Array<{ canonicalName: string; enabledByDefault: boolean }>;
+	skills: SkillDefinition[];
 	commands: SlashCommandDefinition[];
 	subagents: SubagentDefinition[];
 };
@@ -117,10 +121,7 @@ async function loadProfileValidationCatalog(
 
 	return {
 		resolveTargetName,
-		skills: skillCatalog.skills.map((skill) => ({
-			canonicalName: skill.name,
-			enabledByDefault: skill.enabledByDefault,
-		})),
+		skills: skillCatalog.skills,
 		commands: commandCatalog.commands,
 		subagents: subagentCatalog.subagents,
 	};
@@ -132,10 +133,22 @@ function collectProfileReferenceIssues(
 	catalog: ProfileValidationCatalog,
 ): string[] {
 	const filter = createProfileItemFilter(resolvedProfile);
-	for (const skill of catalog.skills) {
-		filter.includes("skills", skill);
-	}
 	const issues: string[] = [];
+	for (const skill of catalog.skills) {
+		const included = filter.includes("skills", {
+			canonicalName: skill.name,
+			enabledByDefault: skill.enabledByDefault,
+		});
+		if (!included) {
+			continue;
+		}
+		try {
+			assertSkillDefinitionUsable(skill);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			issues.push(`profile "${profileName}" includes unusable skill "${skill.name}": ${message}`);
+		}
+	}
 	for (const command of catalog.commands) {
 		const included = filter.includes("commands", {
 			canonicalName: command.name,

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -977,28 +977,24 @@ async function validateTemplatingSources(options: {
 	}
 
 	if (options.instructionsAvailable) {
-		const entries = await scanInstructionTemplateSources({
+		const catalog = await loadInstructionTemplateCatalog({
 			repoRoot: options.repoRoot,
 			includeLocal: options.includeLocalInstructions,
 			agentsDir: options.agentsDir,
+			resolveTargetName: options.resolveTargetName,
 		});
-		for (const entry of entries) {
+		for (const template of catalog.templates) {
 			const effectiveTargets = resolveEffectiveTargets({
-				defaultTargets: entry.targets,
+				defaultTargets: template.targets,
 				allTargets: options.selectedInstructionTargets.map((target) => target.id),
 			});
 			if (!intersectsTargets(effectiveTargets, selectedInstructionTargetIds)) {
 				continue;
 			}
-			const buffer = await readFile(entry.sourcePath);
-			const contents = decodeUtf8(buffer);
-			if (contents === null) {
-				continue;
-			}
 			validateAgentTemplating({
-				content: contents,
+				content: template.rawContents,
 				validAgents: options.validAgents,
-				sourcePath: entry.sourcePath,
+				sourcePath: template.sourcePath,
 			});
 		}
 	}

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -41,9 +41,12 @@ import {
 	targetEnabledByProfile,
 } from "../../lib/profiles/index.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
-import { loadSkillCatalog } from "../../lib/skills/catalog.js";
+import { assertSkillDefinitionUsable, loadSkillCatalog } from "../../lib/skills/catalog.js";
 import { syncSkills as syncSkillTargets } from "../../lib/skills/sync.js";
-import { loadCommandCatalog } from "../../lib/slash-commands/catalog.js";
+import {
+	assertSlashCommandDefinitionUsable,
+	loadCommandCatalog,
+} from "../../lib/slash-commands/catalog.js";
 import {
 	type SyncRequestV2 as CommandSyncRequestV2,
 	type SyncSummary as CommandSyncSummary,
@@ -51,7 +54,10 @@ import {
 	formatSyncSummary as formatCommandSummary,
 	syncSlashCommands as syncSlashCommandsV2,
 } from "../../lib/slash-commands/sync.js";
-import { loadSubagentCatalog } from "../../lib/subagents/catalog.js";
+import {
+	assertSubagentDefinitionUsable,
+	loadSubagentCatalog,
+} from "../../lib/subagents/catalog.js";
 import {
 	formatSubagentSummary,
 	type SubagentSyncRequestV2,
@@ -532,6 +538,7 @@ async function gatherTemplateScriptSources(
 			if (!intersectsTargets(effectiveTargets, selectedCommandTargetIds)) {
 				continue;
 			}
+			assertSlashCommandDefinitionUsable(command);
 			addTemplateScriptSource(sources, command.sourcePath, command.rawContents);
 		}
 	}
@@ -561,6 +568,7 @@ async function gatherTemplateScriptSources(
 			if (!intersectsTargets(effectiveTargets, selectedSubagentTargetIds)) {
 				continue;
 			}
+			assertSubagentDefinitionUsable(subagent);
 			addTemplateScriptSource(sources, subagent.sourcePath, subagent.rawContents);
 		}
 	}
@@ -611,6 +619,7 @@ async function gatherTemplateScriptSources(
 			if (!intersectsTargets(effectiveTargets, selectedSkillTargetIds)) {
 				continue;
 			}
+			assertSkillDefinitionUsable(skill);
 			const files = await listAllFiles(skill.directoryPath);
 			for (const filePath of files) {
 				const buffer = await readFile(filePath);
@@ -776,6 +785,10 @@ async function validateTemplatingSources(options: {
 	repoRoot: string;
 	agentsDir?: string | null;
 	validAgents: string[];
+	selectedSkillTargets: ResolvedTarget[];
+	selectedCommandTargets: ResolvedTarget[];
+	selectedSubagentTargets: ResolvedTarget[];
+	selectedInstructionTargets: ResolvedTarget[];
 	commandsAvailable: boolean;
 	skillsAvailable: boolean;
 	subagentsAvailable: boolean;
@@ -796,6 +809,16 @@ async function validateTemplatingSources(options: {
 			sourcePath,
 		});
 	};
+	const selectedSkillTargetIds = new Set(options.selectedSkillTargets.map((target) => target.id));
+	const selectedCommandTargetIds = new Set(
+		options.selectedCommandTargets.map((target) => target.id),
+	);
+	const selectedSubagentTargetIds = new Set(
+		options.selectedSubagentTargets.map((target) => target.id),
+	);
+	const selectedInstructionTargetIds = new Set(
+		options.selectedInstructionTargets.map((target) => target.id),
+	);
 
 	if (options.commandsAvailable) {
 		const commandCatalog = await loadCommandCatalog(options.repoRoot, {
@@ -813,6 +836,14 @@ async function validateTemplatingSources(options: {
 			) {
 				continue;
 			}
+			const effectiveTargets = resolveEffectiveTargets({
+				defaultTargets: command.targetAgents,
+				allTargets: options.selectedCommandTargets.map((target) => target.id),
+			});
+			if (!intersectsTargets(effectiveTargets, selectedCommandTargetIds)) {
+				continue;
+			}
+			assertSlashCommandDefinitionUsable(command);
 			validateContent(command.sourcePath, command.rawContents);
 		}
 	}
@@ -833,6 +864,14 @@ async function validateTemplatingSources(options: {
 			) {
 				continue;
 			}
+			const effectiveTargets = resolveEffectiveTargets({
+				defaultTargets: skill.targetAgents,
+				allTargets: options.selectedSkillTargets.map((target) => target.id),
+			});
+			if (!intersectsTargets(effectiveTargets, selectedSkillTargetIds)) {
+				continue;
+			}
+			assertSkillDefinitionUsable(skill);
 			const files = await listFiles(skill.directoryPath);
 			const filesToValidate = options.includeLocalSkills
 				? files
@@ -864,6 +903,14 @@ async function validateTemplatingSources(options: {
 			) {
 				continue;
 			}
+			const effectiveTargets = resolveEffectiveTargets({
+				defaultTargets: subagent.targetAgents,
+				allTargets: options.selectedSubagentTargets.map((target) => target.id),
+			});
+			if (!intersectsTargets(effectiveTargets, selectedSubagentTargetIds)) {
+				continue;
+			}
+			assertSubagentDefinitionUsable(subagent);
 			validateContent(subagent.sourcePath, subagent.rawContents);
 		}
 	}
@@ -875,6 +922,13 @@ async function validateTemplatingSources(options: {
 			agentsDir: options.agentsDir,
 		});
 		for (const entry of entries) {
+			const effectiveTargets = resolveEffectiveTargets({
+				defaultTargets: entry.targets,
+				allTargets: options.selectedInstructionTargets.map((target) => target.id),
+			});
+			if (!intersectsTargets(effectiveTargets, selectedInstructionTargetIds)) {
+				continue;
+			}
 			const buffer = await readFile(entry.sourcePath);
 			const contents = decodeUtf8(buffer);
 			if (contents === null) {
@@ -1890,6 +1944,10 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 					repoRoot,
 					agentsDir,
 					validAgents,
+					selectedSkillTargets,
+					selectedCommandTargets,
+					selectedSubagentTargets,
+					selectedInstructionTargets,
 					commandsAvailable: hasCommandsToSync,
 					skillsAvailable: hasSkillsToSync,
 					subagentsAvailable: hasSubagentsToSync,

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -2100,6 +2100,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 				hooks: globalHooks,
 				templateScriptRuntime: scriptRuntime,
 				includeItem: includeItemFor("subagents"),
+				includeSkill: includeItemFor("skills"),
 			} satisfies SubagentSyncRequestV2);
 
 			if (availabilitySubagentSkips.length > 0) {

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -33,6 +33,7 @@ import {
 	DEFAULT_PROFILE_NAME,
 	loadProfileFiles,
 	type ProfileItemFilter,
+	type ProfileItemSelection,
 	type ProfileTargetSetting,
 	profileExists,
 	type ResolvedProfile,
@@ -448,9 +449,9 @@ type ScriptPreflightOptions = {
 	selectedInstructionTargets: ResolvedTarget[];
 	skillsAvailable: boolean;
 	commandsAvailable: boolean;
-	includeSkill?: (name: string) => boolean;
-	includeSubagent?: (name: string) => boolean;
-	includeCommand?: (name: string) => boolean;
+	includeSkill?: (item: ProfileItemSelection) => boolean;
+	includeSubagent?: (item: ProfileItemSelection) => boolean;
+	includeCommand?: (item: ProfileItemSelection) => boolean;
 };
 
 function hasTemplateScripts(content: string): boolean {
@@ -513,7 +514,13 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const command of commandCatalog.commands) {
-			if (options.includeCommand && !options.includeCommand(command.name)) {
+			if (
+				options.includeCommand &&
+				!options.includeCommand({
+					canonicalName: command.name,
+					enabledByDefault: command.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			const effectiveTargets = resolveEffectiveTargets({
@@ -536,7 +543,13 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const subagent of subagentCatalog.subagents) {
-			if (options.includeSubagent && !options.includeSubagent(subagent.resolvedName)) {
+			if (
+				options.includeSubagent &&
+				!options.includeSubagent({
+					canonicalName: subagent.resolvedName,
+					enabledByDefault: subagent.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			const effectiveTargets = resolveEffectiveTargets({
@@ -580,7 +593,13 @@ async function gatherTemplateScriptSources(
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const skill of skillCatalog.skills) {
-			if (options.includeSkill && !options.includeSkill(skill.name)) {
+			if (
+				options.includeSkill &&
+				!options.includeSkill({
+					canonicalName: skill.name,
+					enabledByDefault: skill.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			const effectiveTargets = resolveEffectiveTargets({
@@ -766,9 +785,9 @@ async function validateTemplatingSources(options: {
 	includeLocalInstructions: boolean;
 	instructionsAvailable: boolean;
 	resolveTargetName?: (value: string) => string | null;
-	includeSkill?: (name: string) => boolean;
-	includeSubagent?: (name: string) => boolean;
-	includeCommand?: (name: string) => boolean;
+	includeSkill?: (item: ProfileItemSelection) => boolean;
+	includeSubagent?: (item: ProfileItemSelection) => boolean;
+	includeCommand?: (item: ProfileItemSelection) => boolean;
 }): Promise<void> {
 	const validateContent = (sourcePath: string, contents: string): void => {
 		validateAgentTemplating({
@@ -785,7 +804,13 @@ async function validateTemplatingSources(options: {
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const command of commandCatalog.commands) {
-			if (options.includeCommand && !options.includeCommand(command.name)) {
+			if (
+				options.includeCommand &&
+				!options.includeCommand({
+					canonicalName: command.name,
+					enabledByDefault: command.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			validateContent(command.sourcePath, command.rawContents);
@@ -799,7 +824,13 @@ async function validateTemplatingSources(options: {
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const skill of skillCatalog.skills) {
-			if (options.includeSkill && !options.includeSkill(skill.name)) {
+			if (
+				options.includeSkill &&
+				!options.includeSkill({
+					canonicalName: skill.name,
+					enabledByDefault: skill.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			const files = await listFiles(skill.directoryPath);
@@ -824,7 +855,13 @@ async function validateTemplatingSources(options: {
 			resolveTargetName: options.resolveTargetName,
 		});
 		for (const subagent of subagentCatalog.subagents) {
-			if (options.includeSubagent && !options.includeSubagent(subagent.resolvedName)) {
+			if (
+				options.includeSubagent &&
+				!options.includeSubagent({
+					canonicalName: subagent.resolvedName,
+					enabledByDefault: subagent.enabledByDefault,
+				})
+			) {
 				continue;
 			}
 			validateContent(subagent.sourcePath, subagent.rawContents);
@@ -1609,7 +1646,7 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			};
 			const includeItemFor = (
 				category: "skills" | "subagents" | "commands",
-			): ((item: { canonicalName: string; enabledByDefault: boolean }) => boolean) => {
+			): ((item: ProfileItemSelection) => boolean) => {
 				return (item) => {
 					if (profileItemFilter.enabled) {
 						traversedProfileNames[category].add(item.canonicalName);

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -406,12 +406,21 @@ function replayTraversedProfileWarnings(
 		},
 	});
 	for (const name of traversedNames.skills) {
+		if (!name) {
+			continue;
+		}
 		warningFilter.includes("skills", name);
 	}
 	for (const name of traversedNames.subagents) {
+		if (!name) {
+			continue;
+		}
 		warningFilter.includes("subagents", name);
 	}
 	for (const name of traversedNames.commands) {
+		if (!name) {
+			continue;
+		}
 		warningFilter.includes("commands", name);
 	}
 	return warningFilter.collectUnknownWarnings();
@@ -1600,13 +1609,12 @@ export const syncCommand: CommandModule<Record<string, never>, SyncArgs> = {
 			};
 			const includeItemFor = (
 				category: "skills" | "subagents" | "commands",
-			): ((name: string) => boolean) | undefined => {
-				if (!profileItemFilter.enabled) {
-					return undefined;
-				}
-				return (name) => {
-					traversedProfileNames[category].add(name);
-					return profileItemFilter.includes(category, name);
+			): ((item: { canonicalName: string; enabledByDefault: boolean }) => boolean) => {
+				return (item) => {
+					if (profileItemFilter.enabled) {
+						traversedProfileNames[category].add(item.canonicalName);
+					}
+					return profileItemFilter.includes(category, item);
 				};
 			};
 

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -60,6 +60,7 @@ import {
 } from "../../lib/subagents/catalog.js";
 import {
 	formatSubagentSummary,
+	resolveShadowedSubagentNamesForTargets,
 	type SubagentSyncRequestV2,
 	type SubagentSyncSummary,
 	syncSubagents as syncSubagentsV2,
@@ -482,6 +483,24 @@ function intersectsTargets(targets: string[], selectedTargetIds: Set<string>): b
 	return targets.some((target) => selectedTargetIds.has(target));
 }
 
+function areSelectedTargetsFullyShadowed(options: {
+	selectedTargetIds: Set<string>;
+	effectiveTargets: string[];
+	shadowedSubagentsByTarget: Map<string, Set<string>>;
+	subagentName: string;
+}): boolean {
+	const relevantTargets = options.effectiveTargets.filter((targetId) =>
+		options.selectedTargetIds.has(targetId),
+	);
+	if (relevantTargets.length === 0) {
+		return false;
+	}
+	const normalizedName = options.subagentName.trim().toLowerCase();
+	return relevantTargets.every((targetId) =>
+		options.shadowedSubagentsByTarget.get(targetId)?.has(normalizedName),
+	);
+}
+
 async function listAllFiles(root: string): Promise<string[]> {
 	const entries = await readdir(root, { withFileTypes: true });
 	const files: string[] = [];
@@ -549,6 +568,18 @@ async function gatherTemplateScriptSources(
 			agentsDir: options.agentsDir,
 			resolveTargetName: options.resolveTargetName,
 		});
+		const shadowedSubagentsByTarget = await resolveShadowedSubagentNamesForTargets({
+			repoRoot: options.repoRoot,
+			activeTargets: options.selectedSubagentTargets,
+			allTargetIds: options.allTargetIds,
+			subagents: subagentCatalog.subagents,
+			agentsDir: options.agentsDir,
+			includeLocalSkills: !options.excludeLocalSkills,
+			resolveTargetName: options.resolveTargetName,
+			overrideOnly: options.overrideOnly,
+			overrideSkip: options.overrideSkip,
+			includeSkill: options.includeSkill,
+		});
 		for (const subagent of subagentCatalog.subagents) {
 			if (
 				options.includeSubagent &&
@@ -566,6 +597,16 @@ async function gatherTemplateScriptSources(
 				allTargets: options.allTargetIds,
 			});
 			if (!intersectsTargets(effectiveTargets, selectedSubagentTargetIds)) {
+				continue;
+			}
+			if (
+				areSelectedTargetsFullyShadowed({
+					selectedTargetIds: selectedSubagentTargetIds,
+					effectiveTargets,
+					shadowedSubagentsByTarget,
+					subagentName: subagent.resolvedName,
+				})
+			) {
 				continue;
 			}
 			assertSubagentDefinitionUsable(subagent);
@@ -893,6 +934,16 @@ async function validateTemplatingSources(options: {
 			agentsDir: options.agentsDir,
 			resolveTargetName: options.resolveTargetName,
 		});
+		const shadowedSubagentsByTarget = await resolveShadowedSubagentNamesForTargets({
+			repoRoot: options.repoRoot,
+			activeTargets: options.selectedSubagentTargets,
+			allTargetIds: options.selectedSubagentTargets.map((target) => target.id),
+			subagents: subagentCatalog.subagents,
+			agentsDir: options.agentsDir,
+			includeLocalSkills: options.includeLocalSkills,
+			resolveTargetName: options.resolveTargetName,
+			includeSkill: options.includeSkill,
+		});
 		for (const subagent of subagentCatalog.subagents) {
 			if (
 				options.includeSubagent &&
@@ -908,6 +959,16 @@ async function validateTemplatingSources(options: {
 				allTargets: options.selectedSubagentTargets.map((target) => target.id),
 			});
 			if (!intersectsTargets(effectiveTargets, selectedSubagentTargetIds)) {
+				continue;
+			}
+			if (
+				areSelectedTargetsFullyShadowed({
+					selectedTargetIds: selectedSubagentTargetIds,
+					effectiveTargets,
+					shadowedSubagentsByTarget,
+					subagentName: subagent.resolvedName,
+				})
+			) {
 				continue;
 			}
 			assertSubagentDefinitionUsable(subagent);

--- a/src/lib/frontmatter-enabled.ts
+++ b/src/lib/frontmatter-enabled.ts
@@ -1,0 +1,30 @@
+export type FrontmatterRecord = Record<string, string | string[]>;
+
+export const SYNC_ROUTING_FRONTMATTER_KEYS = new Set(["targets", "targetagents", "enabled"]);
+
+export function resolveFrontmatterEnabledByDefault(options: {
+	frontmatter: FrontmatterRecord;
+	itemKind: string;
+	itemName: string;
+	sourcePath: string;
+}): boolean {
+	const rawEnabled = options.frontmatter.enabled;
+	if (rawEnabled === undefined) {
+		return true;
+	}
+	if (Array.isArray(rawEnabled)) {
+		throw new Error(
+			`${options.itemKind} "${options.itemName}" has invalid enabled value in ${options.sourcePath}. Expected true or false.`,
+		);
+	}
+	const normalized = rawEnabled.trim().toLowerCase();
+	if (normalized === "true") {
+		return true;
+	}
+	if (normalized === "false") {
+		return false;
+	}
+	throw new Error(
+		`${options.itemKind} "${options.itemName}" has invalid enabled value "${rawEnabled}" in ${options.sourcePath}. Expected true or false.`,
+	);
+}

--- a/src/lib/profiles/filter.ts
+++ b/src/lib/profiles/filter.ts
@@ -15,6 +15,11 @@ type CompiledPattern = {
 	matched: boolean;
 };
 
+export type ProfileItemSelection = {
+	canonicalName: string;
+	enabledByDefault: boolean;
+};
+
 function compilePatterns(list: string[] | undefined): CompiledPattern[] {
 	if (!list || list.length === 0) {
 		return [];
@@ -43,9 +48,21 @@ function matchAny(name: string, patterns: CompiledPattern[]): boolean {
 
 export type ProfileItemFilter = {
 	enabled: boolean;
-	includes(category: ProfileCategory, canonicalName: string): boolean;
+	includes(category: ProfileCategory, item: string | ProfileItemSelection): boolean;
 	collectUnknownWarnings(): string[];
 };
+
+function normalizeItemSelection(
+	item: string | ProfileItemSelection | null | undefined,
+): ProfileItemSelection {
+	if (!item) {
+		return { canonicalName: "", enabledByDefault: true };
+	}
+	if (typeof item === "string") {
+		return { canonicalName: item, enabledByDefault: true };
+	}
+	return item;
+}
 
 /**
  * Build a predicate that applies a ResolvedProfile's enable/disable rules to
@@ -56,7 +73,7 @@ export function createProfileItemFilter(resolved: ResolvedProfile | null): Profi
 	if (!resolved || resolved.names.length === 0) {
 		return {
 			enabled: false,
-			includes: () => true,
+			includes: (_category, item) => normalizeItemSelection(item).enabledByDefault,
 			collectUnknownWarnings: () => [],
 		};
 	}
@@ -71,21 +88,20 @@ export function createProfileItemFilter(resolved: ResolvedProfile | null): Profi
 
 	return {
 		enabled: true,
-		includes(category, canonicalName) {
+		includes(category, item) {
+			const { canonicalName, enabledByDefault } = normalizeItemSelection(item);
 			const enablePatterns = enablePatternsByCategory.get(category) ?? [];
 			const disablePatterns = disablePatternsByCategory.get(category) ?? [];
 			const enableApplies = enablePatterns.length > 0;
-			if (enableApplies && !matchAny(canonicalName, enablePatterns)) {
+			const enableMatches = matchAny(canonicalName, enablePatterns);
+			const disableMatches = matchAny(canonicalName, disablePatterns);
+			if (disableMatches) {
 				return false;
 			}
-			if (matchAny(canonicalName, disablePatterns)) {
-				return false;
+			if (enableApplies) {
+				return enableMatches;
 			}
-			// Also record matches against empty filters so zero-match bare names can warn.
-			if (!enableApplies) {
-				// still call matchAny so patterns (if any) track state; harmless when empty.
-			}
-			return true;
+			return enabledByDefault;
 		},
 		collectUnknownWarnings() {
 			const warnings: string[] = [];

--- a/src/lib/profiles/index.ts
+++ b/src/lib/profiles/index.ts
@@ -1,6 +1,7 @@
 export {
 	createProfileItemFilter,
 	type ProfileItemFilter,
+	type ProfileItemSelection,
 	targetEnabledByProfile,
 } from "./filter.js";
 export { DEFAULT_PROFILE_NAME, listProfiles, type ProfileListEntry } from "./list.js";

--- a/src/lib/skills/catalog.ts
+++ b/src/lib/skills/catalog.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { listSkillDirectories, readDirectoryStats } from "../catalog-utils.js";
+import { resolveFrontmatterEnabledByDefault } from "../frontmatter-enabled.js";
 import { resolveLocalPrecedence } from "../local-precedence.js";
 import {
 	buildSourceMetadata,
@@ -23,6 +24,7 @@ import { BUILTIN_TARGETS } from "../targets/builtins.js";
 
 export type SkillDefinition = {
 	name: string;
+	enabledByDefault: boolean;
 	relativePath: string;
 	directoryPath: string;
 	sourcePath: string;
@@ -112,6 +114,12 @@ async function buildSkillDefinition(options: {
 	const relativePath =
 		options.relativePath ?? path.relative(options.skillsRoot, options.directoryPath);
 	const name = resolveSkillName(frontmatter, relativePath || path.basename(options.directoryPath));
+	const enabledByDefault = resolveFrontmatterEnabledByDefault({
+		frontmatter,
+		itemKind: "Skill",
+		itemName: name,
+		sourcePath,
+	});
 	const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 	const { targets, invalidTargets } = resolveFrontmatterTargets(
 		rawTargets,
@@ -130,6 +138,7 @@ async function buildSkillDefinition(options: {
 
 	return {
 		name,
+		enabledByDefault,
 		relativePath,
 		directoryPath: options.directoryPath,
 		sourcePath,

--- a/src/lib/skills/catalog.ts
+++ b/src/lib/skills/catalog.ts
@@ -38,6 +38,7 @@ export type SkillDefinition = {
 	body: string;
 	targetAgents: TargetName[] | null;
 	invalidTargets: string[];
+	routingError?: string | null;
 };
 
 export type SkillCatalog = {
@@ -89,6 +90,26 @@ function resolveSkillRelativePath(
 	return { relativePath: normalized, hadLocalSuffix: true };
 }
 
+function resolveSkillRoutingError(options: {
+	name: string;
+	sourcePath: string;
+	rawTargets: Array<FrontmatterValue | undefined>;
+	targets: TargetName[] | null;
+	invalidTargets: string[];
+}): string | null {
+	if (options.invalidTargets.length > 0) {
+		const invalidList = options.invalidTargets.join(", ");
+		return `Skill "${options.name}" has unsupported targets (${invalidList}) in ${options.sourcePath}.`;
+	}
+	if (
+		hasRawTargetValues(options.rawTargets) &&
+		(!options.targets || options.targets.length === 0)
+	) {
+		return `Skill "${options.name}" has empty targets in ${options.sourcePath}.`;
+	}
+	return null;
+}
+
 async function buildSkillDefinition(options: {
 	directoryPath: string;
 	skillsRoot: string;
@@ -125,14 +146,15 @@ async function buildSkillDefinition(options: {
 		rawTargets,
 		options.resolveTargetName,
 	);
-	if (invalidTargets.length > 0) {
-		const invalidList = invalidTargets.join(", ");
-		throw new InvalidFrontmatterTargetsError(
-			`Skill "${name}" has unsupported targets (${invalidList}) in ${sourcePath}.`,
-		);
-	}
-	if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
-		throw new InvalidFrontmatterTargetsError(`Skill "${name}" has empty targets in ${sourcePath}.`);
+	const routingError = resolveSkillRoutingError({
+		name,
+		sourcePath,
+		rawTargets,
+		targets,
+		invalidTargets,
+	});
+	if (enabledByDefault && routingError) {
+		throw new InvalidFrontmatterTargetsError(routingError);
 	}
 	const { outputFileName } = stripLocalSuffix(options.skillFileName, ".md");
 
@@ -152,7 +174,14 @@ async function buildSkillDefinition(options: {
 		body,
 		targetAgents: targets,
 		invalidTargets,
+		routingError,
 	};
+}
+
+export function assertSkillDefinitionUsable(skill: Pick<SkillDefinition, "routingError">): void {
+	if (skill.routingError) {
+		throw new InvalidFrontmatterTargetsError(skill.routingError);
+	}
 }
 
 export async function loadSkillCatalog(

--- a/src/lib/skills/sync.ts
+++ b/src/lib/skills/sync.ts
@@ -39,7 +39,7 @@ import {
 	writeFileOutput,
 } from "../targets/writers.js";
 import { createTemplateScriptRuntime, type TemplateScriptRuntime } from "../template-scripts.js";
-import { loadSkillCatalog, type SkillDefinition } from "./catalog.js";
+import { assertSkillDefinitionUsable, loadSkillCatalog, type SkillDefinition } from "./catalog.js";
 
 export type SkillSyncRequest = {
 	repoRoot: string;
@@ -74,6 +74,27 @@ function buildInvalidTargetWarnings(skills: SkillDefinition[]): string[] {
 		);
 	}
 	return warnings;
+}
+
+function assertUsableSkillsForTargets(options: {
+	skills: SkillDefinition[];
+	activeTargetIds: Set<string>;
+	overrideOnly?: TargetName[] | null;
+	overrideSkip?: TargetName[] | null;
+	allTargets: string[];
+}): void {
+	for (const skill of options.skills) {
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: skill.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		if (!effectiveTargets.some((targetId) => options.activeTargetIds.has(targetId))) {
+			continue;
+		}
+		assertSkillDefinitionUsable(skill);
+	}
 }
 
 type SkillOutputCandidate = {
@@ -117,9 +138,16 @@ export async function syncSkills(request: SkillSyncRequest): Promise<SyncSummary
 	catalog.sharedSkills = catalog.sharedSkills.filter(predicate);
 	catalog.localSkills = catalog.localSkills.filter(predicate);
 	catalog.localEffectiveSkills = catalog.localEffectiveSkills.filter(predicate);
-	const warnings = buildInvalidTargetWarnings(catalog.skills);
 	const allTargetIds = request.targets.map((target) => target.id);
 	const targetNames = new Set(skillTargets.map((target) => target.id));
+	assertUsableSkillsForTargets({
+		skills: catalog.skills,
+		activeTargetIds: targetNames,
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
+	const warnings = buildInvalidTargetWarnings(catalog.skills);
 	const effectiveTargetsBySkill = new Map<SkillDefinition, TargetName[]>();
 	const activeSourcesByTarget = new Map<string, Set<string>>();
 	for (const skill of catalog.skills) {

--- a/src/lib/skills/sync.ts
+++ b/src/lib/skills/sync.ts
@@ -62,6 +62,12 @@ function formatDisplayPath(repoRoot: string, absolutePath: string): string {
 	return isWithinRepo ? relative : absolutePath;
 }
 
+function buildManagedOutputPathKey(
+	entry: Pick<ManagedOutputRecord, "targetId" | "outputPath">,
+): string {
+	return `${entry.targetId}:${normalizeManagedOutputPath(entry.outputPath)}`;
+}
+
 function buildInvalidTargetWarnings(skills: SkillDefinition[]): string[] {
 	const warnings: string[] = [];
 	for (const skill of skills) {
@@ -419,7 +425,18 @@ export async function syncSkills(request: SkillSyncRequest): Promise<SyncSummary
 	if (managedManifest.entries.length > 0 || nextManaged.size > 0) {
 		const updatedEntries: ManagedOutputRecord[] = [];
 		const managedTargetIds = new Set(skillTargets.map((target) => target.id));
+		const claimedSkillOutputPaths = new Set(
+			Array.from(nextManaged.values())
+				.filter((entry) => entry.sourceType === "skill")
+				.map((entry) => buildManagedOutputPathKey(entry)),
+		);
 		for (const entry of managedManifest.entries) {
+			if (
+				entry.sourceType === "subagent" &&
+				claimedSkillOutputPaths.has(buildManagedOutputPathKey(entry))
+			) {
+				continue;
+			}
 			if (entry.sourceType !== "skill" || !managedTargetIds.has(entry.targetId)) {
 				updatedEntries.push(entry);
 				continue;

--- a/src/lib/skills/sync.ts
+++ b/src/lib/skills/sync.ts
@@ -53,7 +53,7 @@ export type SkillSyncRequest = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
-	includeItem?: (canonicalName: string) => boolean;
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 function formatDisplayPath(repoRoot: string, absolutePath: string): string {
@@ -107,7 +107,11 @@ export async function syncSkills(request: SkillSyncRequest): Promise<SyncSummary
 	});
 	if (request.includeItem) {
 		const includeItem = request.includeItem;
-		const predicate = (skill: SkillDefinition) => includeItem(skill.name);
+		const predicate = (skill: SkillDefinition) =>
+			includeItem({
+				canonicalName: skill.name,
+				enabledByDefault: skill.enabledByDefault,
+			});
 		catalog.skills = catalog.skills.filter(predicate);
 		catalog.sharedSkills = catalog.sharedSkills.filter(predicate);
 		catalog.localSkills = catalog.localSkills.filter(predicate);

--- a/src/lib/skills/sync.ts
+++ b/src/lib/skills/sync.ts
@@ -105,18 +105,18 @@ export async function syncSkills(request: SkillSyncRequest): Promise<SyncSummary
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
-	if (request.includeItem) {
-		const includeItem = request.includeItem;
-		const predicate = (skill: SkillDefinition) =>
-			includeItem({
-				canonicalName: skill.name,
-				enabledByDefault: skill.enabledByDefault,
-			});
-		catalog.skills = catalog.skills.filter(predicate);
-		catalog.sharedSkills = catalog.sharedSkills.filter(predicate);
-		catalog.localSkills = catalog.localSkills.filter(predicate);
-		catalog.localEffectiveSkills = catalog.localEffectiveSkills.filter(predicate);
-	}
+	const includeItem = request.includeItem;
+	const predicate = (skill: SkillDefinition) =>
+		includeItem
+			? includeItem({
+					canonicalName: skill.name,
+					enabledByDefault: skill.enabledByDefault,
+				})
+			: skill.enabledByDefault;
+	catalog.skills = catalog.skills.filter(predicate);
+	catalog.sharedSkills = catalog.sharedSkills.filter(predicate);
+	catalog.localSkills = catalog.localSkills.filter(predicate);
+	catalog.localEffectiveSkills = catalog.localEffectiveSkills.filter(predicate);
 	const warnings = buildInvalidTargetWarnings(catalog.skills);
 	const allTargetIds = request.targets.map((target) => target.id);
 	const targetNames = new Set(skillTargets.map((target) => target.id));

--- a/src/lib/slash-commands/catalog.ts
+++ b/src/lib/slash-commands/catalog.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { normalizeName, readDirectoryStats } from "../catalog-utils.js";
+import { resolveFrontmatterEnabledByDefault } from "../frontmatter-enabled.js";
 import { resolveLocalPrecedence } from "../local-precedence.js";
 import {
 	buildSourceMetadata,
@@ -24,6 +25,7 @@ export type { FrontmatterValue } from "./frontmatter.js";
 
 export type SlashCommandDefinition = {
 	name: string;
+	enabledByDefault: boolean;
 	prompt: string;
 	sourcePath: string;
 	sourceType: SourceType;
@@ -81,6 +83,12 @@ async function buildCommandDefinition(options: {
 	if (!prompt.trim()) {
 		throw new Error(`Slash command "${options.commandName}" has an empty prompt.`);
 	}
+	const enabledByDefault = resolveFrontmatterEnabledByDefault({
+		frontmatter,
+		itemKind: "Slash command",
+		itemName: options.commandName,
+		sourcePath: options.filePath,
+	});
 
 	const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 	const { targets, invalidTargets } = resolveFrontmatterTargets(
@@ -112,6 +120,7 @@ async function buildCommandDefinition(options: {
 
 	return {
 		name: options.commandName,
+		enabledByDefault,
 		prompt,
 		sourcePath: options.filePath,
 		sourceType: metadata.sourceType,

--- a/src/lib/slash-commands/catalog.ts
+++ b/src/lib/slash-commands/catalog.ts
@@ -35,6 +35,7 @@ export type SlashCommandDefinition = {
 	targetAgents: TargetName[] | null;
 	invalidTargets: string[];
 	frontmatter: Record<string, FrontmatterValue>;
+	routingError?: string | null;
 };
 
 export type CommandCatalog = {
@@ -95,16 +96,15 @@ async function buildCommandDefinition(options: {
 		rawTargets,
 		options.resolveTargetName,
 	);
+	let routingError: string | null = null;
 	if (invalidTargets.length > 0) {
 		const invalidList = invalidTargets.join(", ");
-		throw new InvalidFrontmatterTargetsError(
-			`Slash command "${options.commandName}" has unsupported targets (${invalidList}) in ${options.filePath}.`,
-		);
+		routingError = `Slash command "${options.commandName}" has unsupported targets (${invalidList}) in ${options.filePath}.`;
+	} else if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
+		routingError = `Slash command "${options.commandName}" has empty targets in ${options.filePath}.`;
 	}
-	if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
-		throw new InvalidFrontmatterTargetsError(
-			`Slash command "${options.commandName}" has empty targets in ${options.filePath}.`,
-		);
+	if (enabledByDefault && routingError) {
+		throw new InvalidFrontmatterTargetsError(routingError);
 	}
 
 	let metadata: ReturnType<typeof buildSourceMetadata>;
@@ -130,14 +130,18 @@ async function buildCommandDefinition(options: {
 		targetAgents: targets,
 		invalidTargets,
 		frontmatter,
+		routingError,
 	};
 }
 
 export function assertSlashCommandDefinitionUsable(
-	command: Pick<SlashCommandDefinition, "name" | "prompt">,
+	command: Pick<SlashCommandDefinition, "name" | "prompt" | "routingError">,
 ): void {
 	if (!command.prompt.trim()) {
 		throw new Error(`Slash command "${command.name}" has an empty prompt.`);
+	}
+	if (command.routingError) {
+		throw new InvalidFrontmatterTargetsError(command.routingError);
 	}
 }
 

--- a/src/lib/slash-commands/catalog.ts
+++ b/src/lib/slash-commands/catalog.ts
@@ -80,9 +80,6 @@ async function buildCommandDefinition(options: {
 	const contents = await readFile(options.filePath, "utf8");
 	const { frontmatter, body } = extractFrontmatter(contents);
 	const prompt = body.trimEnd();
-	if (!prompt.trim()) {
-		throw new Error(`Slash command "${options.commandName}" has an empty prompt.`);
-	}
 	const enabledByDefault = resolveFrontmatterEnabledByDefault({
 		frontmatter,
 		itemKind: "Slash command",
@@ -131,6 +128,14 @@ async function buildCommandDefinition(options: {
 		invalidTargets,
 		frontmatter,
 	};
+}
+
+export function assertSlashCommandDefinitionUsable(
+	command: Pick<SlashCommandDefinition, "name" | "prompt">,
+): void {
+	if (!command.prompt.trim()) {
+		throw new Error(`Slash command "${command.name}" has an empty prompt.`);
+	}
 }
 
 function registerUniqueName(

--- a/src/lib/slash-commands/catalog.ts
+++ b/src/lib/slash-commands/catalog.ts
@@ -86,6 +86,9 @@ async function buildCommandDefinition(options: {
 		itemName: options.commandName,
 		sourcePath: options.filePath,
 	});
+	if (enabledByDefault && !prompt.trim()) {
+		throw new Error(`Slash command "${options.commandName}" has an empty prompt.`);
+	}
 
 	const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 	const { targets, invalidTargets } = resolveFrontmatterTargets(

--- a/src/lib/slash-commands/formatting.ts
+++ b/src/lib/slash-commands/formatting.ts
@@ -1,3 +1,4 @@
+import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../frontmatter-strip.js";
 import type { FrontmatterValue, SlashCommandDefinition } from "./catalog.js";
 
@@ -20,14 +21,12 @@ function formatYamlString(value: string): string {
 	return JSON.stringify(value);
 }
 
-const TARGET_FRONTMATTER_KEYS = new Set(["targets", "targetagents"]);
-
 function stripTargetMetadata(
 	frontmatter: Record<string, FrontmatterValue>,
 ): Record<string, FrontmatterValue> {
 	const filtered: Record<string, FrontmatterValue> = {};
 	for (const [key, value] of Object.entries(frontmatter)) {
-		if (TARGET_FRONTMATTER_KEYS.has(key.toLowerCase())) {
+		if (SYNC_ROUTING_FRONTMATTER_KEYS.has(key.toLowerCase())) {
 			continue;
 		}
 		filtered[key] = value;
@@ -100,10 +99,10 @@ function renderYamlFrontmatter(
 	return lines.join("\n");
 }
 
-const TOML_RESERVED_KEYS = new Set(["prompt", "targets", "targetagents"]);
+const TOML_RESERVED_KEYS = new Set(["prompt", ...SYNC_ROUTING_FRONTMATTER_KEYS]);
 
 export function renderMarkdownCommand(command: SlashCommandDefinition): string {
-	return stripFrontmatterFields(command.rawContents, TARGET_FRONTMATTER_KEYS);
+	return stripFrontmatterFields(command.rawContents, SYNC_ROUTING_FRONTMATTER_KEYS);
 }
 
 export function renderTomlCommand(command: SlashCommandDefinition): string {

--- a/src/lib/slash-commands/sync.ts
+++ b/src/lib/slash-commands/sync.ts
@@ -43,7 +43,11 @@ import {
 	evaluateTemplateScripts,
 	type TemplateScriptRuntime,
 } from "../template-scripts.js";
-import { loadCommandCatalog, type SlashCommandDefinition } from "./catalog.js";
+import {
+	assertSlashCommandDefinitionUsable,
+	loadCommandCatalog,
+	type SlashCommandDefinition,
+} from "./catalog.js";
 import { renderMarkdownCommand, renderSkillFromCommand, renderTomlCommand } from "./formatting.js";
 import { extractFrontmatter } from "./frontmatter.js";
 import {
@@ -74,6 +78,7 @@ export type SyncRequest = {
 	validAgents?: string[];
 	excludeLocal?: boolean;
 	templateScriptRuntime?: TemplateScriptRuntime;
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 export type SyncRequestV2 = {
@@ -1013,6 +1018,7 @@ export async function planSlashCommandSync(request: SyncRequest): Promise<SyncPl
 		agentsDir: request.agentsDir,
 		resolveTargetName,
 	});
+	filterCommandCatalog(catalog, request.includeItem);
 	const allTargetIds = resolvedTargets.map((target) => target.id);
 	const selectedTargets: ResolvedTarget[] =
 		request.targets && request.targets.length > 0
@@ -1029,6 +1035,13 @@ export async function planSlashCommandSync(request: SyncRequest): Promise<SyncPl
 				})
 			: resolvedTargets;
 	const selectedTargetIds = selectedTargets.map((target) => target.id);
+	assertUsableCommandsForTargets({
+		commands: catalog.commands,
+		activeTargetIds: new Set(selectedTargetIds),
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(resolvedTargets);
 	const conflictResolution = request.conflictResolution ?? DEFAULT_CONFLICT_RESOLUTION;
 	const removeMissing = request.removeMissing ?? true;
@@ -1311,6 +1324,55 @@ type CommandOutputCandidate = {
 	converter: ConverterRule | null;
 };
 
+function includeCommandByDefault(
+	command: SlashCommandDefinition,
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean,
+): boolean {
+	if (!includeItem) {
+		return command.enabledByDefault;
+	}
+	return includeItem({
+		canonicalName: command.name,
+		enabledByDefault: command.enabledByDefault,
+	});
+}
+
+function filterCommandCatalog(
+	catalog: Pick<
+		Awaited<ReturnType<typeof loadCommandCatalog>>,
+		"commands" | "sharedCommands" | "localCommands" | "localEffectiveCommands"
+	>,
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean,
+): void {
+	const predicate = (command: SlashCommandDefinition) =>
+		includeCommandByDefault(command, includeItem);
+	catalog.commands = catalog.commands.filter(predicate);
+	catalog.sharedCommands = catalog.sharedCommands.filter(predicate);
+	catalog.localCommands = catalog.localCommands.filter(predicate);
+	catalog.localEffectiveCommands = catalog.localEffectiveCommands.filter(predicate);
+}
+
+function assertUsableCommandsForTargets(options: {
+	commands: SlashCommandDefinition[];
+	activeTargetIds: Set<string>;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	allTargets: string[];
+}): void {
+	for (const command of options.commands) {
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: command.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		if (!effectiveTargets.some((targetId) => options.activeTargetIds.has(targetId))) {
+			continue;
+		}
+		assertSlashCommandDefinitionUsable(command);
+	}
+}
+
 function renderCommandOutput(
 	command: SlashCommandDefinition,
 	outputKind: "command" | "skill",
@@ -1349,18 +1411,7 @@ export async function syncSlashCommands(request: SyncRequestV2): Promise<SyncSum
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
-	if (request.includeItem) {
-		const includeItem = request.includeItem;
-		const predicate = (command: SlashCommandDefinition) =>
-			includeItem({
-				canonicalName: command.name,
-				enabledByDefault: command.enabledByDefault,
-			});
-		catalog.commands = catalog.commands.filter(predicate);
-		catalog.sharedCommands = catalog.sharedCommands.filter(predicate);
-		catalog.localCommands = catalog.localCommands.filter(predicate);
-		catalog.localEffectiveCommands = catalog.localEffectiveCommands.filter(predicate);
-	}
+	filterCommandCatalog(catalog, request.includeItem);
 	const targets = request.targets.filter(
 		(target) => normalizeCommandOutputDefinition(target.outputs.commands) !== null,
 	);
@@ -1382,6 +1433,13 @@ export async function syncSlashCommands(request: SyncRequestV2): Promise<SyncSum
 	const removeMissing = request.removeMissing ?? false;
 	const allTargetIds = request.targets.map((target) => target.id);
 	const activeTargetIds = new Set(targets.map((target) => target.id));
+	assertUsableCommandsForTargets({
+		commands: catalog.commands,
+		activeTargetIds,
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
 	const effectiveTargetsByCommand = new Map<SlashCommandDefinition, string[]>();
 	const activeSourcesByTarget = new Map<string, Set<string>>();
 	for (const command of catalog.commands) {

--- a/src/lib/slash-commands/sync.ts
+++ b/src/lib/slash-commands/sync.ts
@@ -90,7 +90,7 @@ export type SyncRequestV2 = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
-	includeItem?: (canonicalName: string) => boolean;
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 export type SyncPlanAction = {
@@ -1351,7 +1351,11 @@ export async function syncSlashCommands(request: SyncRequestV2): Promise<SyncSum
 	});
 	if (request.includeItem) {
 		const includeItem = request.includeItem;
-		const predicate = (command: SlashCommandDefinition) => includeItem(command.name);
+		const predicate = (command: SlashCommandDefinition) =>
+			includeItem({
+				canonicalName: command.name,
+				enabledByDefault: command.enabledByDefault,
+			});
 		catalog.commands = catalog.commands.filter(predicate);
 		catalog.sharedCommands = catalog.sharedCommands.filter(predicate);
 		catalog.localCommands = catalog.localCommands.filter(predicate);

--- a/src/lib/subagents/catalog.ts
+++ b/src/lib/subagents/catalog.ts
@@ -197,10 +197,6 @@ async function buildSubagentDefinition(options: {
 		throw new Error(`Invalid frontmatter in ${options.filePath}: ${message}`);
 	}
 
-	if (!body.trim()) {
-		throw new Error(`Subagent file has empty body: ${options.filePath}.`);
-	}
-
 	let resolvedName: string;
 	try {
 		resolvedName = resolveSubagentName(frontmatter, options.fileName);
@@ -257,6 +253,14 @@ async function buildSubagentDefinition(options: {
 		targetAgents: targets,
 		invalidTargets,
 	};
+}
+
+export function assertSubagentDefinitionUsable(
+	subagent: Pick<SubagentDefinition, "sourcePath" | "body">,
+): void {
+	if (!subagent.body.trim()) {
+		throw new Error(`Subagent file has empty body: ${subagent.sourcePath}.`);
+	}
 }
 
 function registerUniqueName(

--- a/src/lib/subagents/catalog.ts
+++ b/src/lib/subagents/catalog.ts
@@ -210,6 +210,9 @@ async function buildSubagentDefinition(options: {
 		itemName: resolvedName,
 		sourcePath: options.filePath,
 	});
+	if (enabledByDefault && !body.trim()) {
+		throw new Error(`Subagent file has empty body: ${options.filePath}.`);
+	}
 
 	const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 	const { targets, invalidTargets } = resolveFrontmatterTargets(

--- a/src/lib/subagents/catalog.ts
+++ b/src/lib/subagents/catalog.ts
@@ -35,6 +35,7 @@ export type SubagentDefinition = {
 	body: string;
 	targetAgents: SubagentTargetName[] | null;
 	invalidTargets: string[];
+	routingError?: string | null;
 };
 
 export type SubagentCatalog = {
@@ -219,16 +220,15 @@ async function buildSubagentDefinition(options: {
 		rawTargets,
 		options.resolveTargetName,
 	);
+	let routingError: string | null = null;
 	if (invalidTargets.length > 0) {
 		const invalidList = invalidTargets.join(", ");
-		throw new InvalidFrontmatterTargetsError(
-			`Subagent "${resolvedName}" has unsupported targets (${invalidList}) in ${options.filePath}.`,
-		);
+		routingError = `Subagent "${resolvedName}" has unsupported targets (${invalidList}) in ${options.filePath}.`;
+	} else if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
+		routingError = `Subagent "${resolvedName}" has empty targets in ${options.filePath}.`;
 	}
-	if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
-		throw new InvalidFrontmatterTargetsError(
-			`Subagent "${resolvedName}" has empty targets in ${options.filePath}.`,
-		);
+	if (enabledByDefault && routingError) {
+		throw new InvalidFrontmatterTargetsError(routingError);
 	}
 
 	let metadata: ReturnType<typeof buildSourceMetadata>;
@@ -255,14 +255,18 @@ async function buildSubagentDefinition(options: {
 		body,
 		targetAgents: targets,
 		invalidTargets,
+		routingError,
 	};
 }
 
 export function assertSubagentDefinitionUsable(
-	subagent: Pick<SubagentDefinition, "sourcePath" | "body">,
+	subagent: Pick<SubagentDefinition, "sourcePath" | "body" | "routingError">,
 ): void {
 	if (!subagent.body.trim()) {
 		throw new Error(`Subagent file has empty body: ${subagent.sourcePath}.`);
+	}
+	if (subagent.routingError) {
+		throw new InvalidFrontmatterTargetsError(subagent.routingError);
 	}
 }
 

--- a/src/lib/subagents/catalog.ts
+++ b/src/lib/subagents/catalog.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { normalizeName, readDirectoryStats } from "../catalog-utils.js";
+import { resolveFrontmatterEnabledByDefault } from "../frontmatter-enabled.js";
 import { resolveLocalPrecedence } from "../local-precedence.js";
 import {
 	buildSourceMetadata,
@@ -23,6 +24,7 @@ export type FrontmatterValue = string | string[];
 
 export type SubagentDefinition = {
 	resolvedName: string;
+	enabledByDefault: boolean;
 	sourcePath: string;
 	fileName: string;
 	sourceType: SourceType;
@@ -206,6 +208,12 @@ async function buildSubagentDefinition(options: {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new Error(`Invalid frontmatter in ${options.filePath}: ${message}`);
 	}
+	const enabledByDefault = resolveFrontmatterEnabledByDefault({
+		frontmatter,
+		itemKind: "Subagent",
+		itemName: resolvedName,
+		sourcePath: options.filePath,
+	});
 
 	const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 	const { targets, invalidTargets } = resolveFrontmatterTargets(
@@ -237,6 +245,7 @@ async function buildSubagentDefinition(options: {
 
 	return {
 		resolvedName,
+		enabledByDefault,
 		sourcePath: options.filePath,
 		fileName: options.fileName,
 		sourceType: metadata.sourceType,

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -683,6 +683,48 @@ async function resolveCanonicalSkillsForSubagentSync(options: {
 	});
 }
 
+export async function resolveShadowedSubagentNamesForTargets(options: {
+	repoRoot: string;
+	activeTargets: ResolvedTarget[];
+	allTargetIds: string[];
+	subagents: SubagentDefinition[];
+	agentsDir?: string | null;
+	includeLocalSkills?: boolean;
+	resolveTargetName?: (value: string) => string | null;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
+}): Promise<Map<string, Set<string>>> {
+	const activeTargetIds = new Set(options.activeTargets.map((target) => target.id));
+	const canonicalSkills = await resolveCanonicalSkillsForSubagentSync(options);
+	const shadowedSources: Map<string, Set<string>> = new Map();
+
+	for (const subagent of options.subagents) {
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: subagent.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargetIds,
+		});
+		for (const targetId of effectiveTargets) {
+			if (!activeTargetIds.has(targetId)) {
+				continue;
+			}
+			const canonicalSkillPath = getCanonicalSkillPath(
+				canonicalSkills,
+				targetId,
+				normalizeSkillKey(subagent.resolvedName),
+			);
+			if (!canonicalSkillPath) {
+				continue;
+			}
+			recordShadowedSubagentSource(shadowedSources, targetId, subagent.resolvedName);
+		}
+	}
+
+	return shadowedSources;
+}
+
 function areManagedSubagentsEqual(
 	left: Map<string, ManagedSubagent>,
 	right: Map<string, ManagedSubagent>,

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -173,6 +173,7 @@ type CanonicalSkillCandidate = {
 	relativePath: string;
 	sourcePath: string;
 };
+type ShadowedSubagentSources = Map<string, Set<string>>;
 
 type TargetPlan = {
 	targetName: SubagentTargetName;
@@ -450,28 +451,21 @@ async function loadCanonicalSkillIndex(
 		const skillName = resolveSkillName(frontmatter, fallbackName);
 		const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 		const { targets, invalidTargets } = resolveFrontmatterTargets(rawTargets, resolveTargetName);
-		if (invalidTargets.length > 0) {
-			const invalidList = invalidTargets.join(", ");
-			throw new InvalidFrontmatterTargetsError(
-				`Skill "${skillName}" has unsupported targets (${invalidList}) in ${skill.sourcePath}.`,
-			);
-		}
-		if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
-			throw new InvalidFrontmatterTargetsError(
-				`Skill "${skillName}" has empty targets in ${skill.sourcePath}.`,
-			);
-		}
-		const effectiveTargets = resolveEffectiveTargets({
-			defaultTargets: targets,
-			overrideOnly: options.overrideOnly ?? undefined,
-			overrideSkip: options.overrideSkip ?? undefined,
-			allTargets: options.allTargets,
-		});
-		const matchingTargets = targetFilter
-			? effectiveTargets.filter((targetId) => targetFilter.has(targetId))
-			: effectiveTargets;
-		if (matchingTargets.length === 0) {
-			continue;
+		const hasEmptyTargets = hasRawTargetValues(rawTargets) && (!targets || targets.length === 0);
+		let matchingTargets: string[] | null = null;
+		if (invalidTargets.length === 0 && !hasEmptyTargets) {
+			const effectiveTargets = resolveEffectiveTargets({
+				defaultTargets: targets,
+				overrideOnly: options.overrideOnly ?? undefined,
+				overrideSkip: options.overrideSkip ?? undefined,
+				allTargets: options.allTargets,
+			});
+			matchingTargets = targetFilter
+				? effectiveTargets.filter((targetId) => targetFilter.has(targetId))
+				: effectiveTargets;
+			if (matchingTargets.length === 0) {
+				continue;
+			}
 		}
 		const enabledByDefault = resolveFrontmatterEnabledByDefault({
 			frontmatter,
@@ -486,6 +480,20 @@ async function loadCanonicalSkillIndex(
 				includeSkill: options.includeSkill,
 			})
 		) {
+			continue;
+		}
+		if (invalidTargets.length > 0) {
+			const invalidList = invalidTargets.join(", ");
+			throw new InvalidFrontmatterTargetsError(
+				`Skill "${skillName}" has unsupported targets (${invalidList}) in ${skill.sourcePath}.`,
+			);
+		}
+		if (hasEmptyTargets) {
+			throw new InvalidFrontmatterTargetsError(
+				`Skill "${skillName}" has empty targets in ${skill.sourcePath}.`,
+			);
+		}
+		if (!matchingTargets || matchingTargets.length === 0) {
 			continue;
 		}
 		const skillKey = normalizeSkillKey(skill.relativePath);
@@ -546,6 +554,16 @@ function getCanonicalSkillPath(
 	skillKey: string,
 ): string | undefined {
 	return index.get(targetId)?.get(skillKey);
+}
+
+function recordShadowedSubagentSource(
+	shadowedSources: ShadowedSubagentSources,
+	targetId: string,
+	sourceId: string,
+): void {
+	const existing = shadowedSources.get(targetId) ?? new Set<string>();
+	existing.add(normalizeName(sourceId));
+	shadowedSources.set(targetId, existing);
 }
 
 function includeSubagentByDefault(
@@ -1385,6 +1403,7 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	const managedManifest = (await readManagedOutputs(request.repoRoot, homeDir)) ?? { entries: [] };
 	const nextManaged = new Map<string, ManagedOutputRecord>();
 	const activeOutputPaths = new Set<string>();
+	const shadowedSubagentSources: ShadowedSubagentSources = new Map();
 	const countsByTarget = new Map<string, SummaryCounts>();
 	const getCounts = (targetId: string): SummaryCounts => {
 		const existing = countsByTarget.get(targetId) ?? emptySummaryCounts();
@@ -1493,6 +1512,7 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 					canonicalSkillKey,
 				);
 				if (canonicalSkillPath) {
+					recordShadowedSubagentSource(shadowedSubagentSources, target.id, subagent.resolvedName);
 					warnings.push(
 						`Skipped ${target.displayName} skill "${subagent.resolvedName}" because canonical skill exists at ${canonicalSkillPath}.`,
 					);
@@ -1707,6 +1727,36 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 			}
 			const key = buildManagedOutputKey(entry);
 			if (nextManaged.has(key)) {
+				continue;
+			}
+			const canonicalSkillPath = getCanonicalSkillPath(
+				canonicalSkills,
+				entry.targetId,
+				normalizeSkillKey(entry.sourceId),
+			);
+			const skillDef = skillDefs.get(entry.targetId);
+			if (canonicalSkillPath && skillDef) {
+				const expectedSkillOutputPath = resolveOutputPath({
+					template: skillDef.path,
+					context: {
+						repoRoot: request.repoRoot,
+						agentsDir: agentsDirPath,
+						homeDir,
+						targetId: entry.targetId,
+						itemName: entry.sourceId,
+					},
+					item: { name: entry.sourceId },
+					baseDir: request.repoRoot,
+				});
+				if (
+					normalizeManagedOutputPath(expectedSkillOutputPath) ===
+					normalizeManagedOutputPath(entry.outputPath)
+				) {
+					continue;
+				}
+			}
+			const shadowedSources = shadowedSubagentSources.get(entry.targetId);
+			if (shadowedSources?.has(normalizeName(entry.sourceId))) {
 				continue;
 			}
 			const activeSources = activeSourcesByTarget.get(entry.targetId);

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -536,6 +536,7 @@ async function collectManagedCanonicalSkillKeys(options: {
 }): Promise<Set<string>> {
 	const managed = new Set<string>();
 	const homeDir = os.homedir();
+	const targetIds = new Set(options.targetIds);
 	for (const targetId of options.targetIds) {
 		const manifest = await readManifest(resolveManifestPath(options.repoRoot, targetId, homeDir));
 		if (!manifest || manifest.targetName !== targetId) {
@@ -544,6 +545,13 @@ async function collectManagedCanonicalSkillKeys(options: {
 		for (const entry of manifest.managedSubagents) {
 			managed.add(normalizeSkillKey(entry.name));
 		}
+	}
+	const managedOutputs = await readManagedOutputs(options.repoRoot, homeDir);
+	for (const entry of managedOutputs?.entries ?? []) {
+		if (entry.sourceType !== "subagent" || !targetIds.has(entry.targetId)) {
+			continue;
+		}
+		managed.add(normalizeSkillKey(entry.sourceId));
 	}
 	return managed;
 }
@@ -624,6 +632,55 @@ function targetRequiresCanonicalSkillLookup(target: ResolvedTarget): boolean {
 		return false;
 	}
 	return normalizeOutputDefinition(target.outputs.skills) !== null;
+}
+
+async function resolveCanonicalSkillsForSubagentSync(options: {
+	repoRoot: string;
+	activeTargets: ResolvedTarget[];
+	allTargetIds: string[];
+	subagents: SubagentDefinition[];
+	agentsDir?: string | null;
+	includeLocalSkills?: boolean;
+	resolveTargetName?: (value: string) => string | null;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
+}): Promise<CanonicalSkillIndex> {
+	const targetIds = options.activeTargets
+		.filter(targetRequiresCanonicalSkillLookup)
+		.map((target) => target.id);
+	if (targetIds.length === 0) {
+		return new Map();
+	}
+
+	const relevantCanonicalSkillKeys = collectRelevantCanonicalSkillKeys({
+		subagents: options.subagents,
+		activeTargetIds: new Set(targetIds),
+		overrideOnly: options.overrideOnly,
+		overrideSkip: options.overrideSkip,
+		allTargets: options.allTargetIds,
+	});
+	for (const skillKey of await collectManagedCanonicalSkillKeys({
+		repoRoot: options.repoRoot,
+		targetIds,
+	})) {
+		relevantCanonicalSkillKeys.add(skillKey);
+	}
+	if (relevantCanonicalSkillKeys.size === 0) {
+		return new Map();
+	}
+
+	return loadCanonicalSkillIndex(options.repoRoot, {
+		includeLocal: options.includeLocalSkills ?? true,
+		agentsDir: options.agentsDir,
+		resolveTargetName: options.resolveTargetName,
+		overrideOnly: options.overrideOnly ?? null,
+		overrideSkip: options.overrideSkip ?? null,
+		allTargets: options.allTargetIds,
+		targetIds,
+		skillKeys: relevantCanonicalSkillKeys,
+		includeSkill: options.includeSkill,
+	});
 }
 
 function areManagedSubagentsEqual(
@@ -1071,36 +1128,18 @@ export async function planSubagentSync(
 		overrideSkip: request.overrideSkip,
 		allTargets: allTargetIds,
 	});
-	const targetsRequiringCanonicalSkills = selectedTargets
-		.filter(targetRequiresCanonicalSkillLookup)
-		.map((target) => target.id);
-	const relevantCanonicalSkillKeys = collectRelevantCanonicalSkillKeys({
+	const canonicalSkills = await resolveCanonicalSkillsForSubagentSync({
+		repoRoot: request.repoRoot,
+		activeTargets: selectedTargets,
+		allTargetIds,
 		subagents: catalog.subagents,
-		activeTargetIds: new Set(targetsRequiringCanonicalSkills),
+		agentsDir: request.agentsDir,
+		includeLocalSkills: request.includeLocalSkills,
+		resolveTargetName,
 		overrideOnly: request.overrideOnly,
 		overrideSkip: request.overrideSkip,
-		allTargets: allTargetIds,
+		includeSkill: request.includeSkill,
 	});
-	for (const skillKey of await collectManagedCanonicalSkillKeys({
-		repoRoot: request.repoRoot,
-		targetIds: targetsRequiringCanonicalSkills,
-	})) {
-		relevantCanonicalSkillKeys.add(skillKey);
-	}
-	const canonicalSkills =
-		targetsRequiringCanonicalSkills.length === 0 || relevantCanonicalSkillKeys.size === 0
-			? new Map()
-			: await loadCanonicalSkillIndex(request.repoRoot, {
-					includeLocal: request.includeLocalSkills ?? true,
-					agentsDir: request.agentsDir,
-					resolveTargetName,
-					overrideOnly: request.overrideOnly ?? null,
-					overrideSkip: request.overrideSkip ?? null,
-					allTargets: allTargetIds,
-					targetIds: targetsRequiringCanonicalSkills,
-					skillKeys: relevantCanonicalSkillKeys,
-					includeSkill: request.includeSkill,
-				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(resolvedTargets);
 	const removeMissing = request.removeMissing ?? true;
 	const timestamp = new Date().toISOString();
@@ -1414,30 +1453,18 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	const writerRegistry: WriterRegistry = new Map([
 		[defaultSubagentWriter.id, defaultSubagentWriter],
 	]);
-	const targetsRequiringCanonicalSkills = targets
-		.filter(targetRequiresCanonicalSkillLookup)
-		.map((target) => target.id);
-	const relevantCanonicalSkillKeys = collectRelevantCanonicalSkillKeys({
+	const canonicalSkills = await resolveCanonicalSkillsForSubagentSync({
+		repoRoot: request.repoRoot,
+		activeTargets: targets,
+		allTargetIds,
 		subagents: catalog.subagents,
-		activeTargetIds: new Set(targetsRequiringCanonicalSkills),
+		agentsDir: request.agentsDir,
+		includeLocalSkills: request.includeLocalSkills,
+		resolveTargetName: request.resolveTargetName,
 		overrideOnly: request.overrideOnly,
 		overrideSkip: request.overrideSkip,
-		allTargets: allTargetIds,
+		includeSkill: request.includeSkill,
 	});
-	const canonicalSkills =
-		targetsRequiringCanonicalSkills.length === 0 || relevantCanonicalSkillKeys.size === 0
-			? new Map()
-			: await loadCanonicalSkillIndex(request.repoRoot, {
-					includeLocal: request.includeLocalSkills ?? true,
-					agentsDir: request.agentsDir,
-					resolveTargetName: request.resolveTargetName,
-					overrideOnly: request.overrideOnly ?? null,
-					overrideSkip: request.overrideSkip ?? null,
-					allTargets: allTargetIds,
-					targetIds: targetsRequiringCanonicalSkills,
-					skillKeys: relevantCanonicalSkillKeys,
-					includeSkill: request.includeSkill,
-				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(request.targets);
 
 	const outputDefs = new Map<string, NonNullable<ReturnType<typeof normalizeOutputDefinition>>>();

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { applyAgentTemplating } from "../agent-templating.js";
 import { resolveAgentsDirPath } from "../agents-dir.js";
 import { listSkillDirectories, normalizeName, type SkillDirectoryEntry } from "../catalog-utils.js";
+import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../frontmatter-strip.js";
 import {
 	resolveLocalCategoryRoot,
@@ -89,7 +90,7 @@ export type SubagentSyncRequestV2 = {
 	resolveTargetName?: (value: string) => string | null;
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
-	includeItem?: (canonicalName: string) => boolean;
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 export type SubagentSyncPlanAction = {
@@ -164,9 +165,8 @@ type TargetPlan = {
 	removeMissing: boolean;
 };
 
-const TARGET_FRONTMATTER_KEYS = new Set(["targets", "targetagents"]);
 const SKILL_FRONTMATTER_KEYS_TO_REMOVE = new Set([
-	...TARGET_FRONTMATTER_KEYS,
+	...SYNC_ROUTING_FRONTMATTER_KEYS,
 	"tools",
 	"model",
 	"color",
@@ -604,7 +604,7 @@ async function buildTargetPlan(
 		const output =
 			outputKind === "skill"
 				? stripFrontmatterFields(templatedContents, SKILL_FRONTMATTER_KEYS_TO_REMOVE)
-				: stripFrontmatterFields(templatedContents, TARGET_FRONTMATTER_KEYS);
+				: stripFrontmatterFields(templatedContents, SYNC_ROUTING_FRONTMATTER_KEYS);
 		const outputHash = hashContent(output);
 		const { destinationPath } = resolveOutputPaths(
 			outputKind,
@@ -1028,7 +1028,11 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	});
 	if (request.includeItem) {
 		const includeItem = request.includeItem;
-		const predicate = (subagent: SubagentDefinition) => includeItem(subagent.resolvedName);
+		const predicate = (subagent: SubagentDefinition) =>
+			includeItem({
+				canonicalName: subagent.resolvedName,
+				enabledByDefault: subagent.enabledByDefault,
+			});
 		catalog.subagents = catalog.subagents.filter(predicate);
 		catalog.sharedSubagents = catalog.sharedSubagents.filter(predicate);
 		catalog.localSubagents = catalog.localSubagents.filter(predicate);

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -4,14 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { applyAgentTemplating } from "../agent-templating.js";
 import { resolveAgentsDirPath } from "../agents-dir.js";
-import { listSkillDirectories, normalizeName, type SkillDirectoryEntry } from "../catalog-utils.js";
+import { normalizeName } from "../catalog-utils.js";
 import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../frontmatter-strip.js";
-import {
-	resolveLocalCategoryRoot,
-	resolveSharedCategoryRoot,
-	stripLocalPathSuffix,
-} from "../local-sources.js";
+import { loadSkillCatalog } from "../skills/catalog.js";
 import { buildSupportedAgentNames } from "../supported-targets.js";
 import type { SyncSourceCounts } from "../sync-results.js";
 import { createTargetNameResolver, resolveEffectiveTargets } from "../sync-targets.js";
@@ -74,6 +70,7 @@ export type SubagentSyncRequest = {
 	validAgents?: string[];
 	excludeLocal?: boolean;
 	includeLocalSkills?: boolean;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 	templateScriptRuntime?: TemplateScriptRuntime;
 };
 
@@ -91,6 +88,7 @@ export type SubagentSyncRequestV2 = {
 	hooks?: SyncHooks;
 	templateScriptRuntime?: TemplateScriptRuntime;
 	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 export type SubagentSyncPlanAction = {
@@ -150,6 +148,7 @@ export type SubagentSyncSummary = {
 };
 
 type OutputKind = "subagent" | "skill";
+type CanonicalSkillIndex = Map<string, Map<string, string>>;
 
 type TargetPlan = {
 	targetName: SubagentTargetName;
@@ -184,14 +183,18 @@ function normalizeSkillKey(name: string): string {
 	return path.normalize(name).replace(/\\/g, "/").toLowerCase();
 }
 
-function normalizeSkillRelativePath(relativePath: string): string {
-	if (!relativePath) {
-		return relativePath;
+function includeCanonicalSkill(options: {
+	canonicalName: string;
+	enabledByDefault: boolean;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
+}): boolean {
+	if (!options.includeSkill) {
+		return options.enabledByDefault;
 	}
-	const baseName = path.basename(relativePath);
-	const { baseName: strippedBase } = stripLocalPathSuffix(baseName);
-	const parent = path.dirname(relativePath);
-	return parent === "." ? strippedBase : path.join(parent, strippedBase);
+	return options.includeSkill({
+		canonicalName: options.canonicalName,
+		enabledByDefault: options.enabledByDefault,
+	});
 }
 
 function formatDisplayPath(repoRoot: string, absolutePath: string): string {
@@ -277,81 +280,65 @@ function buildSourceCounts(
 type CanonicalSkillIndexOptions = {
 	includeLocal?: boolean;
 	agentsDir?: string | null;
+	resolveTargetName?: (value: string) => string | null;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	allTargets: string[];
+	targetIds?: Iterable<string>;
+	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
 
 async function loadCanonicalSkillIndex(
 	repoRoot: string,
-	options: CanonicalSkillIndexOptions = {},
-): Promise<Map<string, string>> {
-	const includeLocal = options.includeLocal ?? true;
-	const skillsRoot = resolveSharedCategoryRoot(repoRoot, "skills", options.agentsDir);
-	const localSkillsRoot = resolveLocalCategoryRoot(repoRoot, "skills", options.agentsDir);
-	let directories: SkillDirectoryEntry[] = [];
-	try {
-		directories = await listSkillDirectories(skillsRoot);
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code;
-		if (code !== "ENOENT" && code !== "ENOTDIR") {
-			throw error;
-		}
-	}
+	options: CanonicalSkillIndexOptions,
+): Promise<CanonicalSkillIndex> {
+	const catalog = await loadSkillCatalog(repoRoot, {
+		includeLocal: options.includeLocal ?? true,
+		agentsDir: options.agentsDir,
+		resolveTargetName: options.resolveTargetName,
+	});
+	const targetFilter = options.targetIds ? new Set(options.targetIds) : null;
+	const index: CanonicalSkillIndex = new Map();
 
-	const index = new Map<string, string>();
-	const addEntry = (relativePath: string, skillPath: string) => {
-		if (!relativePath) {
-			return;
-		}
-		const normalized = normalizeSkillKey(normalizeSkillRelativePath(relativePath));
-		index.set(normalized, skillPath);
-	};
-
-	for (const entry of directories) {
-		const relative = path.relative(skillsRoot, entry.directoryPath);
-		if (!relative) {
+	for (const skill of catalog.skills) {
+		if (
+			!includeCanonicalSkill({
+				canonicalName: skill.name,
+				enabledByDefault: skill.enabledByDefault,
+				includeSkill: options.includeSkill,
+			})
+		) {
 			continue;
 		}
-		const isLocalDir = stripLocalPathSuffix(path.basename(entry.directoryPath)).hadLocalSuffix;
-		if (!isLocalDir && entry.sharedSkillFile) {
-			addEntry(relative, path.join(entry.directoryPath, entry.sharedSkillFile));
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: skill.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		if (effectiveTargets.length === 0) {
+			continue;
 		}
-		if (includeLocal) {
-			if (isLocalDir) {
-				const skillFileName = entry.localSkillFile ?? entry.sharedSkillFile;
-				if (skillFileName) {
-					addEntry(relative, path.join(entry.directoryPath, skillFileName));
-				}
-			} else if (entry.localSkillFile) {
-				addEntry(relative, path.join(entry.directoryPath, entry.localSkillFile));
-			}
-		}
-	}
-
-	if (includeLocal) {
-		let localDirectories: SkillDirectoryEntry[] = [];
-		try {
-			localDirectories = await listSkillDirectories(localSkillsRoot);
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			if (code === "ENOENT" || code === "ENOTDIR") {
-				return index;
-			}
-			throw error;
-		}
-
-		for (const entry of localDirectories) {
-			const relative = path.relative(localSkillsRoot, entry.directoryPath);
-			if (!relative) {
+		const skillKey = normalizeSkillKey(skill.relativePath);
+		for (const targetId of effectiveTargets) {
+			if (targetFilter && !targetFilter.has(targetId)) {
 				continue;
 			}
-			const skillFileName = entry.sharedSkillFile ?? entry.localSkillFile;
-			if (!skillFileName) {
-				continue;
-			}
-			addEntry(relative, path.join(entry.directoryPath, skillFileName));
+			const targetSkills = index.get(targetId) ?? new Map<string, string>();
+			targetSkills.set(skillKey, skill.sourcePath);
+			index.set(targetId, targetSkills);
 		}
 	}
 
 	return index;
+}
+
+function getCanonicalSkillPath(
+	index: CanonicalSkillIndex,
+	targetId: string,
+	skillKey: string,
+): string | undefined {
+	return index.get(targetId)?.get(skillKey);
 }
 
 function areManagedSubagentsEqual(
@@ -456,7 +443,7 @@ async function buildTargetPlan(
 		subagents: SubagentDefinition[];
 		removeMissing: boolean;
 		timestamp: string;
-		canonicalSkills: Map<string, string>;
+		canonicalSkills: CanonicalSkillIndex;
 		validAgents: string[];
 		allTargets: string[];
 	},
@@ -564,7 +551,9 @@ async function buildTargetPlan(
 		catalogNames.add(nameKey);
 		const canonicalSkillKey =
 			outputKind === "skill" ? normalizeSkillKey(subagent.resolvedName) : null;
-		const canonicalSkillPath = canonicalSkillKey && params.canonicalSkills.get(canonicalSkillKey);
+		const canonicalSkillPath =
+			canonicalSkillKey &&
+			getCanonicalSkillPath(params.canonicalSkills, targetName, canonicalSkillKey);
 		if (outputKind === "skill" && canonicalSkillPath) {
 			const { destinationPath } = resolveOutputPaths(
 				outputKind,
@@ -702,7 +691,11 @@ async function buildTargetPlan(
 					: path.join(destinationDir, removalBase);
 			if (outputKind === "skill") {
 				const canonicalSkillKey = normalizeSkillKey(entry.name);
-				const canonicalSkillPath = params.canonicalSkills.get(canonicalSkillKey);
+				const canonicalSkillPath = getCanonicalSkillPath(
+					params.canonicalSkills,
+					targetName,
+					canonicalSkillKey,
+				);
 				if (canonicalSkillPath) {
 					actions.push({
 						targetName,
@@ -769,10 +762,6 @@ export async function planSubagentSync(
 		agentsDir: request.agentsDir,
 		resolveTargetName,
 	});
-	const canonicalSkills = await loadCanonicalSkillIndex(request.repoRoot, {
-		includeLocal: request.includeLocalSkills ?? true,
-		agentsDir: request.agentsDir,
-	});
 	const allTargetIds = resolvedTargets.map((target) => target.id);
 	const selectedTargets: ResolvedTarget[] =
 		request.targets && request.targets.length > 0
@@ -789,6 +778,16 @@ export async function planSubagentSync(
 				})
 			: resolvedTargets;
 	const selectedTargetIds = selectedTargets.map((target) => target.id);
+	const canonicalSkills = await loadCanonicalSkillIndex(request.repoRoot, {
+		includeLocal: request.includeLocalSkills ?? true,
+		agentsDir: request.agentsDir,
+		resolveTargetName,
+		overrideOnly: request.overrideOnly ?? null,
+		overrideSkip: request.overrideSkip ?? null,
+		allTargets: allTargetIds,
+		targetIds: selectedTargetIds,
+		includeSkill: request.includeSkill,
+	});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(resolvedTargets);
 	const removeMissing = request.removeMissing ?? true;
 	const timestamp = new Date().toISOString();
@@ -1108,6 +1107,12 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	const canonicalSkills = await loadCanonicalSkillIndex(request.repoRoot, {
 		includeLocal: request.includeLocalSkills ?? true,
 		agentsDir: request.agentsDir,
+		resolveTargetName: request.resolveTargetName,
+		overrideOnly: request.overrideOnly ?? null,
+		overrideSkip: request.overrideSkip ?? null,
+		allTargets: allTargetIds,
+		targetIds: activeTargetIds,
+		includeSkill: request.includeSkill,
 	});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(request.targets);
 
@@ -1177,7 +1182,11 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 
 			if (outputKind === "skill") {
 				const canonicalSkillKey = normalizeSkillKey(subagent.resolvedName);
-				const canonicalSkillPath = canonicalSkills.get(canonicalSkillKey);
+				const canonicalSkillPath = getCanonicalSkillPath(
+					canonicalSkills,
+					target.id,
+					canonicalSkillKey,
+				);
 				if (canonicalSkillPath) {
 					warnings.push(
 						`Skipped ${target.displayName} skill "${subagent.resolvedName}" because canonical skill exists at ${canonicalSkillPath}.`,

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -4,13 +4,28 @@ import os from "node:os";
 import path from "node:path";
 import { applyAgentTemplating } from "../agent-templating.js";
 import { resolveAgentsDirPath } from "../agents-dir.js";
-import { normalizeName } from "../catalog-utils.js";
-import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../frontmatter-enabled.js";
+import { listSkillDirectories, normalizeName, readDirectoryStats } from "../catalog-utils.js";
+import {
+	resolveFrontmatterEnabledByDefault,
+	SYNC_ROUTING_FRONTMATTER_KEYS,
+} from "../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../frontmatter-strip.js";
-import { loadSkillCatalog } from "../skills/catalog.js";
+import { resolveLocalPrecedence } from "../local-precedence.js";
+import {
+	resolveLocalCategoryRoot,
+	resolveSharedCategoryRoot,
+	stripLocalPathSuffix,
+} from "../local-sources.js";
+import { extractFrontmatter, type FrontmatterValue } from "../slash-commands/frontmatter.js";
 import { buildSupportedAgentNames } from "../supported-targets.js";
 import type { SyncSourceCounts } from "../sync-results.js";
-import { createTargetNameResolver, resolveEffectiveTargets } from "../sync-targets.js";
+import {
+	createTargetNameResolver,
+	hasRawTargetValues,
+	InvalidFrontmatterTargetsError,
+	resolveEffectiveTargets,
+	resolveFrontmatterTargets,
+} from "../sync-targets.js";
 import { BUILTIN_TARGETS } from "../targets/builtins.js";
 import type {
 	ConverterRule,
@@ -154,6 +169,10 @@ export type SubagentSyncSummary = {
 
 type OutputKind = "subagent" | "skill";
 type CanonicalSkillIndex = Map<string, Map<string, string>>;
+type CanonicalSkillCandidate = {
+	relativePath: string;
+	sourcePath: string;
+};
 
 type TargetPlan = {
 	targetName: SubagentTargetName;
@@ -290,45 +309,187 @@ type CanonicalSkillIndexOptions = {
 	overrideSkip?: string[] | null;
 	allTargets: string[];
 	targetIds?: Iterable<string>;
+	skillKeys?: Iterable<string>;
 	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 };
+
+function resolveSkillRelativePath(
+	skillsRoot: string,
+	directoryPath: string,
+): { relativePath: string; hadLocalSuffix: boolean } {
+	const relativePath = path.relative(skillsRoot, directoryPath);
+	if (!relativePath) {
+		return { relativePath, hadLocalSuffix: false };
+	}
+	const baseName = path.basename(relativePath);
+	const { baseName: strippedBase, hadLocalSuffix } = stripLocalPathSuffix(baseName);
+	if (!hadLocalSuffix) {
+		return { relativePath, hadLocalSuffix: false };
+	}
+	const parent = path.dirname(relativePath);
+	const normalized = parent === "." ? strippedBase : path.join(parent, strippedBase);
+	return { relativePath: normalized, hadLocalSuffix: true };
+}
+
+function resolveSkillName(frontmatter: Record<string, FrontmatterValue>, fallback: string): string {
+	const rawName = frontmatter.name;
+	if (typeof rawName === "string") {
+		const trimmed = rawName.trim();
+		if (trimmed) {
+			return trimmed;
+		}
+	}
+	return fallback;
+}
+
+function shouldIncludeCanonicalSkillRelativePath(
+	relativePath: string,
+	skillKeyFilter: Set<string> | null,
+): boolean {
+	if (!skillKeyFilter) {
+		return true;
+	}
+	return skillKeyFilter.has(normalizeSkillKey(relativePath));
+}
 
 async function loadCanonicalSkillIndex(
 	repoRoot: string,
 	options: CanonicalSkillIndexOptions,
 ): Promise<CanonicalSkillIndex> {
-	const catalog = await loadSkillCatalog(repoRoot, {
-		includeLocal: options.includeLocal ?? true,
-		agentsDir: options.agentsDir,
-		resolveTargetName: options.resolveTargetName,
-	});
+	const includeLocal = options.includeLocal ?? true;
+	const fallbackResolver = createTargetNameResolver(BUILTIN_TARGETS).resolveTargetName;
+	const resolveTargetName = options.resolveTargetName ?? fallbackResolver;
+	const skillsRoot = resolveSharedCategoryRoot(repoRoot, "skills", options.agentsDir);
+	const localSkillsRoot = resolveLocalCategoryRoot(repoRoot, "skills", options.agentsDir);
 	const targetFilter = options.targetIds ? new Set(options.targetIds) : null;
+	const skillKeyFilter = options.skillKeys ? new Set(options.skillKeys) : null;
 	const index: CanonicalSkillIndex = new Map();
+	const sharedStats = await readDirectoryStats(skillsRoot);
+	if (sharedStats && !sharedStats.isDirectory()) {
+		throw new Error(`Skills root is not a directory: ${skillsRoot}.`);
+	}
+	const localStats = includeLocal ? await readDirectoryStats(localSkillsRoot) : null;
+	if (localStats && !localStats.isDirectory()) {
+		throw new Error(`Local skills root is not a directory: ${localSkillsRoot}.`);
+	}
+	const sharedEntries = sharedStats ? await listSkillDirectories(skillsRoot) : [];
+	const localEntries = localStats ? await listSkillDirectories(localSkillsRoot) : [];
 
-	for (const skill of catalog.skills) {
+	const sharedSkills: CanonicalSkillCandidate[] = [];
+	const localPathSkills: CanonicalSkillCandidate[] = [];
+	const localSuffixSkills: CanonicalSkillCandidate[] = [];
+
+	for (const entry of sharedEntries) {
+		const { relativePath, hadLocalSuffix } = resolveSkillRelativePath(
+			skillsRoot,
+			entry.directoryPath,
+		);
+		if (!shouldIncludeCanonicalSkillRelativePath(relativePath, skillKeyFilter)) {
+			continue;
+		}
+		if (hadLocalSuffix) {
+			if (!includeLocal) {
+				continue;
+			}
+			const skillFileName = entry.localSkillFile ?? entry.sharedSkillFile;
+			if (!skillFileName) {
+				continue;
+			}
+			localSuffixSkills.push({
+				relativePath,
+				sourcePath: path.join(entry.directoryPath, skillFileName),
+			});
+			continue;
+		}
+		if (entry.sharedSkillFile) {
+			sharedSkills.push({
+				relativePath,
+				sourcePath: path.join(entry.directoryPath, entry.sharedSkillFile),
+			});
+		}
+		if (includeLocal && entry.localSkillFile) {
+			localSuffixSkills.push({
+				relativePath,
+				sourcePath: path.join(entry.directoryPath, entry.localSkillFile),
+			});
+		}
+	}
+
+	if (includeLocal) {
+		for (const entry of localEntries) {
+			const skillFileName = entry.sharedSkillFile ?? entry.localSkillFile;
+			if (!skillFileName) {
+				continue;
+			}
+			const { relativePath } = resolveSkillRelativePath(localSkillsRoot, entry.directoryPath);
+			if (!shouldIncludeCanonicalSkillRelativePath(relativePath, skillKeyFilter)) {
+				continue;
+			}
+			localPathSkills.push({
+				relativePath,
+				sourcePath: path.join(entry.directoryPath, skillFileName),
+			});
+		}
+	}
+
+	const { localEffective: localEffectiveSkills, sharedEffective: sharedEffectiveSkills } =
+		resolveLocalPrecedence({
+			shared: sharedSkills,
+			localPath: localPathSkills,
+			localSuffix: localSuffixSkills,
+			key: (skill) => normalizeSkillKey(skill.relativePath),
+		});
+	const effectiveSkills = includeLocal
+		? [...sharedEffectiveSkills, ...localEffectiveSkills]
+		: sharedSkills;
+
+	for (const skill of effectiveSkills) {
+		const rawContents = await readFile(skill.sourcePath, "utf8");
+		const { frontmatter } = extractFrontmatter(rawContents);
+		const fallbackName = skill.relativePath || path.basename(path.dirname(skill.sourcePath));
+		const skillName = resolveSkillName(frontmatter, fallbackName);
+		const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
+		const { targets, invalidTargets } = resolveFrontmatterTargets(rawTargets, resolveTargetName);
+		if (invalidTargets.length > 0) {
+			const invalidList = invalidTargets.join(", ");
+			throw new InvalidFrontmatterTargetsError(
+				`Skill "${skillName}" has unsupported targets (${invalidList}) in ${skill.sourcePath}.`,
+			);
+		}
+		if (hasRawTargetValues(rawTargets) && (!targets || targets.length === 0)) {
+			throw new InvalidFrontmatterTargetsError(
+				`Skill "${skillName}" has empty targets in ${skill.sourcePath}.`,
+			);
+		}
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: targets,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		const matchingTargets = targetFilter
+			? effectiveTargets.filter((targetId) => targetFilter.has(targetId))
+			: effectiveTargets;
+		if (matchingTargets.length === 0) {
+			continue;
+		}
+		const enabledByDefault = resolveFrontmatterEnabledByDefault({
+			frontmatter,
+			itemKind: "Skill",
+			itemName: skillName,
+			sourcePath: skill.sourcePath,
+		});
 		if (
 			!includeCanonicalSkill({
-				canonicalName: skill.name,
-				enabledByDefault: skill.enabledByDefault,
+				canonicalName: skillName,
+				enabledByDefault,
 				includeSkill: options.includeSkill,
 			})
 		) {
 			continue;
 		}
-		const effectiveTargets = resolveEffectiveTargets({
-			defaultTargets: skill.targetAgents,
-			overrideOnly: options.overrideOnly ?? undefined,
-			overrideSkip: options.overrideSkip ?? undefined,
-			allTargets: options.allTargets,
-		});
-		if (effectiveTargets.length === 0) {
-			continue;
-		}
 		const skillKey = normalizeSkillKey(skill.relativePath);
-		for (const targetId of effectiveTargets) {
-			if (targetFilter && !targetFilter.has(targetId)) {
-				continue;
-			}
+		for (const targetId of matchingTargets) {
 			const targetSkills = index.get(targetId) ?? new Map<string, string>();
 			targetSkills.set(skillKey, skill.sourcePath);
 			index.set(targetId, targetSkills);
@@ -336,6 +497,47 @@ async function loadCanonicalSkillIndex(
 	}
 
 	return index;
+}
+
+function collectRelevantCanonicalSkillKeys(options: {
+	subagents: SubagentDefinition[];
+	activeTargetIds: Set<string>;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	allTargets: string[];
+}): Set<string> {
+	const relevant = new Set<string>();
+	for (const subagent of options.subagents) {
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: subagent.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		if (!effectiveTargets.some((targetId) => options.activeTargetIds.has(targetId))) {
+			continue;
+		}
+		relevant.add(normalizeSkillKey(subagent.resolvedName));
+	}
+	return relevant;
+}
+
+async function collectManagedCanonicalSkillKeys(options: {
+	repoRoot: string;
+	targetIds: string[];
+}): Promise<Set<string>> {
+	const managed = new Set<string>();
+	const homeDir = os.homedir();
+	for (const targetId of options.targetIds) {
+		const manifest = await readManifest(resolveManifestPath(options.repoRoot, targetId, homeDir));
+		if (!manifest || manifest.targetName !== targetId) {
+			continue;
+		}
+		for (const entry of manifest.managedSubagents) {
+			managed.add(normalizeSkillKey(entry.name));
+		}
+	}
+	return managed;
 }
 
 function getCanonicalSkillPath(
@@ -854,8 +1056,21 @@ export async function planSubagentSync(
 	const targetsRequiringCanonicalSkills = selectedTargets
 		.filter(targetRequiresCanonicalSkillLookup)
 		.map((target) => target.id);
+	const relevantCanonicalSkillKeys = collectRelevantCanonicalSkillKeys({
+		subagents: catalog.subagents,
+		activeTargetIds: new Set(targetsRequiringCanonicalSkills),
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
+	for (const skillKey of await collectManagedCanonicalSkillKeys({
+		repoRoot: request.repoRoot,
+		targetIds: targetsRequiringCanonicalSkills,
+	})) {
+		relevantCanonicalSkillKeys.add(skillKey);
+	}
 	const canonicalSkills =
-		targetsRequiringCanonicalSkills.length === 0
+		targetsRequiringCanonicalSkills.length === 0 || relevantCanonicalSkillKeys.size === 0
 			? new Map()
 			: await loadCanonicalSkillIndex(request.repoRoot, {
 					includeLocal: request.includeLocalSkills ?? true,
@@ -865,6 +1080,7 @@ export async function planSubagentSync(
 					overrideSkip: request.overrideSkip ?? null,
 					allTargets: allTargetIds,
 					targetIds: targetsRequiringCanonicalSkills,
+					skillKeys: relevantCanonicalSkillKeys,
 					includeSkill: request.includeSkill,
 				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(resolvedTargets);
@@ -1182,8 +1398,15 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	const targetsRequiringCanonicalSkills = targets
 		.filter(targetRequiresCanonicalSkillLookup)
 		.map((target) => target.id);
+	const relevantCanonicalSkillKeys = collectRelevantCanonicalSkillKeys({
+		subagents: catalog.subagents,
+		activeTargetIds: new Set(targetsRequiringCanonicalSkills),
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
 	const canonicalSkills =
-		targetsRequiringCanonicalSkills.length === 0
+		targetsRequiringCanonicalSkills.length === 0 || relevantCanonicalSkillKeys.size === 0
 			? new Map()
 			: await loadCanonicalSkillIndex(request.repoRoot, {
 					includeLocal: request.includeLocalSkills ?? true,
@@ -1193,6 +1416,7 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 					overrideSkip: request.overrideSkip ?? null,
 					allTargets: allTargetIds,
 					targetIds: targetsRequiringCanonicalSkills,
+					skillKeys: relevantCanonicalSkillKeys,
 					includeSkill: request.includeSkill,
 				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(request.targets);

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -47,7 +47,11 @@ import {
 	evaluateTemplateScripts,
 	type TemplateScriptRuntime,
 } from "../template-scripts.js";
-import { loadSubagentCatalog, type SubagentDefinition } from "./catalog.js";
+import {
+	assertSubagentDefinitionUsable,
+	loadSubagentCatalog,
+	type SubagentDefinition,
+} from "./catalog.js";
 import {
 	type ManagedSubagent,
 	readManifest,
@@ -70,6 +74,7 @@ export type SubagentSyncRequest = {
 	validAgents?: string[];
 	excludeLocal?: boolean;
 	includeLocalSkills?: boolean;
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 	includeSkill?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean;
 	templateScriptRuntime?: TemplateScriptRuntime;
 };
@@ -339,6 +344,66 @@ function getCanonicalSkillPath(
 	skillKey: string,
 ): string | undefined {
 	return index.get(targetId)?.get(skillKey);
+}
+
+function includeSubagentByDefault(
+	subagent: SubagentDefinition,
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean,
+): boolean {
+	if (!includeItem) {
+		return subagent.enabledByDefault;
+	}
+	return includeItem({
+		canonicalName: subagent.resolvedName,
+		enabledByDefault: subagent.enabledByDefault,
+	});
+}
+
+function filterSubagentCatalog(
+	catalog: Pick<
+		Awaited<ReturnType<typeof loadSubagentCatalog>>,
+		"subagents" | "sharedSubagents" | "localSubagents" | "localEffectiveSubagents"
+	>,
+	includeItem?: (item: { canonicalName: string; enabledByDefault: boolean }) => boolean,
+): void {
+	const predicate = (subagent: SubagentDefinition) =>
+		includeSubagentByDefault(subagent, includeItem);
+	catalog.subagents = catalog.subagents.filter(predicate);
+	catalog.sharedSubagents = catalog.sharedSubagents.filter(predicate);
+	catalog.localSubagents = catalog.localSubagents.filter(predicate);
+	catalog.localEffectiveSubagents = catalog.localEffectiveSubagents.filter(predicate);
+}
+
+function assertUsableSubagentsForTargets(options: {
+	subagents: SubagentDefinition[];
+	activeTargetIds: Set<string>;
+	overrideOnly?: string[] | null;
+	overrideSkip?: string[] | null;
+	allTargets: string[];
+}): void {
+	for (const subagent of options.subagents) {
+		const effectiveTargets = resolveEffectiveTargets({
+			defaultTargets: subagent.targetAgents,
+			overrideOnly: options.overrideOnly ?? undefined,
+			overrideSkip: options.overrideSkip ?? undefined,
+			allTargets: options.allTargets,
+		});
+		if (!effectiveTargets.some((targetId) => options.activeTargetIds.has(targetId))) {
+			continue;
+		}
+		assertSubagentDefinitionUsable(subagent);
+	}
+}
+
+function targetRequiresCanonicalSkillLookup(target: ResolvedTarget): boolean {
+	const outputDef = normalizeOutputDefinition(target.outputs.subagents);
+	if (!outputDef) {
+		return false;
+	}
+	if (outputDef.fallback?.mode !== "convert" || outputDef.fallback.targetType !== "skills") {
+		return false;
+	}
+	return normalizeOutputDefinition(target.outputs.skills) !== null;
 }
 
 function areManagedSubagentsEqual(
@@ -762,6 +827,7 @@ export async function planSubagentSync(
 		agentsDir: request.agentsDir,
 		resolveTargetName,
 	});
+	filterSubagentCatalog(catalog, request.includeItem);
 	const allTargetIds = resolvedTargets.map((target) => target.id);
 	const selectedTargets: ResolvedTarget[] =
 		request.targets && request.targets.length > 0
@@ -778,16 +844,29 @@ export async function planSubagentSync(
 				})
 			: resolvedTargets;
 	const selectedTargetIds = selectedTargets.map((target) => target.id);
-	const canonicalSkills = await loadCanonicalSkillIndex(request.repoRoot, {
-		includeLocal: request.includeLocalSkills ?? true,
-		agentsDir: request.agentsDir,
-		resolveTargetName,
-		overrideOnly: request.overrideOnly ?? null,
-		overrideSkip: request.overrideSkip ?? null,
+	assertUsableSubagentsForTargets({
+		subagents: catalog.subagents,
+		activeTargetIds: new Set(selectedTargetIds),
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
 		allTargets: allTargetIds,
-		targetIds: selectedTargetIds,
-		includeSkill: request.includeSkill,
 	});
+	const targetsRequiringCanonicalSkills = selectedTargets
+		.filter(targetRequiresCanonicalSkillLookup)
+		.map((target) => target.id);
+	const canonicalSkills =
+		targetsRequiringCanonicalSkills.length === 0
+			? new Map()
+			: await loadCanonicalSkillIndex(request.repoRoot, {
+					includeLocal: request.includeLocalSkills ?? true,
+					agentsDir: request.agentsDir,
+					resolveTargetName,
+					overrideOnly: request.overrideOnly ?? null,
+					overrideSkip: request.overrideSkip ?? null,
+					allTargets: allTargetIds,
+					targetIds: targetsRequiringCanonicalSkills,
+					includeSkill: request.includeSkill,
+				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(resolvedTargets);
 	const removeMissing = request.removeMissing ?? true;
 	const timestamp = new Date().toISOString();
@@ -1025,18 +1104,7 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 		agentsDir: request.agentsDir,
 		resolveTargetName: request.resolveTargetName,
 	});
-	if (request.includeItem) {
-		const includeItem = request.includeItem;
-		const predicate = (subagent: SubagentDefinition) =>
-			includeItem({
-				canonicalName: subagent.resolvedName,
-				enabledByDefault: subagent.enabledByDefault,
-			});
-		catalog.subagents = catalog.subagents.filter(predicate);
-		catalog.sharedSubagents = catalog.sharedSubagents.filter(predicate);
-		catalog.localSubagents = catalog.localSubagents.filter(predicate);
-		catalog.localEffectiveSubagents = catalog.localEffectiveSubagents.filter(predicate);
-	}
+	filterSubagentCatalog(catalog, request.includeItem);
 	const targets = request.targets.filter(
 		(target) => normalizeOutputDefinition(target.outputs.subagents) !== null,
 	);
@@ -1058,6 +1126,13 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 
 	const allTargetIds = request.targets.map((target) => target.id);
 	const activeTargetIds = new Set(targets.map((target) => target.id));
+	assertUsableSubagentsForTargets({
+		subagents: catalog.subagents,
+		activeTargetIds,
+		overrideOnly: request.overrideOnly,
+		overrideSkip: request.overrideSkip,
+		allTargets: allTargetIds,
+	});
 	const effectiveTargetsBySubagent = new Map<SubagentDefinition, string[]>();
 	const activeSourcesByTarget = new Map<string, Set<string>>();
 	for (const subagent of catalog.subagents) {
@@ -1104,16 +1179,22 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 	const writerRegistry: WriterRegistry = new Map([
 		[defaultSubagentWriter.id, defaultSubagentWriter],
 	]);
-	const canonicalSkills = await loadCanonicalSkillIndex(request.repoRoot, {
-		includeLocal: request.includeLocalSkills ?? true,
-		agentsDir: request.agentsDir,
-		resolveTargetName: request.resolveTargetName,
-		overrideOnly: request.overrideOnly ?? null,
-		overrideSkip: request.overrideSkip ?? null,
-		allTargets: allTargetIds,
-		targetIds: activeTargetIds,
-		includeSkill: request.includeSkill,
-	});
+	const targetsRequiringCanonicalSkills = targets
+		.filter(targetRequiresCanonicalSkillLookup)
+		.map((target) => target.id);
+	const canonicalSkills =
+		targetsRequiringCanonicalSkills.length === 0
+			? new Map()
+			: await loadCanonicalSkillIndex(request.repoRoot, {
+					includeLocal: request.includeLocalSkills ?? true,
+					agentsDir: request.agentsDir,
+					resolveTargetName: request.resolveTargetName,
+					overrideOnly: request.overrideOnly ?? null,
+					overrideSkip: request.overrideSkip ?? null,
+					allTargets: allTargetIds,
+					targetIds: targetsRequiringCanonicalSkills,
+					includeSkill: request.includeSkill,
+				});
 	const validAgents = request.validAgents ?? buildSupportedAgentNames(request.targets);
 
 	const outputDefs = new Map<string, NonNullable<ReturnType<typeof normalizeOutputDefinition>>>();

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -452,20 +452,19 @@ async function loadCanonicalSkillIndex(
 		const rawTargets = [frontmatter.targets, frontmatter.targetAgents];
 		const { targets, invalidTargets } = resolveFrontmatterTargets(rawTargets, resolveTargetName);
 		const hasEmptyTargets = hasRawTargetValues(rawTargets) && (!targets || targets.length === 0);
-		let matchingTargets: string[] | null = null;
-		if (invalidTargets.length === 0 && !hasEmptyTargets) {
-			const effectiveTargets = resolveEffectiveTargets({
-				defaultTargets: targets,
-				overrideOnly: options.overrideOnly ?? undefined,
-				overrideSkip: options.overrideSkip ?? undefined,
-				allTargets: options.allTargets,
-			});
-			matchingTargets = targetFilter
-				? effectiveTargets.filter((targetId) => targetFilter.has(targetId))
-				: effectiveTargets;
-			if (matchingTargets.length === 0) {
-				continue;
-			}
+		const effectiveTargets = hasEmptyTargets
+			? []
+			: resolveEffectiveTargets({
+					defaultTargets: targets,
+					overrideOnly: options.overrideOnly ?? undefined,
+					overrideSkip: options.overrideSkip ?? undefined,
+					allTargets: options.allTargets,
+				});
+		const matchingTargets = targetFilter
+			? effectiveTargets.filter((targetId) => targetFilter.has(targetId))
+			: effectiveTargets;
+		if (matchingTargets.length === 0) {
+			continue;
 		}
 		const enabledByDefault = resolveFrontmatterEnabledByDefault({
 			frontmatter,
@@ -492,9 +491,6 @@ async function loadCanonicalSkillIndex(
 			throw new InvalidFrontmatterTargetsError(
 				`Skill "${skillName}" has empty targets in ${skill.sourcePath}.`,
 			);
-		}
-		if (!matchingTargets || matchingTargets.length === 0) {
-			continue;
 		}
 		const skillKey = normalizeSkillKey(skill.relativePath);
 		for (const targetId of matchingTargets) {

--- a/src/lib/subagents/sync.ts
+++ b/src/lib/subagents/sync.ts
@@ -891,6 +891,7 @@ async function buildTargetPlan(
 
 		const nameKey = normalizeName(subagent.resolvedName);
 		catalogNames.add(nameKey);
+		const previousEntry = previousManaged.get(nameKey);
 		const canonicalSkillKey =
 			outputKind === "skill" ? normalizeSkillKey(subagent.resolvedName) : null;
 		const canonicalSkillPath =
@@ -916,6 +917,9 @@ async function buildTargetPlan(
 					subagent.resolvedName
 				}" because canonical skill exists at ${canonicalSkillPath}.`,
 			);
+			if (previousEntry) {
+				nextManaged.set(nameKey, previousEntry);
+			}
 			continue;
 		}
 
@@ -945,7 +949,6 @@ async function buildTargetPlan(
 		);
 		const existingContent = await readFileIfExists(destinationPath);
 		const existingHash = existingContent ? hashContent(existingContent) : null;
-		const previousEntry = previousManaged.get(nameKey);
 
 		if (!existingContent) {
 			const actionType = outputKind === "skill" ? "convert" : "create";
@@ -1052,6 +1055,7 @@ async function buildTargetPlan(
 							entry.name
 						}" because canonical skill exists at ${canonicalSkillPath}.`,
 					);
+					nextManaged.set(normalizeName(entry.name), entry);
 					continue;
 				}
 			}
@@ -1779,11 +1783,13 @@ export async function syncSubagents(request: SubagentSyncRequestV2): Promise<Sub
 					normalizeManagedOutputPath(expectedSkillOutputPath) ===
 					normalizeManagedOutputPath(entry.outputPath)
 				) {
+					updatedEntries.push(entry);
 					continue;
 				}
 			}
 			const shadowedSources = shadowedSubagentSources.get(entry.targetId);
 			if (shadowedSources?.has(normalizeName(entry.sourceId))) {
+				updatedEntries.push(entry);
 				continue;
 			}
 			const activeSources = activeSourcesByTarget.get(entry.targetId);

--- a/src/lib/targets/builtins/copilot-cli/target.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
+import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../../../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../../../frontmatter-strip.js";
 import type { TargetDefinition } from "../../config-types.js";
-
-const TARGET_FRONTMATTER_KEYS = new Set(["targets", "targetagents"]);
 
 type SlashCommandLike = {
 	name: string;
@@ -77,7 +76,7 @@ export const copilotTarget: TargetDefinition = {
 						outputs: [
 							{
 								outputPath: agentPath,
-								content: stripFrontmatterFields(item.rawContents, TARGET_FRONTMATTER_KEYS),
+								content: stripFrontmatterFields(item.rawContents, SYNC_ROUTING_FRONTMATTER_KEYS),
 							},
 							{
 								outputPath: promptPath,

--- a/src/lib/targets/writers.ts
+++ b/src/lib/targets/writers.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { TextDecoder } from "node:util";
 import { applyAgentTemplating } from "../agent-templating.js";
+import { SYNC_ROUTING_FRONTMATTER_KEYS } from "../frontmatter-enabled.js";
 import { stripFrontmatterFields } from "../frontmatter-strip.js";
 import {
 	detectLocalMarkerFromPath,
@@ -16,9 +17,8 @@ import type { OutputWriter, OutputWriterRef, WriterContext, WriterResult } from 
 
 const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
-const TARGET_FRONTMATTER_KEYS = new Set(["targets", "targetagents"]);
 const SKILL_FRONTMATTER_KEYS_TO_REMOVE = new Set([
-	...TARGET_FRONTMATTER_KEYS,
+	...SYNC_ROUTING_FRONTMATTER_KEYS,
 	"tools",
 	"model",
 	"color",
@@ -300,7 +300,7 @@ async function copySkillDirectory(options: {
 			sourcePath: winner.sourcePath,
 		});
 		const output = winner.isSkillFile
-			? stripFrontmatterFields(templated, TARGET_FRONTMATTER_KEYS)
+			? stripFrontmatterFields(templated, SYNC_ROUTING_FRONTMATTER_KEYS)
 			: templated;
 		await mkdir(path.dirname(winner.destinationPath), { recursive: true });
 		await writeFile(winner.destinationPath, output, "utf8");
@@ -362,7 +362,7 @@ export const defaultSubagentWriter: OutputWriter = {
 		const cleaned =
 			item.outputKind === "skill"
 				? stripFrontmatterFields(templated, SKILL_FRONTMATTER_KEYS_TO_REMOVE)
-				: stripFrontmatterFields(templated, TARGET_FRONTMATTER_KEYS);
+				: stripFrontmatterFields(templated, SYNC_ROUTING_FRONTMATTER_KEYS);
 		if (item.outputKind === "skill") {
 			const destinationPath = path.join(options.outputPath, "SKILL.md");
 			return writeOutputFile(destinationPath, cleaned);

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -337,9 +337,54 @@ describe.sequential("profiles subcommand", () => {
 		});
 	});
 
-	it("validate exits non-zero when a profile includes disabled draft commands or subagents", async () => {
+	it("validate ignores frontmatter-disabled items with invalid targets until a profile enables them", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"draft-skill",
+				["---", "enabled: false", "targets:", "  - nope", "---", "Skill body"].join("\n"),
+			);
+			await writeCommand(
+				root,
+				"draft-command",
+				["---", "enabled: false", "targets:", "  - nope", "---", "Command body"].join("\n"),
+			);
+			const subagentPath = path.join(root, "agents", "agents", "draft-agent.md");
+			await mkdir(path.dirname(subagentPath), { recursive: true });
+			await writeFile(
+				subagentPath,
+				[
+					"---",
+					"name: draft-agent",
+					"enabled: false",
+					"targets:",
+					"  - nope",
+					"---",
+					"Subagent body",
+				].join("\n"),
+				"utf8",
+			);
+			await writeProfile(root, "profiles/default.json", {});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).toContain("Validated 1 profile(s).");
+		});
+	});
+
+	it("validate exits non-zero when a profile includes disabled draft skills, commands, or subagents", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"draft-skill",
+				["---", "enabled: false", "targets:", "  - nope", "---", "Skill body"].join("\n"),
+			);
 			await writeCommand(root, "draft", ["---", "enabled: false", "---", ""].join("\n"));
 			const subagentPath = path.join(root, "agents", "agents", "draft.md");
 			await mkdir(path.dirname(subagentPath), { recursive: true });
@@ -349,7 +394,7 @@ describe.sequential("profiles subcommand", () => {
 				"utf8",
 			);
 			await writeProfile(root, "profiles/drafts.json", {
-				enable: { commands: ["draft"], subagents: ["draft"] },
+				enable: { skills: ["draft-skill"], commands: ["draft"], subagents: ["draft"] },
 			});
 
 			await withCwd(root, async () => {
@@ -358,6 +403,8 @@ describe.sequential("profiles subcommand", () => {
 
 			expect(exitSpy).toHaveBeenCalledWith(1);
 			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain('includes unusable skill "draft-skill"');
+			expect(errOut).toContain("unsupported targets");
 			expect(errOut).toContain('includes unusable command "draft"');
 			expect(errOut).toContain("empty prompt");
 			expect(errOut).toContain('includes unusable subagent "draft"');

--- a/tests/commands/profiles.test.ts
+++ b/tests/commands/profiles.test.ts
@@ -337,6 +337,34 @@ describe.sequential("profiles subcommand", () => {
 		});
 	});
 
+	it("validate exits non-zero when a profile includes disabled draft commands or subagents", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCommand(root, "draft", ["---", "enabled: false", "---", ""].join("\n"));
+			const subagentPath = path.join(root, "agents", "agents", "draft.md");
+			await mkdir(path.dirname(subagentPath), { recursive: true });
+			await writeFile(
+				subagentPath,
+				["---", "name: draft", "enabled: false", "---", ""].join("\n"),
+				"utf8",
+			);
+			await writeProfile(root, "profiles/drafts.json", {
+				enable: { commands: ["draft"], subagents: ["draft"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "profiles", "validate"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain('includes unusable command "draft"');
+			expect(errOut).toContain("empty prompt");
+			expect(errOut).toContain('includes unusable subagent "draft"');
+			expect(errOut).toContain("empty body");
+		});
+	});
+
 	it("validate stays silent for zero-match glob references", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -444,6 +444,62 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("skips shadowed subagents during templating validation when a profile activates a canonical skill", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "---", "canonical planner"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "<agents nope>bad</agents>");
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["planner"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--profile", "focus"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n")).not.toContain(
+				"Unknown agent selector",
+			);
+			expect(
+				await readFile(path.join(root, ".codex", "skills", "planner", "SKILL.md"), "utf8"),
+			).toContain("canonical planner");
+		});
+	});
+
+	it("skips shadowed subagents during template script evaluation when a profile activates a canonical skill", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "---", "canonical planner"].join("\n"),
+			);
+			await writeSubagent(
+				root,
+				"planner",
+				["<nodejs>", "throw new Error('boom');", "</nodejs>"].join("\n"),
+			);
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["planner"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--profile", "focus"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n")).not.toContain("boom");
+			expect(
+				await readFile(path.join(root, ".codex", "skills", "planner", "SKILL.md"), "utf8"),
+			).toContain("canonical planner");
+		});
+	});
+
 	it("retires stale subagent ownership when a profile activates a canonical skill", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/pr
 import os from "node:os";
 import path from "node:path";
 import { runCli } from "../../src/cli/index.js";
+import { resolveManagedOutputsPath } from "../../src/lib/targets/managed-outputs.js";
 
 const DEFAULT_CLI_COMMANDS = ["codex", "claude", "gemini", "copilot"];
 
@@ -103,6 +104,14 @@ async function writeTargetConfig(root: string, contents: string): Promise<void> 
 	const target = path.join(root, "agents", "omniagent.config.cjs");
 	await mkdir(path.dirname(target), { recursive: true });
 	await writeFile(target, contents, "utf8");
+}
+
+async function readManagedOutputsManifest(
+	root: string,
+): Promise<{ entries: Array<Record<string, unknown>> }> {
+	const manifestPath = resolveManagedOutputsPath(root, path.join(root, "home"));
+	const contents = await readFile(manifestPath, "utf8");
+	return JSON.parse(contents) as { entries: Array<Record<string, unknown>> };
 }
 
 describe.sequential("sync command with profiles", () => {
@@ -241,6 +250,74 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("ignores invalid targets on frontmatter-disabled items until a profile opts them in", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"hidden-skill",
+				["---", "enabled: false", "targets:", "  - nope", "---", "hidden-skill"].join("\n"),
+			);
+			await writeCommand(
+				root,
+				"hidden-command",
+				["---", "enabled: false", "targets:", "  - nope", "---", "hidden-command"].join("\n"),
+			);
+			await writeSubagent(root, "hidden-agent", "body", [
+				"name: hidden-agent",
+				"enabled: false",
+				"targets:",
+				"  - nope",
+			]);
+			await writeSkill(root, "visible-skill");
+			await writeCommand(root, "visible-command");
+			await writeSubagent(root, "visible-agent");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "hidden-skill", "SKILL.md")),
+			).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "commands", "hidden-command.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".claude", "agents", "hidden-agent.md"))).toBe(false);
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "visible-skill", "SKILL.md")),
+			).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "commands", "visible-command.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "agents", "visible-agent.md"))).toBe(true);
+		});
+	});
+
+	it("fails when a profile opts an invalid frontmatter-disabled skill back in", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"hidden-skill",
+				["---", "enabled: false", "targets:", "  - nope", "---", "hidden-skill"].join("\n"),
+			);
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["hidden-skill"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "focus"]);
+			});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const errOut = errorSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(errOut).toContain('Skill "hidden-skill" has unsupported targets (nope)');
+		});
+	});
+
 	it("skips frontmatter-disabled items during templating preflight and script evaluation", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -364,6 +441,65 @@ describe.sequential("sync command with profiles", () => {
 			const codexSkillOutput = await readFile(codexSkillPath, "utf8");
 			expect(codexSkillOutput).toContain("canonical planner");
 			expect(codexSkillOutput).not.toContain("subagent planner");
+		});
+	});
+
+	it("retires stale subagent ownership when a profile activates a canonical skill", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "---", "canonical planner"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "subagent planner");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex"]);
+			});
+
+			let manifest = await readManagedOutputsManifest(root);
+			expect(
+				manifest.entries.filter(
+					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
+				),
+			).toEqual([
+				expect.objectContaining({
+					sourceType: "subagent",
+				}),
+			]);
+
+			logSpy.mockClear();
+			errorSpy.mockClear();
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["planner"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--profile", "focus"]);
+			});
+
+			manifest = await readManagedOutputsManifest(root);
+			expect(
+				manifest.entries.filter(
+					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
+				),
+			).toEqual([
+				expect.objectContaining({
+					sourceType: "skill",
+				}),
+			]);
+
+			await rm(path.join(root, "agents", "agents", "planner.md"));
+			logSpy.mockClear();
+			errorSpy.mockClear();
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--profile", "focus"]);
+			});
+
+			const output = logSpy.mock.calls.map(([msg]) => String(msg)).join("\n");
+			expect(output).not.toContain("Output modified since last sync");
 		});
 	});
 

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -241,6 +241,38 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("skips frontmatter-disabled items during templating preflight and script evaluation", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(
+				root,
+				"hidden-skill",
+				[
+					"---",
+					"enabled: false",
+					"---",
+					"<agents nope>bad</agents>",
+					"<nodejs>",
+					"throw new Error('boom');",
+					"</nodejs>",
+				].join("\n"),
+			);
+			await writeSkill(root, "visible-skill", "visible-skill");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			expect(exitSpy).not.toHaveBeenCalled();
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "hidden-skill", "SKILL.md")),
+			).toBe(false);
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "visible-skill", "SKILL.md")),
+			).toBe(true);
+		});
+	});
+
 	it("lets profiles override frontmatter enabled=false and strips the field from outputs", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -262,13 +294,21 @@ describe.sequential("sync command with profiles", () => {
 			const skillOutputPath = path.join(root, ".claude", "skills", "hidden-skill", "SKILL.md");
 			const commandOutputPath = path.join(root, ".claude", "commands", "hidden-command.md");
 			const subagentOutputPath = path.join(root, ".claude", "agents", "hidden-agent.md");
+			const copilotCommandOutputPath = path.join(
+				root,
+				".github",
+				"agents",
+				"hidden-command.agent.md",
+			);
 			expect(await pathExists(skillOutputPath)).toBe(true);
 			expect(await pathExists(commandOutputPath)).toBe(true);
 			expect(await pathExists(subagentOutputPath)).toBe(true);
+			expect(await pathExists(copilotCommandOutputPath)).toBe(true);
 
 			expect(await readFile(skillOutputPath, "utf8")).not.toContain("enabled:");
 			expect(await readFile(commandOutputPath, "utf8")).not.toContain("enabled:");
 			expect(await readFile(subagentOutputPath, "utf8")).not.toContain("enabled:");
+			expect(await readFile(copilotCommandOutputPath, "utf8")).not.toContain("enabled:");
 		});
 	});
 

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -67,16 +67,26 @@ async function writeSkill(root: string, name: string, body?: string): Promise<vo
 	await writeFile(path.join(dir, "SKILL.md"), body ?? `skill-${name}`, "utf8");
 }
 
-async function writeCommand(root: string, name: string): Promise<void> {
+async function writeCommand(root: string, name: string, body?: string): Promise<void> {
 	const dir = path.join(root, "agents", "commands");
 	await mkdir(dir, { recursive: true });
-	await writeFile(path.join(dir, `${name}.md`), `command-${name}`, "utf8");
+	await writeFile(path.join(dir, `${name}.md`), body ?? `command-${name}`, "utf8");
 }
 
-async function writeSubagent(root: string, name: string): Promise<void> {
+async function writeSubagent(
+	root: string,
+	name: string,
+	body = "body",
+	frontmatterLines?: string[],
+): Promise<void> {
 	const dir = path.join(root, "agents", "agents");
 	await mkdir(dir, { recursive: true });
-	await writeFile(path.join(dir, `${name}.md`), `---\nname: ${name}\n---\nbody`, "utf8");
+	const frontmatter = frontmatterLines ?? [`name: ${name}`];
+	await writeFile(
+		path.join(dir, `${name}.md`),
+		["---", ...frontmatter, "---", body].join("\n"),
+		"utf8",
+	);
 }
 
 async function writeProfile(
@@ -197,6 +207,68 @@ describe.sequential("sync command with profiles", () => {
 				true,
 			);
 			expect(await pathExists(path.join(root, ".claude", "commands", "note.md"))).toBe(false);
+		});
+	});
+
+	it("keeps frontmatter-disabled items out by default", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "hidden-skill", "---\nenabled: false\n---\nhidden-skill");
+			await writeCommand(root, "hidden-command", "---\nenabled: false\n---\nhidden-command");
+			await writeSubagent(root, "hidden-agent", "body", ["name: hidden-agent", "enabled: false"]);
+			await writeSkill(root, "visible-skill");
+			await writeCommand(root, "visible-command");
+			await writeSubagent(root, "visible-agent");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync"]);
+			});
+
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "hidden-skill", "SKILL.md")),
+			).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "commands", "hidden-command.md"))).toBe(
+				false,
+			);
+			expect(await pathExists(path.join(root, ".claude", "agents", "hidden-agent.md"))).toBe(false);
+			expect(
+				await pathExists(path.join(root, ".claude", "skills", "visible-skill", "SKILL.md")),
+			).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "commands", "visible-command.md"))).toBe(
+				true,
+			);
+			expect(await pathExists(path.join(root, ".claude", "agents", "visible-agent.md"))).toBe(true);
+		});
+	});
+
+	it("lets profiles override frontmatter enabled=false and strips the field from outputs", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "hidden-skill", "---\nenabled: false\n---\nhidden-skill");
+			await writeCommand(root, "hidden-command", "---\nenabled: false\n---\nhidden-command");
+			await writeSubagent(root, "hidden-agent", "body", ["name: hidden-agent", "enabled: false"]);
+			await writeProfile(root, "profiles/focus.json", {
+				enable: {
+					skills: ["hidden-skill"],
+					commands: ["hidden-command"],
+					subagents: ["hidden-agent"],
+				},
+			});
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--profile", "focus"]);
+			});
+
+			const skillOutputPath = path.join(root, ".claude", "skills", "hidden-skill", "SKILL.md");
+			const commandOutputPath = path.join(root, ".claude", "commands", "hidden-command.md");
+			const subagentOutputPath = path.join(root, ".claude", "agents", "hidden-agent.md");
+			expect(await pathExists(skillOutputPath)).toBe(true);
+			expect(await pathExists(commandOutputPath)).toBe(true);
+			expect(await pathExists(subagentOutputPath)).toBe(true);
+
+			expect(await readFile(skillOutputPath, "utf8")).not.toContain("enabled:");
+			expect(await readFile(commandOutputPath, "utf8")).not.toContain("enabled:");
+			expect(await readFile(subagentOutputPath, "utf8")).not.toContain("enabled:");
 		});
 	});
 

--- a/tests/commands/sync-profiles.test.ts
+++ b/tests/commands/sync-profiles.test.ts
@@ -312,6 +312,61 @@ describe.sequential("sync command with profiles", () => {
 		});
 	});
 
+	it("uses the profile-filtered skill set when checking subagent-to-skill conflicts", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "planner", "---\nenabled: false\n---\ncanonical planner");
+			await writeSubagent(root, "planner", "subagent planner");
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "codex", "--json"]);
+			});
+
+			const firstRun = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? ""));
+			const firstSubagentResult = firstRun.subagents.results.find(
+				(entry: { targetName: string }) => entry.targetName === "codex",
+			);
+			expect(firstSubagentResult?.counts.converted).toBe(1);
+
+			const codexSkillPath = path.join(root, ".codex", "skills", "planner", "SKILL.md");
+			expect(await pathExists(codexSkillPath)).toBe(true);
+			expect(await readFile(codexSkillPath, "utf8")).toContain("subagent planner");
+
+			logSpy.mockClear();
+			await writeProfile(root, "profiles/focus.json", {
+				enable: { skills: ["planner"] },
+			});
+
+			await withCwd(root, async () => {
+				await runCli([
+					"node",
+					"omniagent",
+					"sync",
+					"--only",
+					"codex",
+					"--profile",
+					"focus",
+					"--json",
+				]);
+			});
+
+			const secondRun = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? ""));
+			const secondSubagentResult = secondRun.subagents.results.find(
+				(entry: { targetName: string }) => entry.targetName === "codex",
+			);
+			expect(secondSubagentResult?.counts.converted).toBe(0);
+			expect(
+				secondRun.subagents.warnings.some((warning: string) =>
+					warning.includes("canonical skill exists at"),
+				),
+			).toBe(true);
+
+			const codexSkillOutput = await readFile(codexSkillPath, "utf8");
+			expect(codexSkillOutput).toContain("canonical planner");
+			expect(codexSkillOutput).not.toContain("subagent planner");
+		});
+	});
+
 	it("disables a target via targets.<name>.enabled=false", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -538,6 +538,24 @@ describe.sequential("sync command", () => {
 		});
 	});
 
+	it("ignores instruction templates for unselected targets during templating validation", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeRepoInstruction(
+				root,
+				path.join("agents", "other", "other.AGENTS.md"),
+				["---", "targets:", "  - codex", "---", "<agents nope>bad</agents>"].join("\n"),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
+
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	it("renders nodejs blocks in synced command outputs", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -337,6 +337,23 @@ describe.sequential("sync command", () => {
 		});
 	});
 
+	it("errors on invalid skill enabled values in frontmatter", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await createCanonicalCommands(root);
+			const contents = ["---", "enabled: maybe", "---", "Hello"].join("\n");
+			await writeCanonicalSkillFile(root, "bad-enabled", contents);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "sync", "--only", "claude", "--yes"]);
+			});
+
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("invalid enabled value"));
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			expect(await pathExists(path.join(root, ".claude", "skills"))).toBe(false);
+		});
+	});
+
 	it("errors on invalid command targets in frontmatter", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/lib/profiles/filter.test.ts
+++ b/tests/lib/profiles/filter.test.ts
@@ -21,6 +21,16 @@ describe("createProfileItemFilter", () => {
 		expect(filter.collectUnknownWarnings()).toEqual([]);
 	});
 
+	it("respects item defaults when no profile is active", () => {
+		const filter = createProfileItemFilter(null);
+		expect(
+			filter.includes("skills", { canonicalName: "hidden-skill", enabledByDefault: false }),
+		).toBe(false);
+		expect(
+			filter.includes("skills", { canonicalName: "visible-skill", enabledByDefault: true }),
+		).toBe(true);
+	});
+
 	it("includes everything when enable/disable are empty", () => {
 		const filter = createProfileItemFilter(profile({}));
 		expect(filter.includes("skills", "anything")).toBe(true);
@@ -45,6 +55,29 @@ describe("createProfileItemFilter", () => {
 		);
 		expect(filter.includes("skills", "code-review")).toBe(true);
 		expect(filter.includes("skills", "security-review")).toBe(false);
+	});
+
+	it("lets profiles opt default-disabled items back in", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["review"], subagents: [], commands: [] },
+			}),
+		);
+		expect(filter.includes("skills", { canonicalName: "review", enabledByDefault: false })).toBe(
+			true,
+		);
+	});
+
+	it("still tracks bare disable matches outside the allowlist", () => {
+		const filter = createProfileItemFilter(
+			profile({
+				enable: { skills: ["review"], subagents: [], commands: [] },
+				disable: { skills: ["helper"], subagents: [], commands: [] },
+			}),
+		);
+		filter.includes("skills", "review");
+		filter.includes("skills", "helper");
+		expect(filter.collectUnknownWarnings()).toEqual([]);
 	});
 
 	it("supports minimatch globs", () => {

--- a/tests/lib/slash-commands/catalog.test.ts
+++ b/tests/lib/slash-commands/catalog.test.ts
@@ -23,4 +23,17 @@ describe("slash command catalog", () => {
 			await expect(loadCommandCatalog(root)).rejects.toThrow(/Duplicate command name/);
 		});
 	});
+
+	it("rejects default-enabled commands with empty prompts", async () => {
+		await withTempRepo(async (root) => {
+			const commandsDir = path.join(root, "agents", "commands");
+			await mkdir(commandsDir, { recursive: true });
+			await writeFile(
+				path.join(commandsDir, "draft.md"),
+				["---", 'description: "draft"', "---", ""].join("\n"),
+			);
+
+			await expect(loadCommandCatalog(root)).rejects.toThrow(/empty prompt/);
+		});
+	});
 });

--- a/tests/lib/slash-commands/sync.test.ts
+++ b/tests/lib/slash-commands/sync.test.ts
@@ -725,4 +725,41 @@ describe("slash command sync planning", () => {
 			).rejects.toThrow(/empty prompt/);
 		});
 	});
+
+	it("skips disabled commands with invalid targets by default and fails when explicitly included", async () => {
+		await withTempRepo(async (root) => {
+			await createCanonicalCommand(root, "visible");
+			const commandsDir = path.join(root, "agents", "commands");
+			await writeFile(
+				path.join(commandsDir, "draft.md"),
+				["---", "enabled: false", "targets:", "  - nope", "---", "draft prompt"].join("\n"),
+				"utf8",
+			);
+			const claudeTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "claude");
+
+			const summary = await syncSlashCommands({
+				repoRoot: root,
+				targets: claudeTargets,
+				validAgents: ["claude"],
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "commands", "visible.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "commands", "draft.md"))).toBe(false);
+
+			await expect(
+				syncSlashCommands({
+					repoRoot: root,
+					targets: claudeTargets,
+					validAgents: ["claude"],
+					removeMissing: true,
+					includeItem: (item) => (item.canonicalName === "draft" ? true : item.enabledByDefault),
+				}),
+			).rejects.toThrow(/unsupported targets/);
+		});
+	});
 });

--- a/tests/lib/slash-commands/sync.test.ts
+++ b/tests/lib/slash-commands/sync.test.ts
@@ -688,4 +688,41 @@ describe("slash command sync planning", () => {
 			expect(copilotOutput).toContain("Run the canonical prompt.");
 		});
 	});
+
+	it("skips disabled draft commands by default and fails when explicitly included", async () => {
+		await withTempRepo(async (root) => {
+			await createCanonicalCommand(root, "visible");
+			const commandsDir = path.join(root, "agents", "commands");
+			await writeFile(
+				path.join(commandsDir, "draft.md"),
+				["---", "enabled: false", "---", ""].join("\n"),
+				"utf8",
+			);
+			const claudeTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "claude");
+
+			const summary = await syncSlashCommands({
+				repoRoot: root,
+				targets: claudeTargets,
+				validAgents: ["claude"],
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "commands", "visible.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "commands", "draft.md"))).toBe(false);
+
+			await expect(
+				syncSlashCommands({
+					repoRoot: root,
+					targets: claudeTargets,
+					validAgents: ["claude"],
+					removeMissing: true,
+					includeItem: (item) => (item.canonicalName === "draft" ? true : item.enabledByDefault),
+				}),
+			).rejects.toThrow(/empty prompt/);
+		});
+	});
 });

--- a/tests/lib/targets/custom-targets-sync.test.ts
+++ b/tests/lib/targets/custom-targets-sync.test.ts
@@ -266,6 +266,30 @@ describe("custom target sync", () => {
 		});
 	});
 
+	it("does not validate unrelated skills for native-only subagent targets", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSkill(root, "broken", ["---", "enabled: maybe", "---", "Broken"].join("\n"));
+			await writeSubagent(root, "helper", "Helper body");
+
+			const target = createTarget("acme", {
+				subagents: "{repoRoot}/.acme/agents/{itemName}.md",
+			});
+
+			const summary = await syncSubagents({
+				repoRoot: root,
+				targets: [target],
+				validAgents: VALID_AGENTS,
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			expect(await readFile(path.join(root, ".acme", "agents", "helper.md"), "utf8")).toContain(
+				"Helper body",
+			);
+		});
+	});
+
 	it("summarizes command converter errors with item names", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/subagents/catalog.test.ts
+++ b/tests/subagents/catalog.test.ts
@@ -91,4 +91,12 @@ describe("subagent catalog", () => {
 			await expect(loadSubagentCatalog(root)).rejects.toThrow(/Subagent file is empty/);
 		});
 	});
+
+	it("rejects default-enabled subagents with empty bodies", async () => {
+		await withTempRepo(async (root) => {
+			await writeSubagentFile(root, "draft.md", ["---", "name: draft", "---", ""].join("\n"));
+
+			await expect(loadSubagentCatalog(root)).rejects.toThrow(/empty body/);
+		});
+	});
 });

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import os from "node:os";
 import path from "node:path";
 import { syncSkills } from "../../src/lib/skills/sync.js";
+import { readManifest, resolveManifestPath } from "../../src/lib/subagents/manifest.js";
 import {
 	applySubagentSync,
 	planSubagentSync,
@@ -60,6 +61,10 @@ async function writeLocalSkill(root: string, name: string, body: string): Promis
 	const skillPath = path.join(skillDir, "SKILL.md");
 	await writeFile(skillPath, body, "utf8");
 	return skillPath;
+}
+
+async function readSubagentManifest(root: string, targetName: string) {
+	return readManifest(resolveManifestPath(root, targetName, path.join(root, "home")));
 }
 
 describe.sequential("subagent sync", () => {
@@ -480,6 +485,36 @@ describe.sequential("subagent sync", () => {
 		});
 	});
 
+	it("preserves managed conversion ownership in plan/apply mode until skills sync takes over", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "planner", "subagent body");
+
+			const initialPlan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["codex"],
+				removeMissing: true,
+			});
+			await applySubagentSync(initialPlan);
+
+			await writeCanonicalSkill(root, "planner", "canonical skill");
+
+			const takeoverPlan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["codex"],
+				removeMissing: true,
+			});
+			await applySubagentSync(takeoverPlan);
+
+			const manifest = await readSubagentManifest(root, "codex");
+			expect(manifest?.managedSubagents).toEqual([
+				expect.objectContaining({
+					name: "planner",
+				}),
+			]);
+		});
+	});
+
 	it("retires stale managed conversion ownership during direct sync when a canonical skill appears", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -500,8 +535,28 @@ describe.sequential("subagent sync", () => {
 			const destination = path.join(root, ".codex", "skills", "planner", "SKILL.md");
 			expect(await pathExists(destination)).toBe(true);
 
-			await rm(path.join(root, "agents", "agents", "planner.md"));
 			await writeCanonicalSkill(root, "planner", "canonical skill");
+
+			const shadowedSummary = await syncSubagents({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+			});
+			expect(shadowedSummary.hadFailures).toBe(false);
+
+			let managed = await readManagedOutputs(root, path.join(root, "home"));
+			let plannerEntries =
+				managed?.entries.filter(
+					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
+				) ?? [];
+			expect(plannerEntries).toEqual([
+				expect.objectContaining({
+					sourceType: "subagent",
+				}),
+			]);
+
+			await rm(path.join(root, "agents", "agents", "planner.md"));
 
 			const skillSummary = await syncSkills({
 				repoRoot: root,
@@ -510,6 +565,17 @@ describe.sequential("subagent sync", () => {
 				removeMissing: true,
 			});
 			expect(skillSummary.hadFailures).toBe(false);
+
+			managed = await readManagedOutputs(root, path.join(root, "home"));
+			plannerEntries =
+				managed?.entries.filter(
+					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
+				) ?? [];
+			expect(plannerEntries).toEqual([
+				expect.objectContaining({
+					sourceType: "skill",
+				}),
+			]);
 
 			const subagentSummary = await syncSubagents({
 				repoRoot: root,
@@ -523,8 +589,8 @@ describe.sequential("subagent sync", () => {
 				),
 			).toBe(false);
 
-			const managed = await readManagedOutputs(root, path.join(root, "home"));
-			const plannerEntries =
+			managed = await readManagedOutputs(root, path.join(root, "home"));
+			plannerEntries =
 				managed?.entries.filter(
 					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
 				) ?? [];

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -1,12 +1,14 @@
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { syncSkills } from "../../src/lib/skills/sync.js";
 import {
 	applySubagentSync,
 	planSubagentSync,
 	syncSubagents,
 } from "../../src/lib/subagents/sync.js";
 import { BUILTIN_TARGETS } from "../../src/lib/targets/builtins.js";
+import { readManagedOutputs } from "../../src/lib/targets/managed-outputs.js";
 import { resolveTargets } from "../../src/lib/targets/resolve-targets.js";
 
 async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
@@ -475,6 +477,63 @@ describe.sequential("subagent sync", () => {
 			const summary = await applySubagentSync(removalPlan);
 			expect(summary.warnings.some((warning) => warning.includes("Skipped removing"))).toBe(true);
 			expect(await pathExists(destination)).toBe(true);
+		});
+	});
+
+	it("retires stale managed conversion ownership during direct sync when a canonical skill appears", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "planner", "subagent body");
+			const codexTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "codex");
+
+			const initialSummary = await syncSubagents({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+			});
+			expect(initialSummary.hadFailures).toBe(false);
+
+			const destination = path.join(root, ".codex", "skills", "planner", "SKILL.md");
+			expect(await pathExists(destination)).toBe(true);
+
+			await rm(path.join(root, "agents", "agents", "planner.md"));
+			await writeCanonicalSkill(root, "planner", "canonical skill");
+
+			const skillSummary = await syncSkills({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+			});
+			expect(skillSummary.hadFailures).toBe(false);
+
+			const subagentSummary = await syncSubagents({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+			});
+			expect(
+				subagentSummary.warnings.some((warning) =>
+					warning.includes("Output modified since last sync"),
+				),
+			).toBe(false);
+
+			const managed = await readManagedOutputs(root, path.join(root, "home"));
+			const plannerEntries =
+				managed?.entries.filter(
+					(entry) => entry.targetId === "codex" && entry.sourceId === "planner",
+				) ?? [];
+			expect(plannerEntries).toEqual([
+				expect.objectContaining({
+					sourceType: "skill",
+				}),
+			]);
+			expect(await readFile(destination, "utf8")).toContain("canonical skill");
 		});
 	});
 

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -215,6 +215,46 @@ describe.sequential("subagent sync", () => {
 		});
 	});
 
+	it("skips disabled subagents with invalid targets by default and fails when explicitly included", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "helper", "Subagent body");
+			const catalogDir = path.join(root, "agents", "agents");
+			await writeFile(
+				path.join(catalogDir, "draft.md"),
+				["---", "name: draft", "enabled: false", "targets:", "  - nope", "---", "Draft body"].join(
+					"\n",
+				),
+				"utf8",
+			);
+			const claudeTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "claude");
+
+			const summary = await syncSubagents({
+				repoRoot: root,
+				targets: claudeTargets,
+				validAgents: ["claude"],
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "agents", "helper.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "agents", "draft.md"))).toBe(false);
+
+			await expect(
+				syncSubagents({
+					repoRoot: root,
+					targets: claudeTargets,
+					validAgents: ["claude"],
+					removeMissing: true,
+					includeItem: (item) => (item.canonicalName === "draft" ? true : item.enabledByDefault),
+				}),
+			).rejects.toThrow(/unsupported targets/);
+		});
+	});
+
 	it("ignores target-mismatched invalid canonical skills during direct sync", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -232,6 +232,35 @@ describe.sequential("subagent sync", () => {
 		});
 	});
 
+	it("does not treat frontmatter-disabled canonical skills as conversion conflicts", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "---", "canonical skill"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "subagent body");
+
+			const plan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["codex"],
+				removeMissing: true,
+			});
+
+			expect(plan.plan.actions).toHaveLength(1);
+			const action = plan.plan.actions[0];
+			expect(action.action).toBe("convert");
+			expect(action.conflict).not.toBe(true);
+
+			await applySubagentSync(plan);
+
+			const destination = path.join(root, ".codex", "skills", "planner", "SKILL.md");
+			expect(await pathExists(destination)).toBe(true);
+			expect(await readFile(destination, "utf8")).toContain("subagent body");
+		});
+	});
+
 	it("skips conversion when a local skill exists", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -184,6 +184,28 @@ describe.sequential("subagent sync", () => {
 		});
 	});
 
+	it("ignores target-mismatched canonical skills with invalid target aliases when planning skill conversion", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "targets:", "  - claude", "  - nope", "---", "Broken"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "Subagent body");
+
+			const plan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["codex"],
+				removeMissing: true,
+				includeSkill: (item) => (item.canonicalName === "planner" ? true : item.enabledByDefault),
+			});
+
+			const plannerAction = plan.plan.actions.find((action) => action.subagentName === "planner");
+			expect(plannerAction?.action).toBe("convert");
+		});
+	});
+
 	it("skips disabled draft subagents by default and fails when explicitly included", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -281,6 +303,35 @@ describe.sequential("subagent sync", () => {
 				targets: codexTargets,
 				validAgents: ["codex"],
 				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			const destination = path.join(root, ".codex", "skills", "planner", "SKILL.md");
+			expect(await pathExists(destination)).toBe(true);
+			expect(await readFile(destination, "utf8")).toContain("Subagent body");
+		});
+	});
+
+	it("ignores target-mismatched canonical skills with invalid target aliases during direct sync", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"planner",
+				["---", "enabled: false", "targets:", "  - claude", "  - nope", "---", "Broken"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "Subagent body");
+			const codexTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "codex");
+
+			const summary = await syncSubagents({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+				includeSkill: (item) => (item.canonicalName === "planner" ? true : item.enabledByDefault),
 			});
 
 			expect(summary.hadFailures).toBe(false);

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -1,7 +1,13 @@
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { applySubagentSync, planSubagentSync } from "../../src/lib/subagents/sync.js";
+import {
+	applySubagentSync,
+	planSubagentSync,
+	syncSubagents,
+} from "../../src/lib/subagents/sync.js";
+import { BUILTIN_TARGETS } from "../../src/lib/targets/builtins.js";
+import { resolveTargets } from "../../src/lib/targets/resolve-targets.js";
 
 async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
 	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-subagents-"));
@@ -126,6 +132,65 @@ describe.sequential("subagent sync", () => {
 				entry.includes("does not support native subagents"),
 			);
 			expect(warning).toBeTruthy();
+		});
+	});
+
+	it("does not validate unrelated skills when planning native subagent sync", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"broken",
+				["---", "enabled: maybe", "---", "Broken"].join("\n"),
+			);
+			await writeSubagent(root, "helper", "Subagent body");
+
+			const plan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["claude"],
+				removeMissing: true,
+			});
+
+			const helperAction = plan.plan.actions.find((action) => action.subagentName === "helper");
+			expect(helperAction?.action).toBe("create");
+		});
+	});
+
+	it("skips disabled draft subagents by default and fails when explicitly included", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeSubagent(root, "helper", "Subagent body");
+			const catalogDir = path.join(root, "agents", "agents");
+			await writeFile(
+				path.join(catalogDir, "draft.md"),
+				["---", "name: draft", "enabled: false", "---", ""].join("\n"),
+				"utf8",
+			);
+			const claudeTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "claude");
+
+			const summary = await syncSubagents({
+				repoRoot: root,
+				targets: claudeTargets,
+				validAgents: ["claude"],
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			expect(await pathExists(path.join(root, ".claude", "agents", "helper.md"))).toBe(true);
+			expect(await pathExists(path.join(root, ".claude", "agents", "draft.md"))).toBe(false);
+
+			await expect(
+				syncSubagents({
+					repoRoot: root,
+					targets: claudeTargets,
+					validAgents: ["claude"],
+					removeMissing: true,
+					includeItem: (item) => (item.canonicalName === "draft" ? true : item.enabledByDefault),
+				}),
+			).rejects.toThrow(/empty body/);
 		});
 	});
 

--- a/tests/subagents/sync.test.ts
+++ b/tests/subagents/sync.test.ts
@@ -156,6 +156,27 @@ describe.sequential("subagent sync", () => {
 		});
 	});
 
+	it("ignores target-mismatched invalid canonical skills when planning skill conversion", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"planner",
+				["---", "targets:", "  - claude", "enabled: maybe", "---", "Broken"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "Subagent body");
+
+			const plan = await planSubagentSync({
+				repoRoot: root,
+				targets: ["codex"],
+				removeMissing: true,
+			});
+
+			const plannerAction = plan.plan.actions.find((action) => action.subagentName === "planner");
+			expect(plannerAction?.action).toBe("convert");
+		});
+	});
+
 	it("skips disabled draft subagents by default and fails when explicitly included", async () => {
 		await withTempRepo(async (root) => {
 			await createRepoRoot(root);
@@ -191,6 +212,34 @@ describe.sequential("subagent sync", () => {
 					includeItem: (item) => (item.canonicalName === "draft" ? true : item.enabledByDefault),
 				}),
 			).rejects.toThrow(/empty body/);
+		});
+	});
+
+	it("ignores target-mismatched invalid canonical skills during direct sync", async () => {
+		await withTempRepo(async (root) => {
+			await createRepoRoot(root);
+			await writeCanonicalSkill(
+				root,
+				"planner",
+				["---", "targets:", "  - claude", "enabled: maybe", "---", "Broken"].join("\n"),
+			);
+			await writeSubagent(root, "planner", "Subagent body");
+			const codexTargets = resolveTargets({
+				config: null,
+				builtIns: BUILTIN_TARGETS,
+			}).targets.filter((target) => target.id === "codex");
+
+			const summary = await syncSubagents({
+				repoRoot: root,
+				targets: codexTargets,
+				validAgents: ["codex"],
+				removeMissing: true,
+			});
+
+			expect(summary.hadFailures).toBe(false);
+			const destination = path.join(root, ".codex", "skills", "planner", "SKILL.md");
+			expect(await pathExists(destination)).toBe(true);
+			expect(await readFile(destination, "utf8")).toContain("Subagent body");
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add frontmatter `enabled: false` support for skills, commands, and subagents as an item-level default
- let profile `enable` rules opt default-disabled items back in while keeping profile `disable` as the last word
- strip `enabled` from rendered outputs and document the new behavior

## Testing
- npm run check
- npm test