### PR TITLE
[codex] Handle Claude usage TUI errors

### DIFF
--- a/src/lib/usage/claude.ts
+++ b/src/lib/usage/claude.ts
@@ -70,7 +70,7 @@ async function extractClaudeUsageFromTui(
 			{ waitFor: /Claude|>|❯/u, waitForSource: "screen", waitForTimeoutMs: 8_000 },
 			{ write: `/usage${enterKey()}` },
 			{
-				waitFor: hasClaudeUsageRows,
+				waitFor: hasClaudeUsageResult,
 				waitForTimeoutMs: 15_000,
 				capture: "usage",
 				captureWaitMs: 500,
@@ -86,6 +86,12 @@ async function extractClaudeUsageFromTui(
 	const parsed = parseClaudeUsage(usageSnapshot.screen, cleanedOutput);
 	const limits = buildClaudeUsageLimits(parsed, context);
 	if (limits.length === 0) {
+		const usageError = extractClaudeUsageError(usageSnapshot.screen, cleanedOutput);
+		if (usageError != null) {
+			const error = new Error(`Claude usage error: ${usageError}`);
+			Object.assign(error, { debug: ptyResult.debug });
+			throw error;
+		}
 		throw new Error("Claude usage output did not include session or weekly usage rows.");
 	}
 
@@ -364,6 +370,36 @@ function formatPercent(value: number): string {
 function hasClaudeUsageRows(snapshot: { raw: string; screen: string }): boolean {
 	const parsed = parseClaudeUsage(snapshot.screen, cleanControlOutput(snapshot.raw));
 	return Boolean(parsed.currentSessionUsed || parsed.currentWeekUsed);
+}
+
+function hasClaudeUsageResult(snapshot: { raw: string; screen: string }): boolean {
+	return (
+		hasClaudeUsageRows(snapshot) ||
+		extractClaudeUsageError(snapshot.screen, cleanControlOutput(snapshot.raw)) != null
+	);
+}
+
+function extractClaudeUsageError(screen: string, cleanedOutput = ""): string | null {
+	for (const source of [screen, cleanedOutput]) {
+		for (const line of compactLines(source)) {
+			const errorMatch = /^Error:\s*(.+)$/i.exec(line);
+			if (errorMatch?.[1]) {
+				return errorMatch[1].trim();
+			}
+
+			if (isClaudeAuthErrorLine(line)) {
+				return line;
+			}
+		}
+	}
+	return null;
+}
+
+function isClaudeAuthErrorLine(line: string): boolean {
+	return (
+		/\b(?:auth(?:entication)?|credentials?|login|logged in|token)\b/i.test(line) &&
+		/\b(?:error|expired|failed|invalid|missing|not|please|required|sign in)\b/i.test(line)
+	);
 }
 
 export function buildClaudeUsageLimits(

--- a/src/lib/usage/claude.ts
+++ b/src/lib/usage/claude.ts
@@ -373,10 +373,7 @@ function hasClaudeUsageRows(snapshot: { raw: string; screen: string }): boolean 
 }
 
 function hasClaudeUsageResult(snapshot: { raw: string; screen: string }): boolean {
-	return (
-		hasClaudeUsageRows(snapshot) ||
-		extractClaudeUsageError(snapshot.screen, cleanControlOutput(snapshot.raw)) != null
-	);
+	return hasClaudeUsageRows(snapshot) || extractClaudeUsageError(snapshot.screen) != null;
 }
 
 function extractClaudeUsageError(screen: string, cleanedOutput = ""): string | null {

--- a/tests/lib/usage/claude-extract.test.ts
+++ b/tests/lib/usage/claude-extract.test.ts
@@ -109,6 +109,50 @@ Current week
 		]);
 		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([37, 64]);
 	});
+
+	it("surfaces Claude TUI usage errors instead of waiting for usage rows", async () => {
+		const { extractClaudeUsage } = await import("../../../src/lib/usage/claude.js");
+		fetchMock.mockResolvedValue({
+			status: 200,
+			headers: new Headers(),
+		});
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "claude",
+			args: ["--model", "haiku"],
+			exitCode: 0,
+			timedOut: false,
+			raw: "",
+			screen: "",
+			snapshots: {
+				usage: {
+					raw: "",
+					screen: "Error: Usage endpoint is rate limited. Please try again in a moment.",
+				},
+			},
+			debug: [{ type: "screen-snapshot", label: "usage", content: "rate limited" }],
+		});
+
+		await expect(
+			extractClaudeUsage(buildContext({ homeDir, now: new Date("2026-05-18T12:00:00.000Z") })),
+		).rejects.toMatchObject({
+			message: "Claude usage error: Usage endpoint is rate limited. Please try again in a moment.",
+			debug: [{ type: "screen-snapshot", label: "usage", content: "rate limited" }],
+		});
+
+		const scenarioOptions = ptyMock.runPtyScenario.mock.calls[0]?.[0] as {
+			steps: Array<{
+				capture?: string;
+				waitFor?: (snapshot: { raw: string; screen: string }) => boolean;
+			}>;
+		};
+		const usageStep = scenarioOptions.steps.find((step) => step.capture === "usage");
+		expect(
+			usageStep?.waitFor?.({
+				raw: "",
+				screen: "Error: Usage endpoint is rate limited. Please try again in a moment.",
+			}),
+		).toBe(true);
+	});
 });
 
 function buildContext(options: { homeDir: string; now: Date }) {

--- a/tests/lib/usage/claude-extract.test.ts
+++ b/tests/lib/usage/claude-extract.test.ts
@@ -153,6 +153,57 @@ Current week
 			}),
 		).toBe(true);
 	});
