### PR TITLE
Add fast usage extraction and fix Claude weekly totals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniagent",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniagent",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniagent",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "description": "Unified agent configuration CLI that compiles canonical agent configs to multiple runtimes.",
   "type": "module",
   "bin": {

--- a/src/lib/usage/claude.ts
+++ b/src/lib/usage/claude.ts
@@ -431,7 +431,7 @@ function parseClaudeLines(lines: string[]): ParsedClaudeUsage {
 		}
 
 		if (line.startsWith("Current week")) {
-			section = "currentWeek";
+			section = shouldParseClaudeWeeklySection(line, values) ? "currentWeek" : "";
 			continue;
 		}
 
@@ -459,6 +459,14 @@ function parseClaudeLines(lines: string[]): ParsedClaudeUsage {
 	}
 
 	return values;
+}
+
+function shouldParseClaudeWeeklySection(line: string, values: ParsedClaudeUsage): boolean {
+	const sectionLabel = line.toLowerCase();
+	if (/\([^)]*\bonly\)/.test(sectionLabel)) {
+		return false;
+	}
+	return !values.currentWeekUsed || sectionLabel.includes("all models");
 }
 
 function formatRaw(used: string, resets: string): string {

--- a/src/lib/usage/claude.ts
+++ b/src/lib/usage/claude.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import { cleanControlOutput, compactLines, makeUsageLimit, parsePercentUsed } from "./format.js";
 import { enterKey, escapeKey, runPtyScenario } from "./pty.js";
 import type {
@@ -5,6 +10,23 @@ import type {
 	UsageExtractionContext,
 	UsageExtractionResult,
 } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+const CLAUDE_CODE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+const CLAUDE_CODE_CREDENTIALS_PATH = [".claude", ".credentials.json"];
+const CLAUDE_USAGE_API_URL = "https://api.anthropic.com/v1/messages";
+const CLAUDE_USAGE_API_TIMEOUT_MS = 10_000;
+const CLAUDE_USAGE_API_HEADERS = {
+	"anthropic-version": "2023-06-01",
+	"anthropic-beta": "oauth-2025-04-20",
+	"content-type": "application/json",
+	"user-agent": "claude-code/2.1.5",
+} as const;
+const CLAUDE_USAGE_API_BODY = {
+	model: "claude-haiku-4-5-20251001",
+	max_tokens: 1,
+	messages: [{ role: "user", content: "hi" }],
+} as const;
 
 export type ParsedClaudeUsage = {
 	currentSessionUsed: string;
@@ -14,6 +36,19 @@ export type ParsedClaudeUsage = {
 };
 
 export async function extractClaudeUsage(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	try {
+		return await extractClaudeUsageFromApi(context);
+	} catch (error) {
+		if (context.signal.aborted) {
+			throw error;
+		}
+		return extractClaudeUsageFromTui(context);
+	}
+}
+
+async function extractClaudeUsageFromTui(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "claude";
@@ -61,6 +96,269 @@ export async function extractClaudeUsage(
 		limits,
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
+}
+
+async function extractClaudeUsageFromApi(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	const command = context.command ?? context.launch?.command ?? "claude";
+	const token = await readClaudeAccessToken(context);
+	if (token == null) {
+		throw new Error("Claude Code OAuth token was not available.");
+	}
+
+	const response = await fetchClaudeUsageHeaders(token, context.signal);
+	if (response.status >= 400) {
+		throw new Error(`Claude usage API returned HTTP ${response.status}.`);
+	}
+
+	const result = buildClaudeApiUsageResult(response.headers, {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		now: context.now,
+		command,
+	});
+	if (result.limits.length === 0) {
+		throw new Error("Claude usage API response did not include usage headers.");
+	}
+	return result;
+}
+
+type ClaudeApiUsageContext = Pick<UsageExtractionContext, "targetId" | "displayName" | "now"> & {
+	command?: string;
+};
+
+type ClaudeUsageHeaders = Pick<Headers, "get">;
+
+type ClaudeUsageApiResponse = {
+	status: number;
+	headers: ClaudeUsageHeaders;
+};
+
+export function buildClaudeApiUsageResult(
+	headers: ClaudeUsageHeaders,
+	context: ClaudeApiUsageContext,
+): UsageExtractionResult {
+	const sessionUsed = parseUsageHeaderFraction(
+		headers.get("anthropic-ratelimit-unified-5h-utilization"),
+	);
+	const weekUsed = parseUsageHeaderFraction(
+		headers.get("anthropic-ratelimit-unified-7d-utilization"),
+	);
+
+	if (sessionUsed == null || weekUsed == null) {
+		throw new Error("Claude usage API response did not include complete usage headers.");
+	}
+
+	return {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		command: context.command,
+		limits: [
+			makeClaudeApiUsageLimit({
+				targetId: context.targetId,
+				scope: "current_session",
+				window: "session",
+				percentUsed: sessionUsed,
+				resetAt: parseEpochSecondsHeader(headers.get("anthropic-ratelimit-unified-5h-reset")),
+				now: context.now,
+			}),
+			makeClaudeApiUsageLimit({
+				targetId: context.targetId,
+				scope: "current_week",
+				window: "weekly",
+				percentUsed: weekUsed,
+				resetAt: parseEpochSecondsHeader(headers.get("anthropic-ratelimit-unified-7d-reset")),
+				now: context.now,
+			}),
+		],
+	};
+}
+
+export function extractClaudeAccessToken(blob: string): string | null {
+	const trimmed = blob.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		const token = findAccessToken(parsed);
+		if (token != null) {
+			return token;
+		}
+	} catch {
+		// Fall through to the shape-tolerant extractors below.
+	}
+
+	const match = /"accessToken"\s*:\s*"([^"]+)"/.exec(trimmed);
+	if (match?.[1]) {
+		return match[1];
+	}
+
+	if (/^[A-Za-z0-9_\-.~+/=]{20,}$/.test(trimmed)) {
+		return trimmed;
+	}
+	return null;
+}
+
+async function readClaudeAccessToken(
+	context: Pick<UsageExtractionContext, "homeDir" | "signal">,
+): Promise<string | null> {
+	const tokenFromFile = await readClaudeAccessTokenFromFile(context.homeDir);
+	if (tokenFromFile != null) {
+		return tokenFromFile;
+	}
+
+	if (process.platform !== "darwin") {
+		return null;
+	}
+	return readClaudeAccessTokenFromKeychain(context.signal);
+}
+
+async function readClaudeAccessTokenFromFile(homeDir: string): Promise<string | null> {
+	try {
+		const raw = await readFile(path.join(homeDir, ...CLAUDE_CODE_CREDENTIALS_PATH), "utf8");
+		return extractClaudeAccessToken(raw);
+	} catch {
+		return null;
+	}
+}
+
+async function readClaudeAccessTokenFromKeychain(signal: AbortSignal): Promise<string | null> {
+	const username = os.userInfo().username;
+	const keychainArgs = [
+		["find-generic-password", "-s", CLAUDE_CODE_KEYCHAIN_SERVICE, "-a", username, "-w"],
+		["find-generic-password", "-s", CLAUDE_CODE_KEYCHAIN_SERVICE, "-w"],
+	];
+
+	for (const args of keychainArgs) {
+		try {
+			const { stdout } = await execFileAsync("security", args, {
+				timeout: 5_000,
+				signal,
+				maxBuffer: 1024 * 1024,
+			});
+			const token = extractClaudeAccessToken(stdout);
+			if (token != null) {
+				return token;
+			}
+		} catch {
+			if (signal.aborted) {
+				throw signal.reason;
+			}
+		}
+	}
+	return null;
+}
+
+async function fetchClaudeUsageHeaders(
+	token: string,
+	parentSignal: AbortSignal,
+): Promise<ClaudeUsageApiResponse> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort(new Error("Claude usage API request timed out."));
+	}, CLAUDE_USAGE_API_TIMEOUT_MS);
+	const abortFromParent = () => {
+		controller.abort(parentSignal.reason);
+	};
+	parentSignal.addEventListener("abort", abortFromParent, { once: true });
+
+	try {
+		const response = await fetch(CLAUDE_USAGE_API_URL, {
+			method: "POST",
+			headers: {
+				...CLAUDE_USAGE_API_HEADERS,
+				authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify(CLAUDE_USAGE_API_BODY),
+			signal: controller.signal,
+		});
+		return {
+			status: response.status,
+			headers: response.headers,
+		};
+	} finally {
+		clearTimeout(timeout);
+		parentSignal.removeEventListener("abort", abortFromParent);
+	}
+}
+
+function findAccessToken(value: unknown): string | null {
+	if (value == null || typeof value !== "object") {
+		return null;
+	}
+
+	const record = value as Record<string, unknown>;
+	if (typeof record.accessToken === "string") {
+		return record.accessToken;
+	}
+
+	for (const child of Object.values(record)) {
+		const token = findAccessToken(child);
+		if (token != null) {
+			return token;
+		}
+	}
+	return null;
+}
+
+function makeClaudeApiUsageLimit(options: {
+	targetId: string;
+	scope: string;
+	window: "session" | "weekly";
+	percentUsed: number;
+	resetAt: string | null;
+	now: Date;
+}): NormalizedUsageLimit {
+	const percentUsed = clampPercent(options.percentUsed);
+	const resetText = options.resetAt == null ? null : `resets ${options.resetAt}`;
+	const raw = `${formatPercent(percentUsed)} used${resetText == null ? "" : ` (${resetText})`}`;
+	const limit = makeUsageLimit({
+		targetId: options.targetId,
+		scope: options.scope,
+		window: options.window,
+		percentUsed,
+		percentRemaining: 100 - percentUsed,
+		resetText,
+		raw,
+		now: options.now,
+	});
+	return {
+		...limit,
+		resetAt: options.resetAt,
+	};
+}
+
+function parseUsageHeaderFraction(value: string | null): number | null {
+	if (value == null || !value.trim()) {
+		return null;
+	}
+	const fraction = Number(value);
+	if (!Number.isFinite(fraction)) {
+		return null;
+	}
+	return fraction * 100;
+}
+
+function parseEpochSecondsHeader(value: string | null): string | null {
+	if (value == null || !value.trim()) {
+		return null;
+	}
+	const seconds = Number(value);
+	if (!Number.isFinite(seconds) || seconds <= 0) {
+		return null;
+	}
+	return new Date(seconds * 1000).toISOString();
+}
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, value));
+}
+
+function formatPercent(value: number): string {
+	return Number.isInteger(value) ? `${value}%` : `${Number(value.toFixed(2))}%`;
 }
 
 function hasClaudeUsageRows(snapshot: { raw: string; screen: string }): boolean {

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import {
 	cleanControlOutput,
 	makeUsageLimit,
@@ -25,6 +27,10 @@ const CODEX_WINDOWS = [
 	["spark", "weekly", "sparkWeeklyLimit"],
 ] as const;
 const CLEAR_LINE = "\x15";
+const CODEX_AUTH_PATH = [".codex", "auth.json"];
+const CODEX_INSTALLATION_ID_PATH = [".codex", "installation_id"];
+const CODEX_USAGE_API_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CODEX_USAGE_API_TIMEOUT_MS = 10_000;
 
 export type ParsedCodexStatus = {
 	model: string;
@@ -41,6 +47,19 @@ export type ParsedCodexStatus = {
 };
 
 export async function extractCodexUsage(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	try {
+		return await extractCodexUsageFromApi(context);
+	} catch (error) {
+		if (context.signal.aborted) {
+			throw error;
+		}
+		return extractCodexUsageFromTui(context);
+	}
+}
+
+async function extractCodexUsageFromTui(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "codex";
@@ -92,6 +111,341 @@ export async function extractCodexUsage(
 		...result,
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
+}
+
+async function extractCodexUsageFromApi(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	const command = context.command ?? context.launch?.command ?? "codex";
+	const auth = await readCodexBackendAuth(context.homeDir);
+	if (auth == null) {
+		throw new Error("Codex ChatGPT backend auth was not available.");
+	}
+
+	const installationId = await readCodexInstallationId(context.homeDir);
+	const response = await fetchCodexUsage(auth, installationId, context.signal);
+	if (response.status >= 400) {
+		throw new Error(`Codex usage API returned HTTP ${response.status}.`);
+	}
+
+	const body = await response.json();
+	return buildCodexApiUsageResult(body, {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		now: context.now,
+		command,
+	});
+}
+
+type CodexApiUsageContext = Pick<UsageExtractionContext, "targetId" | "displayName" | "now"> & {
+	command?: string;
+};
+
+type CodexBackendAuth = {
+	accessToken: string;
+	accountId: string;
+};
+
+type CodexUsageApiResponse = Pick<Response, "json" | "status">;
+
+type CodexUsagePayload = {
+	rate_limit?: CodexApiRateLimit;
+	additional_rate_limits?: CodexApiAdditionalRateLimit[];
+};
+
+type CodexApiAdditionalRateLimit = {
+	limit_name?: unknown;
+	metered_feature?: unknown;
+	rate_limit?: CodexApiRateLimit;
+};
+
+type CodexApiRateLimit = {
+	primary_window?: CodexApiRateLimitWindow;
+	secondary_window?: CodexApiRateLimitWindow;
+};
+
+type CodexApiRateLimitWindow = {
+	used_percent?: unknown;
+	limit_window_seconds?: unknown;
+	reset_at?: unknown;
+};
+
+export function buildCodexApiUsageResult(
+	payload: unknown,
+	context: CodexApiUsageContext,
+): UsageExtractionResult {
+	const usage = isRecord(payload) ? (payload as CodexUsagePayload) : {};
+	const limits = [
+		...buildCodexApiRateLimitUsageLimits({
+			targetId: context.targetId,
+			scope: "main",
+			rateLimit: usage.rate_limit,
+			now: context.now,
+			requireBothWindows: true,
+		}),
+		...buildCodexApiAdditionalUsageLimits(usage.additional_rate_limits, context),
+	];
+
+	const hasMainHourly = limits.some((limit) => limit.scope === "main" && limit.window === "hourly");
+	const hasMainWeekly = limits.some((limit) => limit.scope === "main" && limit.window === "weekly");
+	if (!hasMainHourly || !hasMainWeekly) {
+		throw new Error("Codex usage API response did not include complete main rate-limit windows.");
+	}
+
+	return {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		command: context.command,
+		limits,
+	};
+}
+
+export function extractCodexBackendAuth(blob: string): CodexBackendAuth | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(blob);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed) || !isRecord(parsed.tokens)) {
+		return null;
+	}
+
+	const accessToken = parsed.tokens.access_token;
+	const accountId = parsed.tokens.account_id;
+	if (typeof accessToken !== "string" || typeof accountId !== "string") {
+		return null;
+	}
+	if (!accessToken.trim() || !accountId.trim()) {
+		return null;
+	}
+	return {
+		accessToken,
+		accountId,
+	};
+}
+
+async function readCodexBackendAuth(homeDir: string): Promise<CodexBackendAuth | null> {
+	try {
+		const raw = await readFile(path.join(homeDir, ...CODEX_AUTH_PATH), "utf8");
+		return extractCodexBackendAuth(raw);
+	} catch {
+		return null;
+	}
+}
+
+async function readCodexInstallationId(homeDir: string): Promise<string | null> {
+	try {
+		const installationId = await readFile(
+			path.join(homeDir, ...CODEX_INSTALLATION_ID_PATH),
+			"utf8",
+		);
+		const trimmed = installationId.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
+async function fetchCodexUsage(
+	auth: CodexBackendAuth,
+	installationId: string | null,
+	parentSignal: AbortSignal,
+): Promise<CodexUsageApiResponse> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort(new Error("Codex usage API request timed out."));
+	}, CODEX_USAGE_API_TIMEOUT_MS);
+	const abortFromParent = () => {
+		controller.abort(parentSignal.reason);
+	};
+	parentSignal.addEventListener("abort", abortFromParent, { once: true });
+
+	try {
+		const headers: Record<string, string> = {
+			accept: "application/json",
+			authorization: `Bearer ${auth.accessToken}`,
+			"chatgpt-account-id": auth.accountId,
+			"user-agent": "codex-cli",
+		};
+		if (installationId != null) {
+			headers["x-codex-installation-id"] = installationId;
+		}
+
+		return await fetch(CODEX_USAGE_API_URL, {
+			method: "GET",
+			headers,
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timeout);
+		parentSignal.removeEventListener("abort", abortFromParent);
+	}
+}
+
+function buildCodexApiAdditionalUsageLimits(
+	additionalRateLimits: CodexApiAdditionalRateLimit[] | undefined,
+	context: Pick<UsageExtractionContext, "targetId" | "now">,
+): NormalizedUsageLimit[] {
+	if (!Array.isArray(additionalRateLimits)) {
+		return [];
+	}
+
+	return additionalRateLimits.flatMap((entry) => {
+		if (!isRecord(entry)) {
+			return [];
+		}
+
+		const limitName = typeof entry.limit_name === "string" ? entry.limit_name : "";
+		const meteredFeature = typeof entry.metered_feature === "string" ? entry.metered_feature : "";
+		const scope = codexAdditionalLimitScope(limitName, meteredFeature);
+		return buildCodexApiRateLimitUsageLimits({
+			targetId: context.targetId,
+			scope,
+			rateLimit: entry.rate_limit,
+			now: context.now,
+			labelPrefix: scope === "spark" ? undefined : limitName || meteredFeature || scope,
+			requireBothWindows: false,
+		});
+	});
+}
+
+function buildCodexApiRateLimitUsageLimits(options: {
+	targetId: string;
+	scope: string;
+	rateLimit: CodexApiRateLimit | undefined;
+	now: Date;
+	labelPrefix?: string;
+	requireBothWindows: boolean;
+}): NormalizedUsageLimit[] {
+	if (!isRecord(options.rateLimit)) {
+		return [];
+	}
+
+	const windows = [
+		["primary", options.rateLimit.primary_window],
+		["secondary", options.rateLimit.secondary_window],
+	] as const;
+	const limits = windows.flatMap(([kind, window]) => {
+		const limit = makeCodexApiUsageLimit({
+			targetId: options.targetId,
+			scope: options.scope,
+			windowKind: kind,
+			window,
+			now: options.now,
+			labelPrefix: options.labelPrefix,
+		});
+		return limit == null ? [] : [limit];
+	});
+
+	if (options.requireBothWindows && limits.length !== 2) {
+		return [];
+	}
+	return limits;
+}
+
+function makeCodexApiUsageLimit(options: {
+	targetId: string;
+	scope: string;
+	windowKind: "primary" | "secondary";
+	window: CodexApiRateLimitWindow | undefined;
+	now: Date;
+	labelPrefix?: string;
+}): NormalizedUsageLimit | null {
+	if (!isRecord(options.window)) {
+		return null;
+	}
+
+	const percentUsed = parseApiNumber(options.window.used_percent);
+	if (percentUsed == null) {
+		return null;
+	}
+
+	const resetAt = parseApiEpochSeconds(options.window.reset_at);
+	const window = codexApiWindowName(options.window, options.windowKind);
+	const percentUsedClamped = clampPercent(percentUsed);
+	const percentRemaining = 100 - percentUsedClamped;
+	const resetText = resetAt == null ? null : `resets ${resetAt}`;
+	const label =
+		options.labelPrefix == null ? undefined : `${options.labelPrefix} ${formatWindowLabel(window)}`;
+	const raw = `${formatPercent(percentRemaining)} left${resetText == null ? "" : ` (${resetText})`}`;
+	const limit = makeUsageLimit({
+		targetId: options.targetId,
+		scope: options.scope,
+		window,
+		label,
+		percentUsed: percentUsedClamped,
+		percentRemaining,
+		resetText,
+		raw,
+		now: options.now,
+	});
+	return {
+		...limit,
+		resetAt,
+	};
+}
+
+function codexAdditionalLimitScope(limitName: string, meteredFeature: string): string {
+	if (/\bspark\b/i.test(limitName) || /\bbengalfox\b/i.test(meteredFeature)) {
+		return "spark";
+	}
+	const source = limitName || meteredFeature || "additional";
+	const normalized = source
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return normalized || "additional";
+}
+
+function codexApiWindowName(
+	window: CodexApiRateLimitWindow,
+	kind: "primary" | "secondary",
+): "5h" | "weekly" | string {
+	const seconds = parseApiNumber(window.limit_window_seconds);
+	if (seconds === 18_000) {
+		return "5h";
+	}
+	if (seconds === 604_800) {
+		return "weekly";
+	}
+	return kind === "primary" ? "5h" : "weekly";
+}
+
+function formatWindowLabel(window: string): string {
+	return window === "weekly" ? "Weekly" : window === "5h" ? "5h" : window;
+}
+
+function parseApiNumber(value: unknown): number | null {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value !== "string" || !value.trim()) {
+		return null;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseApiEpochSeconds(value: unknown): string | null {
+	const seconds = parseApiNumber(value);
+	if (seconds == null || seconds <= 0) {
+		return null;
+	}
+	return new Date(seconds * 1000).toISOString();
+}
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, value));
+}
+
+function formatPercent(value: number): string {
+	return Number.isInteger(value) ? `${value}%` : `${Number(value.toFixed(2))}%`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function selectCodexStatus(result: PtyScenarioResult): ParsedCodexStatus {

--- a/src/lib/usage/gemini.ts
+++ b/src/lib/usage/gemini.ts
@@ -1,11 +1,36 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { cleanControlOutput, compactLines, makeUsageLimit } from "./format.js";
 import { enterKey, escapeKey, runPtyScenario, typeTextSteps } from "./pty.js";
-import type { UsageExtractionContext, UsageExtractionResult } from "./types.js";
+import type {
+	NormalizedUsageLimit,
+	UsageExtractionContext,
+	UsageExtractionResult,
+} from "./types.js";
 
 const TIER_MODEL_IDS = new Map([
 	["Flash", "flash"],
 	["Flash Lite", "flash-lite"],
 	["Pro", "pro"],
+]);
+const GEMINI_OAUTH_PATH = [".gemini", "oauth_creds.json"];
+const GEMINI_CODE_ASSIST_ENDPOINT = "https://cloudcode-pa.googleapis.com";
+const GEMINI_CODE_ASSIST_API_VERSION = "v1internal";
+const GEMINI_CODE_ASSIST_TIMEOUT_MS = 10_000;
+const GEMINI_OAUTH_EXPIRY_SKEW_MS = 60_000;
+const GEMINI_MODEL_TIERS = new Map([
+	["gemini-2.5-flash", "flash"],
+	["gemini-2.5-flash-lite", "flash-lite"],
+	["gemini-2.5-pro", "pro"],
+	["gemini-3-flash-preview", "flash"],
+	["gemini-3-pro-preview", "pro"],
+	["gemini-3.1-flash-lite-preview", "flash-lite"],
+	["gemini-3.1-pro-preview", "pro"],
+]);
+const GEMINI_TIER_DISPLAY_NAMES = new Map([
+	["flash", "Flash"],
+	["flash-lite", "Flash Lite"],
+	["pro", "Pro"],
 ]);
 
 export type ParsedGeminiUsageRow = {
@@ -22,6 +47,19 @@ export type ParsedGeminiModelDialog = {
 };
 
 export async function extractGeminiUsage(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	try {
+		return await extractGeminiUsageFromApi(context);
+	} catch (error) {
+		if (context.signal.aborted) {
+			throw error;
+		}
+		return extractGeminiUsageFromTui(context);
+	}
+}
+
+async function extractGeminiUsageFromTui(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "gemini";
@@ -81,6 +119,337 @@ export async function extractGeminiUsage(
 		}),
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
+}
+
+async function extractGeminiUsageFromApi(
+	context: UsageExtractionContext,
+): Promise<UsageExtractionResult> {
+	const command = context.command ?? context.launch?.command ?? "gemini";
+	const auth = await readGeminiOAuthCredentials(context.homeDir);
+	if (auth == null) {
+		throw new Error("Gemini OAuth credentials were not available.");
+	}
+
+	const accessToken = resolveGeminiAccessToken(auth);
+	const projectResponse = await fetchGeminiCodeAssistJson(
+		"loadCodeAssist",
+		accessToken,
+		buildGeminiLoadCodeAssistRequest(),
+		context.signal,
+	);
+	if (projectResponse.status >= 400) {
+		throw new Error(`Gemini Code Assist load API returned HTTP ${projectResponse.status}.`);
+	}
+
+	const project = extractGeminiCodeAssistProject(projectResponse.body);
+	if (project == null) {
+		throw new Error("Gemini Code Assist load API did not return a project.");
+	}
+
+	const quotaResponse = await fetchGeminiCodeAssistJson(
+		"retrieveUserQuota",
+		accessToken,
+		{ project },
+		context.signal,
+	);
+	if (quotaResponse.status >= 400) {
+		throw new Error(`Gemini Code Assist quota API returned HTTP ${quotaResponse.status}.`);
+	}
+
+	return buildGeminiApiUsageResult(quotaResponse.body, {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		now: context.now,
+		command,
+	});
+}
+
+type GeminiApiUsageContext = Pick<UsageExtractionContext, "targetId" | "displayName" | "now"> & {
+	command?: string;
+};
+
+type GeminiOAuthCredentials = {
+	accessToken?: string;
+	refreshToken?: string;
+	expiryDate?: number;
+};
+
+type GeminiCodeAssistResponse = {
+	status: number;
+	body: unknown;
+};
+
+type GeminiQuotaPayload = {
+	buckets?: GeminiQuotaBucket[];
+};
+
+type GeminiQuotaBucket = {
+	modelId?: unknown;
+	remainingFraction?: unknown;
+	remainingAmount?: unknown;
+	resetTime?: unknown;
+};
+
+type GeminiQuotaRow = {
+	modelId: string;
+	label: string;
+	remainingFraction: number;
+	resetAt: string | null;
+};
+
+export function buildGeminiApiUsageResult(
+	payload: unknown,
+	context: GeminiApiUsageContext,
+): UsageExtractionResult {
+	const usage = isRecord(payload) ? (payload as GeminiQuotaPayload) : {};
+	const limits = buildGeminiApiUsageLimits(usage.buckets, context);
+	if (limits.length === 0) {
+		throw new Error("Gemini Code Assist quota API response did not include model quota buckets.");
+	}
+
+	return {
+		targetId: context.targetId,
+		displayName: context.displayName,
+		command: context.command,
+		limits,
+	};
+}
+
+export function extractGeminiOAuthCredentials(blob: string): GeminiOAuthCredentials | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(blob);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed)) {
+		return null;
+	}
+
+	const accessToken =
+		typeof parsed.access_token === "string" && parsed.access_token.trim()
+			? parsed.access_token
+			: undefined;
+	const refreshToken =
+		typeof parsed.refresh_token === "string" && parsed.refresh_token.trim()
+			? parsed.refresh_token
+			: undefined;
+	const expiryDate = parseApiNumber(parsed.expiry_date) ?? undefined;
+	if (!accessToken && !refreshToken) {
+		return null;
+	}
+	return { accessToken, refreshToken, expiryDate };
+}
+
+async function readGeminiOAuthCredentials(homeDir: string): Promise<GeminiOAuthCredentials | null> {
+	try {
+		const raw = await readFile(path.join(homeDir, ...GEMINI_OAUTH_PATH), "utf8");
+		return extractGeminiOAuthCredentials(raw);
+	} catch {
+		return null;
+	}
+}
+
+function resolveGeminiAccessToken(auth: GeminiOAuthCredentials): string {
+	if (
+		auth.accessToken &&
+		(auth.expiryDate == null || auth.expiryDate - Date.now() > GEMINI_OAUTH_EXPIRY_SKEW_MS)
+	) {
+		return auth.accessToken;
+	}
+	throw new Error("Gemini cached access token was not available or expired.");
+}
+
+async function fetchGeminiCodeAssistJson(
+	method: string,
+	accessToken: string,
+	body: unknown,
+	parentSignal: AbortSignal,
+): Promise<GeminiCodeAssistResponse> {
+	const endpoint = process.env.CODE_ASSIST_ENDPOINT ?? GEMINI_CODE_ASSIST_ENDPOINT;
+	const version = process.env.CODE_ASSIST_API_VERSION ?? GEMINI_CODE_ASSIST_API_VERSION;
+	const response = await fetchWithTimeout(
+		`${endpoint}/${version}:${method}`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${accessToken}`,
+			},
+			body: JSON.stringify(body),
+		},
+		parentSignal,
+	);
+
+	return {
+		status: response.status,
+		body: await response.json(),
+	};
+}
+
+async function fetchWithTimeout(
+	input: string,
+	init: RequestInit,
+	parentSignal: AbortSignal,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort(new Error("Gemini Code Assist API request timed out."));
+	}, GEMINI_CODE_ASSIST_TIMEOUT_MS);
+	const abortFromParent = () => {
+		controller.abort(parentSignal.reason);
+	};
+	parentSignal.addEventListener("abort", abortFromParent, { once: true });
+
+	try {
+		return await fetch(input, { ...init, signal: controller.signal });
+	} finally {
+		clearTimeout(timeout);
+		parentSignal.removeEventListener("abort", abortFromParent);
+	}
+}
+
+function buildGeminiLoadCodeAssistRequest(): Record<string, unknown> {
+	const project = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GOOGLE_CLOUD_PROJECT_ID;
+	const metadata: Record<string, string> = {
+		ideType: "IDE_UNSPECIFIED",
+		platform: "PLATFORM_UNSPECIFIED",
+		pluginType: "GEMINI",
+	};
+	if (project) {
+		metadata.duetProject = project;
+	}
+	return {
+		...(project ? { cloudaicompanionProject: project } : {}),
+		metadata,
+	};
+}
+
+function extractGeminiCodeAssistProject(payload: unknown): string | null {
+	if (!isRecord(payload)) {
+		return null;
+	}
+	const project = payload.cloudaicompanionProject;
+	if (typeof project === "string" && project.trim()) {
+		return project;
+	}
+	if (isRecord(project) && typeof project.id === "string" && project.id.trim()) {
+		return project.id;
+	}
+	return null;
+}
+
+function buildGeminiApiUsageLimits(
+	buckets: GeminiQuotaBucket[] | undefined,
+	context: Pick<UsageExtractionContext, "targetId" | "now">,
+): NormalizedUsageLimit[] {
+	if (!Array.isArray(buckets)) {
+		return [];
+	}
+
+	return selectGeminiQuotaRows(buckets).map((row) =>
+		makeGeminiApiUsageLimit({
+			targetId: context.targetId,
+			now: context.now,
+			row,
+		}),
+	);
+}
+
+function selectGeminiQuotaRows(buckets: GeminiQuotaBucket[]): GeminiQuotaRow[] {
+	const grouped = new Map<string, GeminiQuotaRow>();
+
+	for (const bucket of buckets) {
+		if (!isRecord(bucket) || typeof bucket.modelId !== "string") {
+			continue;
+		}
+		const remainingFraction = parseApiNumber(bucket.remainingFraction);
+		if (remainingFraction == null) {
+			continue;
+		}
+
+		const modelId = bucket.modelId;
+		const tier = GEMINI_MODEL_TIERS.get(modelId);
+		const groupId = tier ?? modelId;
+		const label =
+			tier == null
+				? formatGeminiModelLabel(modelId)
+				: (GEMINI_TIER_DISPLAY_NAMES.get(tier) ?? tier);
+		const row = {
+			modelId: groupId,
+			label,
+			remainingFraction: clampFraction(remainingFraction),
+			resetAt: parseGeminiResetTime(bucket.resetTime),
+		};
+		const existing = grouped.get(groupId);
+		if (existing == null || row.remainingFraction < existing.remainingFraction) {
+			grouped.set(groupId, row);
+		}
+	}
+
+	return [...grouped.values()];
+}
+
+function makeGeminiApiUsageLimit(options: {
+	targetId: string;
+	now: Date;
+	row: GeminiQuotaRow;
+}): NormalizedUsageLimit {
+	const percentUsed = Math.round((1 - options.row.remainingFraction) * 100);
+	const percentRemaining = 100 - percentUsed;
+	const resetText = options.row.resetAt == null ? null : `resets ${options.row.resetAt}`;
+	const raw = `${options.row.label} ${percentUsed}% used${resetText == null ? "" : ` (${resetText})`}`;
+	const limit = makeUsageLimit({
+		targetId: options.targetId,
+		scope: modelScope(options.row.modelId),
+		window: "model",
+		label: options.row.label,
+		modelId: options.row.modelId,
+		modelLabel: options.row.label,
+		percentUsed,
+		percentRemaining,
+		resetText,
+		raw,
+		now: options.now,
+	});
+	return {
+		...limit,
+		resetAt: options.row.resetAt,
+	};
+}
+
+function formatGeminiModelLabel(modelId: string): string {
+	return modelId.length > 12 ? `${modelId.slice(0, 11)}…` : modelId;
+}
+
+function parseGeminiResetTime(value: unknown): string | null {
+	if (typeof value !== "string" || !value.trim()) {
+		return null;
+	}
+	const reset = new Date(value);
+	if (Number.isNaN(reset.getTime()) || reset.getUTCFullYear() < 2000) {
+		return null;
+	}
+	return reset.toISOString();
+}
+
+function parseApiNumber(value: unknown): number | null {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value !== "string" || !value.trim()) {
+		return null;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clampFraction(value: number): number {
+	return Math.max(0, Math.min(1, value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function isGeminiPromptReady(snapshot: { raw: string; screen: string }): boolean {

--- a/tests/lib/usage/claude-extract.test.ts
+++ b/tests/lib/usage/claude-extract.test.ts
@@ -1,0 +1,136 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { vi } from "vitest";
+
+const ptyMock = vi.hoisted(() => ({
+	runPtyScenario: vi.fn(),
+}));
+
+vi.mock("../../../src/lib/usage/pty.js", () => ({
+	enterKey: () => "\r",
+	escapeKey: () => "\x1b",
+	runPtyScenario: ptyMock.runPtyScenario,
+}));
+
+describe("Claude usage extraction", () => {
+	let homeDir: string;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		homeDir = await mkdtemp(path.join(os.tmpdir(), "omniagent-claude-usage-"));
+		await mkdir(path.join(homeDir, ".claude"), { recursive: true });
+		await writeFile(
+			path.join(homeDir, ".claude", ".credentials.json"),
+			JSON.stringify({ claudeAiOauth: { accessToken: "test-token-value-12345" } }),
+		);
+
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		ptyMock.runPtyScenario.mockReset();
+		ptyMock.runPtyScenario.mockResolvedValue({
+			command: "claude",
+			args: ["--model", "haiku"],
+			exitCode: 0,
+			timedOut: false,
+			raw: "",
+			screen: "",
+			snapshots: {
+				usage: {
+					raw: "",
+					screen: `
+Current session
+  37% used
+  Resets 3pm
+
+Current week
+  64% used
+  Resets May 25 at 9am
+`,
+				},
+			},
+			debug: [],
+		});
+	});
+
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await rm(homeDir, { recursive: true, force: true });
+	});
+
+	it("uses Claude API rate-limit headers before starting the TUI probe", async () => {
+		const { extractClaudeUsage } = await import("../../../src/lib/usage/claude.js");
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		fetchMock.mockResolvedValue({
+			status: 200,
+			headers: new Headers({
+				"anthropic-ratelimit-unified-5h-utilization": "0.12",
+				"anthropic-ratelimit-unified-5h-reset": String(now.getTime() / 1000 + 30 * 60),
+				"anthropic-ratelimit-unified-7d-utilization": "0.42",
+				"anthropic-ratelimit-unified-7d-reset": String(now.getTime() / 1000 + 5 * 24 * 60 * 60),
+			}),
+		});
+
+		const result = await extractClaudeUsage(buildContext({ homeDir, now }));
+
+		expect(ptyMock.runPtyScenario).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.anthropic.com/v1/messages",
+			expect.objectContaining({
+				method: "POST",
+				headers: expect.objectContaining({
+					authorization: "Bearer test-token-value-12345",
+					"anthropic-beta": "oauth-2025-04-20",
+				}),
+			}),
+		);
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"current_session:hourly",
+			"current_week:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([12, 42]);
+	});
+
+	it("falls back to the TUI probe when API headers are unavailable", async () => {
+		const { extractClaudeUsage } = await import("../../../src/lib/usage/claude.js");
+		fetchMock.mockResolvedValue({
+			status: 200,
+			headers: new Headers(),
+		});
+
+		const result = await extractClaudeUsage(
+			buildContext({ homeDir, now: new Date("2026-05-18T12:00:00.000Z") }),
+		);
+
+		expect(ptyMock.runPtyScenario).toHaveBeenCalledOnce();
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"current_session:hourly",
+			"current_week:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([37, 64]);
+	});
+});
+
+function buildContext(options: { homeDir: string; now: Date }) {
+	return {
+		targetId: "claude",
+		displayName: "Claude Code",
+		command: "claude",
+		window: "hourly",
+		windows: ["hourly", "weekly"],
+		now: options.now,
+		repoRoot: "/repo",
+		agentsDir: "/repo/agents",
+		homeDir: options.homeDir,
+		launch: {
+			command: "claude",
+			args: ["--model", "haiku"],
+			timeoutMs: 60_000,
+			cheapModel: "haiku",
+		},
+		signal: new AbortController().signal,
+		debug: {
+			enabled: false,
+		},
+	};
+}

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { vi } from "vitest";
 
 const ptyMock = vi.hoisted(() => ({
@@ -12,6 +15,8 @@ vi.mock("../../../src/lib/usage/pty.js", () => ({
 }));
 
 describe("Codex usage extraction", () => {
+	let tempDirs: string[] = [];
+
 	beforeEach(() => {
 		ptyMock.runPtyScenario.mockReset();
 		ptyMock.runPtyScenario.mockResolvedValue({
@@ -35,29 +40,106 @@ Weekly limit: 41% left
 		});
 	});
 
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+		tempDirs = [];
+	});
+
+	it("uses Codex API usage JSON before starting the TUI probe", async () => {
+		const { extractCodexUsage } = await import("../../../src/lib/usage/codex.js");
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const homeDir = await createCodexHome();
+		const fetchMock = vi.fn().mockResolvedValue({
+			status: 200,
+			json: async () => ({
+				rate_limit: {
+					primary_window: {
+						used_percent: 6,
+						limit_window_seconds: 18_000,
+						reset_at: now.getTime() / 1000 + 30 * 60,
+					},
+					secondary_window: {
+						used_percent: 25,
+						limit_window_seconds: 604_800,
+						reset_at: now.getTime() / 1000 + 7 * 24 * 60 * 60,
+					},
+				},
+				additional_rate_limits: [
+					{
+						limit_name: "GPT-5.3-Codex-Spark",
+						metered_feature: "codex_bengalfox",
+						rate_limit: {
+							primary_window: {
+								used_percent: 0,
+								limit_window_seconds: 18_000,
+							},
+							secondary_window: {
+								used_percent: 1,
+								limit_window_seconds: 604_800,
+							},
+						},
+					},
+				],
+			}),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await extractCodexUsage(buildContext({ homeDir, now }));
+
+		expect(ptyMock.runPtyScenario).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://chatgpt.com/backend-api/wham/usage",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					authorization: "Bearer test-access-token",
+					"chatgpt-account-id": "test-account-id",
+					"x-codex-installation-id": "test-installation-id",
+				}),
+			}),
+		);
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:hourly",
+			"main:weekly",
+			"spark:hourly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([6, 25, 0, 1]);
+	});
+
+	it("falls back to the TUI probe when the Codex API usage shape is unavailable", async () => {
+		const { extractCodexUsage } = await import("../../../src/lib/usage/codex.js");
+		const homeDir = await createCodexHome();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				status: 200,
+				json: async () => ({}),
+			}),
+		);
+
+		const result = await extractCodexUsage(
+			buildContext({ homeDir, now: new Date("2026-05-18T12:00:00.000Z") }),
+		);
+
+		expect(ptyMock.runPtyScenario).toHaveBeenCalledOnce();
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:hourly",
+			"main:weekly",
+		]);
+	});
+
 	it("runs the built-in probe from home and continues past the Codex trust gate", async () => {
 		const { extractCodexUsage } = await import("../../../src/lib/usage/codex.js");
 
-		const result = await extractCodexUsage({
-			targetId: "codex",
-			displayName: "OpenAI Codex",
-			command: "codex",
-			window: "hourly",
-			windows: ["hourly", "weekly"],
-			now: new Date("2026-05-18T12:00:00.000Z"),
-			repoRoot: "/tmp/untrusted-repo",
-			agentsDir: "/tmp/untrusted-repo/agents",
-			homeDir: "/Users/tester",
-			launch: {
-				command: "codex",
-				args: ["--no-alt-screen"],
-				timeoutMs: 60_000,
-			},
-			signal: new AbortController().signal,
-			debug: {
-				enabled: false,
-			},
-		});
+		const result = await extractCodexUsage(
+			buildContext({
+				homeDir: "/Users/tester",
+				now: new Date("2026-05-18T12:00:00.000Z"),
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		expect(options.cwd).toBe("/Users/tester");
@@ -74,4 +156,44 @@ Weekly limit: 41% left
 		expect(steps[1].skipIf({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
 		expect(steps[2].waitFor({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
 	});
+
+	async function createCodexHome(): Promise<string> {
+		const homeDir = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-usage-"));
+		tempDirs.push(homeDir);
+		await mkdir(path.join(homeDir, ".codex"), { recursive: true });
+		await writeFile(
+			path.join(homeDir, ".codex", "auth.json"),
+			JSON.stringify({
+				tokens: {
+					access_token: "test-access-token",
+					account_id: "test-account-id",
+				},
+			}),
+		);
+		await writeFile(path.join(homeDir, ".codex", "installation_id"), "test-installation-id");
+		return homeDir;
+	}
+
+	function buildContext(options: { homeDir: string; now: Date; repoRoot?: string }) {
+		return {
+			targetId: "codex",
+			displayName: "OpenAI Codex",
+			command: "codex",
+			window: "hourly",
+			windows: ["hourly", "weekly"],
+			now: options.now,
+			repoRoot: options.repoRoot ?? "/repo",
+			agentsDir: `${options.repoRoot ?? "/repo"}/agents`,
+			homeDir: options.homeDir,
+			launch: {
+				command: "codex",
+				args: ["--no-alt-screen"],
+				timeoutMs: 60_000,
+			},
+			signal: new AbortController().signal,
+			debug: {
+				enabled: false,
+			},
+		};
+	}
 });

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -1,4 +1,9 @@
-import { buildClaudeUsageLimits, parseClaudeUsage } from "../../../src/lib/usage/claude.js";
+import {
+	buildClaudeApiUsageResult,
+	buildClaudeUsageLimits,
+	extractClaudeAccessToken,
+	parseClaudeUsage,
+} from "../../../src/lib/usage/claude.js";
 import {
 	buildCodexUsageLimits,
 	buildCodexUsageResult,
@@ -329,6 +334,63 @@ gpt-5.5 xhigh · Context 0% used
 });
 
 describe("Claude usage parser", () => {
+	it("builds Claude usage limits from Anthropic rate-limit headers", () => {
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const headers = new Headers({
+			"anthropic-ratelimit-unified-5h-utilization": "0.375",
+			"anthropic-ratelimit-unified-5h-reset": String(now.getTime() / 1000 + 60 * 60),
+			"anthropic-ratelimit-unified-7d-utilization": "0.64",
+			"anthropic-ratelimit-unified-7d-reset": String(now.getTime() / 1000 + 7 * 24 * 60 * 60),
+		});
+
+		const result = buildClaudeApiUsageResult(headers, {
+			targetId: "claude",
+			displayName: "Claude Code",
+			command: "claude",
+			now,
+		});
+
+		expect(result.limits).toHaveLength(2);
+		expect(result.limits[0]).toMatchObject({
+			scope: "current_session",
+			window: "hourly",
+			percentUsed: 37.5,
+			percentRemaining: 62.5,
+			resetAt: "2026-05-18T13:00:00.000Z",
+		});
+		expect(result.limits[1]).toMatchObject({
+			scope: "current_week",
+			window: "weekly",
+			percentUsed: 64,
+			percentRemaining: 36,
+			resetAt: "2026-05-25T12:00:00.000Z",
+		});
+	});
+
+	it("requires complete Claude API utilization headers", () => {
+		expect(() =>
+			buildClaudeApiUsageResult(new Headers(), {
+				targetId: "claude",
+				displayName: "Claude Code",
+				now: new Date("2026-05-18T12:00:00.000Z"),
+			}),
+		).toThrow("Claude usage API response did not include complete usage headers.");
+	});
+
+	it("extracts Claude access tokens from known credential shapes", () => {
+		expect(extractClaudeAccessToken('{"accessToken":"direct-token-value-12345"}')).toBe(
+			"direct-token-value-12345",
+		);
+		expect(
+			extractClaudeAccessToken(
+				JSON.stringify({ claudeAiOauth: { accessToken: "nested-token-value-12345" } }),
+			),
+		).toBe("nested-token-value-12345");
+		expect(extractClaudeAccessToken("raw-token-value-with-enough-length")).toBe(
+			"raw-token-value-with-enough-length",
+		);
+	});
+
 	it("parses current session and current week usage", () => {
 		const parsed = parseClaudeUsage(`
 Current session

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -20,7 +20,11 @@ import {
 	parseResetAt,
 	parseResetText,
 } from "../../../src/lib/usage/format.js";
-import { parseGeminiModelDialog } from "../../../src/lib/usage/gemini.js";
+import {
+	buildGeminiApiUsageResult,
+	extractGeminiOAuthCredentials,
+	parseGeminiModelDialog,
+} from "../../../src/lib/usage/gemini.js";
 
 describe("usage parser utilities", () => {
 	it("cleans control output and parses common limit fragments", () => {
@@ -526,6 +530,87 @@ Current week
 });
 
 describe("Gemini usage parser", () => {
+	it("builds Gemini usage limits from Code Assist quota buckets", () => {
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const result = buildGeminiApiUsageResult(
+			{
+				buckets: [
+					{
+						modelId: "gemini-2.5-flash",
+						remainingFraction: 1,
+						resetTime: "2026-05-19T12:00:00Z",
+					},
+					{
+						modelId: "gemini-2.5-flash-lite",
+						remainingFraction: 0.999,
+						resetTime: "2026-05-19T01:00:00Z",
+					},
+					{
+						modelId: "gemini-2.5-pro",
+						remainingFraction: 0,
+						resetTime: "1970-01-01T00:00:00Z",
+					},
+					{
+						modelId: "gemini-3.1-flash-lite",
+						remainingFraction: "0.5",
+						resetTime: "2026-05-19T02:00:00Z",
+					},
+					{
+						modelId: "gemini-3.1-flash-lite-preview",
+						remainingFraction: 0.75,
+						resetTime: "2026-05-19T03:00:00Z",
+					},
+				],
+			},
+			{
+				targetId: "gemini",
+				displayName: "Gemini CLI",
+				command: "gemini",
+				now,
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.modelId}:${limit.label}`)).toEqual([
+			"flash:Flash",
+			"flash-lite:Flash Lite",
+			"pro:Pro",
+			"gemini-3.1-flash-lite:gemini-3.1-…",
+		]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([0, 25, 100, 50]);
+		expect(result.limits[0]?.resetAt).toBe("2026-05-19T12:00:00.000Z");
+		expect(result.limits[2]?.resetAt).toBeNull();
+	});
+
+	it("requires Gemini quota buckets", () => {
+		expect(() =>
+			buildGeminiApiUsageResult(
+				{},
+				{
+					targetId: "gemini",
+					displayName: "Gemini CLI",
+					now: new Date("2026-05-18T12:00:00.000Z"),
+				},
+			),
+		).toThrow("Gemini Code Assist quota API response did not include model quota buckets.");
+	});
+
+	it("extracts Gemini OAuth credentials", () => {
+		expect(
+			extractGeminiOAuthCredentials(
+				JSON.stringify({
+					access_token: "access-token-value",
+					refresh_token: "refresh-token-value",
+					expiry_date: "1770000000000",
+				}),
+			),
+		).toEqual({
+			accessToken: "access-token-value",
+			refreshToken: "refresh-token-value",
+			expiryDate: 1770000000000,
+		});
+		expect(extractGeminiOAuthCredentials("{}")).toBeNull();
+	});
+
 	it("parses selected models and usage rows", () => {
 		const parsed = parseGeminiModelDialog(`
 │ ● 1. gemini-2.5-pro │

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -5,8 +5,10 @@ import {
 	parseClaudeUsage,
 } from "../../../src/lib/usage/claude.js";
 import {
+	buildCodexApiUsageResult,
 	buildCodexUsageLimits,
 	buildCodexUsageResult,
+	extractCodexBackendAuth,
 	parseCodexStatus,
 } from "../../../src/lib/usage/codex.js";
 import {
@@ -71,6 +73,98 @@ describe("usage parser utilities", () => {
 });
 
 describe("Codex usage parser", () => {
+	it("builds Codex usage limits from the ChatGPT usage endpoint", () => {
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const result = buildCodexApiUsageResult(
+			{
+				rate_limit: {
+					primary_window: {
+						used_percent: 6,
+						limit_window_seconds: 18_000,
+						reset_at: now.getTime() / 1000 + 60 * 60,
+					},
+					secondary_window: {
+						used_percent: 25,
+						limit_window_seconds: 604_800,
+						reset_at: now.getTime() / 1000 + 7 * 24 * 60 * 60,
+					},
+				},
+				additional_rate_limits: [
+					{
+						limit_name: "GPT-5.3-Codex-Spark",
+						metered_feature: "codex_bengalfox",
+						rate_limit: {
+							primary_window: {
+								used_percent: 0,
+								limit_window_seconds: 18_000,
+								reset_at: now.getTime() / 1000 + 5 * 60 * 60,
+							},
+							secondary_window: {
+								used_percent: 1,
+								limit_window_seconds: 604_800,
+								reset_at: now.getTime() / 1000 + 6 * 24 * 60 * 60,
+							},
+						},
+					},
+				],
+			},
+			{
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				command: "codex",
+				now,
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:hourly",
+			"main:weekly",
+			"spark:hourly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([6, 25, 0, 1]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([94, 75, 100, 99]);
+		expect(result.limits[0]?.resetAt).toBe("2026-05-18T13:00:00.000Z");
+		expect(result.limits[1]?.resetAt).toBe("2026-05-25T12:00:00.000Z");
+	});
+
+	it("requires complete main Codex API rate-limit windows", () => {
+		expect(() =>
+			buildCodexApiUsageResult(
+				{
+					rate_limit: {
+						primary_window: {
+							used_percent: 6,
+							limit_window_seconds: 18_000,
+						},
+					},
+				},
+				{
+					targetId: "codex",
+					displayName: "OpenAI Codex",
+					now: new Date("2026-05-18T12:00:00.000Z"),
+				},
+			),
+		).toThrow("Codex usage API response did not include complete main rate-limit windows.");
+	});
+
+	it("extracts Codex ChatGPT backend auth from auth.json", () => {
+		expect(
+			extractCodexBackendAuth(
+				JSON.stringify({
+					tokens: {
+						access_token: "access-token-value",
+						account_id: "account-id-value",
+					},
+				}),
+			),
+		).toEqual({
+			accessToken: "access-token-value",
+			accountId: "account-id-value",
+		});
+		expect(extractCodexBackendAuth("{}")).toBeNull();
+	});
+
 	it("parses main and Spark status limits", () => {
 		const parsed = parseCodexStatus(`
 ╭──────────────────────────╮

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -508,6 +508,28 @@ Current week
 		});
 	});
 
+	it("prefers aggregate Claude weekly usage over model-specific weekly rows", () => {
+		const parsed = parseClaudeUsage(`
+Current session
+  100% used
+  Resets 2:10pm (America/New_York)
+
+Current week (all models)
+  14% used
+  Resets Jun 11 at 10am (America/New_York)
+
+Current week (Sonnet only)
+  0% used
+`);
+
+		expect(parsed).toEqual({
+			currentSessionUsed: "100% used",
+			currentSessionResets: "2:10pm (America/New_York)",
+			currentWeekUsed: "14% used",
+			currentWeekResets: "Jun 11 at 10am (America/New_York)",
+		});
+	});
+
 	it("omits absent current session or week rows when building normalized results", () => {
 		const limits = buildClaudeUsageLimits(
 			{


### PR DESCRIPTION
## Summary
- Add fast usage extraction paths for Claude, Codex, and Gemini so `omniagent usage` can read provider usage data before falling back to interactive TUI probes.
- Add and update usage extraction tests for the new provider-backed paths and parser behavior.
- Bump the package release to `0.1.11`.
- Fix the Claude Code 2.1.170 weekly usage regression by preserving `Current week (all models)` and ignoring later model-specific `(... only)` weekly rows.

## Verification
- `npx vitest run tests/lib/usage/parsers.test.ts tests/lib/usage/claude-extract.test.ts`
- `npm run dev -- usage claude --json` reports weekly `14% used`, `86% remaining` locally
- `npm run check && npm test`

## Commit Scope
- `091350d` Add fast Claude usage extraction
- `fb1799b` Add fast Codex usage extraction
- `9069cd8` Add fast Gemini usage extraction
- `07493a0` Release 0.1.11
- `78622c4` Fix Claude weekly usage parsing