+
+	it("does not treat stale raw terminal errors as usage results", async () => {
+		const { extractClaudeUsage } = await import("../../../src/lib/usage/claude.js");
+		fetchMock.mockResolvedValue({
+			status: 200,
+			headers: new Headers(),
+		});
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "claude",
+			args: ["--model", "haiku"],
+			exitCode: 0,
+			timedOut: false,
+			raw: "",
+			screen: "",
+			snapshots: {
+				usage: {
+					raw: "Error: Previous unrelated startup error.",
+					screen: `
+Current session
+  37% used
+  Resets 3pm
+
+Current week
+  64% used
+  Resets May 25 at 9am
+`,
+				},
+			},
+			debug: [],
+		});
+
+		const result = await extractClaudeUsage(
+			buildContext({ homeDir, now: new Date("2026-05-18T12:00:00.000Z") }),
+		);
+
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([37, 64]);
+
+		const scenarioOptions = ptyMock.runPtyScenario.mock.calls[0]?.[0] as {
+			steps: Array<{
+				capture?: string;
+				waitFor?: (snapshot: { raw: string; screen: string }) => boolean;
+			}>;
+		};
+		const usageStep = scenarioOptions.steps.find((step) => step.capture === "usage");
+		expect(
+			usageStep?.waitFor?.({
+				raw: "Error: Previous unrelated startup error.",
+				screen: "Claude >",
+			}),
+		).toBe(false);
+	});
 });
 
 function buildContext(options: { homeDir: string; now: Date }) {


### PR DESCRIPTION
## Summary

- Detect Claude `/usage` TUI error output as a completed probe result instead of waiting for usage rows until timeout.
- Surface the Claude error message directly, while preserving debug artifacts for `--debug`.
- Add regression coverage for the rate-limited usage screen.

## Root Cause

When Claude rendered an error such as `Error: Usage endpoint is rate limited. Please try again in a moment.`, the extractor only waited for parsed usage rows. Since no rows appeared, omniagent reported `Timed out waiting for usage.` instead of the actionable Claude error.

## Validation

- `npx vitest run tests/lib/usage/claude-extract.test.ts`
- `npx biome check src/lib/usage/claude.ts tests/lib/usage/claude-extract.test.ts`
- `npm run build`
- Live rebuilt probe: `node dist/cli.js usage claude --debug --timeout=20s` returned quickly with `Claude usage error: Usage endpoint is rate limited. Please try again in a moment.`
