### PR TITLE
Add unified structured output (--output-schema) to the CLI shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ Example usage:
 ./code-review.sh codex
 ```
 
+The shim also unifies structured outputs: pass a JSON schema (file path or inline JSON) with
+`--output-schema`, and stdout is exactly the schema-conforming JSON regardless of agent:
+
+```bash
+omniagent -p "Top 3 benefits of TypeScript" --agent claude \
+  --output-schema ./schema.json | jq .answer
+```
+
+See [`docs/cli-shim.md`](docs/cli-shim.md) for the full shared-flag capability matrix.
+
 ## Documentation
 
 - Docs index: [`docs/README.md`](docs/README.md)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ Example usage:
 ```
 
 The shim also unifies structured outputs: pass a JSON schema (file path or inline JSON) with
-`--output-schema`, and stdout is exactly the schema-conforming JSON regardless of agent:
+`--output-schema`, and stdout is exactly the schema-conforming JSON regardless of agent. Agents
+with native schema support (claude, codex) enforce it server-side; all others get a prompt-based
+fallback with client-side validation and automatic retries:
 
 ```bash
 omniagent -p "Top 3 benefits of TypeScript" --agent claude \

--- a/docs/cli-shim.md
+++ b/docs/cli-shim.md
@@ -91,7 +91,9 @@ Rules:
 - Native runs (codex, claude) are not re-validated client-side (enforcement is delegated to the
   agent); `--output-schema-retries` is ignored with a warning.
 - Fallback runs validate with ajv (`strict: false`); unknown schema keywords and `format` are not
-  enforced. Schemas that fail to compile exit with code 2 before the agent is spawned.
+  enforced. The validator dialect follows the schema's `$schema` declaration — draft 2020-12,
+  draft 2019-09, and draft-07 (also the default when `$schema` is absent) are supported. Schemas
+  that fail to compile exit with code 2 before the agent is spawned.
 - The schema must be a JSON object.
 - Failures exit with code 1 and write diagnostics to stderr: extraction failures (missing
   payload, error result, unparseable envelope) for native runs, and exhausted retries for

--- a/docs/cli-shim.md
+++ b/docs/cli-shim.md
@@ -27,21 +27,61 @@ You can set `defaultAgent` in `agents/omniagent.config.*` to avoid repeating `--
 - `--output <text|json|stream-json>` (aliases: `--json`, `--stream-json`)
 - `--model <name>`
 - `--web <on|off|true|false|1|0>` (bare `--web` enables)
+- `--output-schema <path-or-json>` (JSON schema file path or inline JSON object; one-shot only)
 
 ## Shared-flag capability matrix
 
-| Agent   | Approval | Sandbox | Output | Model | Web |
-|---------|----------|---------|--------|-------|-----|
-| codex   | ✓        | ✓       | ✓      | ✓     | ✓   |
-| claude  | ✓        | ✗       | ✓      | ✓     | ✗   |
-| gemini  | ✓        | ✓       | ✓      | ✓     | ✓   |
-| copilot | ✓        | ✗       | ✓      | ✓     | ✗   |
+| Agent   | Approval | Sandbox | Output | Model | Web | Output schema |
+|---------|----------|---------|--------|-------|-----|---------------|
+| codex   | ✓        | ✓       | ✓      | ✓     | ✓   | ✓             |
+| claude  | ✓        | ✗       | ✓      | ✓     | ✗   | ✓             |
+| gemini  | ✓        | ✓       | ✓      | ✓     | ✓   | ✗             |
+| copilot | ✓        | ✗       | ✓      | ✓     | ✗   | ✗             |
+
+## Structured output
+
+`--output-schema` enforces a JSON-schema-shaped final response — the coding-agent equivalent
+of API "structured outputs". The value is either a path to a `.json` schema file or an inline
+JSON object (values starting with `{` are treated as inline).
+
+```bash
+# Inline schema
+omniagent --agent claude -p "Top 3 TypeScript benefits" \
+  --output-schema '{"type":"object","properties":{"answer":{"type":"array","items":{"type":"string"}}},"required":["answer"],"additionalProperties":false}' \
+  | jq .answer
+
+# Schema file — identical stdout contract on codex
+omniagent --agent codex -p "Top 3 TypeScript benefits" --output-schema ./schema.json | jq .answer
+```
+
+The stdout contract is the same for every supporting agent: stdout is exactly the
+schema-conforming JSON (pipe it straight to `jq`). Agent-specific envelopes and session logs
+are handled by the shim:
+
+- claude: the shim forces `--output-format json`, consumes the result envelope, and prints only
+  its `structured_output` payload.
+- codex: the shim passes the schema via a temp file plus `--output-last-message`, forwards the
+  session log to stderr, and prints the final message to stdout.
+
+Rules:
+
+- One-shot only — provide `-p/--prompt` or pipe stdin; interactive mode exits with code 2.
+- Cannot be combined with explicit `--output`, `--json`, or `--stream-json` (exit code 2); the
+  shim owns the output format for schema runs.
+- Agents without native schema support (gemini, copilot) fail fast with exit code 2 instead of
+  the usual warn-and-ignore, because the output shape is a contract downstream scripts rely on.
+- The schema must be a JSON object; the response is not re-validated client-side (enforcement is
+  delegated to the agent).
+- Extraction failures (missing payload, error result, unparseable envelope) exit with code 1 and
+  write diagnostics to stderr.
 
 ## Notes
 
 - `--` passthrough is only valid after `--agent`.
-- Unsupported shared flags are ignored with a warning.
-- Output is passed through unmodified.
+- Unsupported shared flags are ignored with a warning (except `--output-schema`, which errors).
+- Output is passed through unmodified, except for `--output-schema` runs (see above).
+- Passthrough args after `--` are not checked for collisions with shim-generated flags such as
+  `--output-schema`; the agent CLI's own duplicate-flag error surfaces instead.
 - Some approval values are agent-specific.
 - Some output formats are one-shot only for specific CLIs.
 - Copilot exposes JSONL via `--output-format json`, so `--output json` and `--output stream-json` both map to that flag in one-shot mode.

--- a/docs/cli-shim.md
+++ b/docs/cli-shim.md
@@ -28,15 +28,16 @@ You can set `defaultAgent` in `agents/omniagent.config.*` to avoid repeating `--
 - `--model <name>`
 - `--web <on|off|true|false|1|0>` (bare `--web` enables)
 - `--output-schema <path-or-json>` (JSON schema file path or inline JSON object; one-shot only)
+- `--output-schema-retries <n>` (0-10, default 2; max retries for prompt-based fallback runs)
 
 ## Shared-flag capability matrix
 
 | Agent   | Approval | Sandbox | Output | Model | Web | Output schema |
 |---------|----------|---------|--------|-------|-----|---------------|
-| codex   | ✓        | ✓       | ✓      | ✓     | ✓   | ✓             |
-| claude  | ✓        | ✗       | ✓      | ✓     | ✗   | ✓             |
-| gemini  | ✓        | ✓       | ✓      | ✓     | ✓   | ✗             |
-| copilot | ✓        | ✗       | ✓      | ✓     | ✗   | ✗             |
+| codex   | ✓        | ✓       | ✓      | ✓     | ✓   | ✓ (native)    |
+| claude  | ✓        | ✗       | ✓      | ✓     | ✗   | ✓ (native)    |
+| gemini  | ✓        | ✓       | ✓      | ✓     | ✓   | ✓ (fallback)  |
+| copilot | ✓        | ✗       | ✓      | ✓     | ✗   | ✓ (fallback)  |
 
 ## Structured output
 
@@ -54,34 +55,58 @@ omniagent --agent claude -p "Top 3 TypeScript benefits" \
 omniagent --agent codex -p "Top 3 TypeScript benefits" --output-schema ./schema.json | jq .answer
 ```
 
-The stdout contract is the same for every supporting agent: stdout is exactly the
-schema-conforming JSON (pipe it straight to `jq`). Agent-specific envelopes and session logs
-are handled by the shim:
+The stdout contract is the same for every agent: stdout is exactly the schema-conforming JSON
+(pipe it straight to `jq`). Agent-specific envelopes and session logs are handled by the shim:
 
-- claude: the shim forces `--output-format json`, consumes the result envelope, and prints only
-  its `structured_output` payload.
-- codex: the shim passes the schema via a temp file plus `--output-last-message`, forwards the
-  session log to stderr, and prints the final message to stdout.
+- claude (native): the shim forces `--output-format json`, consumes the result envelope, and
+  prints only its `structured_output` payload.
+- codex (native): the shim passes the schema via a temp file plus `--output-last-message`,
+  forwards the session log to stderr, and prints the final message to stdout.
+- gemini, copilot, custom targets (fallback): see below.
+
+### Prompt-based fallback
+
+Agents without native schema support automatically use a prompt-based fallback: the shim embeds
+the schema in the prompt, captures the response, extracts the JSON (stripping prose or code
+fences), and validates it client-side against the schema. If validation fails, the shim re-invokes
+the agent with the previous output and the validation errors, up to `--output-schema-retries`
+retries (default 2, so 3 attempts total). Each attempt is a fresh agent run and incurs its own
+cost. A notice is written to stderr when the fallback engages:
+
+```text
+Notice: gemini lacks native --output-schema support; using prompt-based fallback with client-side validation.
+```
+
+- gemini: the shim adds `--output-format json` and reads the model text from the envelope's
+  `response` field.
+- copilot: the shim adds `--silent` and reads the response text from stdout.
+- Custom targets: declare `cli.flags.structuredOutputFallback` for clean capture, or get a plain
+  text-mode fallback by default (see [`docs/custom-targets.md`](custom-targets.md)).
 
 Rules:
 
 - One-shot only — provide `-p/--prompt` or pipe stdin; interactive mode exits with code 2.
 - Cannot be combined with explicit `--output`, `--json`, or `--stream-json` (exit code 2); the
   shim owns the output format for schema runs.
-- Agents without native schema support (gemini, copilot) fail fast with exit code 2 instead of
-  the usual warn-and-ignore, because the output shape is a contract downstream scripts rely on.
-- The schema must be a JSON object; the response is not re-validated client-side (enforcement is
-  delegated to the agent).
-- Extraction failures (missing payload, error result, unparseable envelope) exit with code 1 and
-  write diagnostics to stderr.
+- Native runs (codex, claude) are not re-validated client-side (enforcement is delegated to the
+  agent); `--output-schema-retries` is ignored with a warning.
+- Fallback runs validate with ajv (`strict: false`); unknown schema keywords and `format` are not
+  enforced. Schemas that fail to compile exit with code 2 before the agent is spawned.
+- The schema must be a JSON object.
+- Failures exit with code 1 and write diagnostics to stderr: extraction failures (missing
+  payload, error result, unparseable envelope) for native runs, and exhausted retries for
+  fallback runs. Nonzero agent exits are passed through without retrying.
+- A fallback target that defines no prompt mechanism cannot receive the schema and exits with
+  code 2.
 
 ## Notes
 
 - `--` passthrough is only valid after `--agent`.
-- Unsupported shared flags are ignored with a warning (except `--output-schema`, which errors).
+- Unsupported shared flags are ignored with a warning.
 - Output is passed through unmodified, except for `--output-schema` runs (see above).
 - Passthrough args after `--` are not checked for collisions with shim-generated flags such as
-  `--output-schema`; the agent CLI's own duplicate-flag error surfaces instead.
+  `--output-schema` or fallback-injected flags (gemini's `--output-format json`, copilot's
+  `--silent`); the agent CLI's own duplicate-flag error surfaces instead.
 - Some approval values are agent-specific.
 - Some output formats are one-shot only for specific CLIs.
 - Copilot exposes JSONL via `--output-format json`, so `--output json` and `--output stream-json` both map to that flag in one-shot mode.

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -94,6 +94,48 @@ const config = {
 export default config;
 ```
 
+## Structured output (`cli.flags.structuredOutput`)
+
+Custom targets whose CLI supports schema-constrained responses can declare a
+`structuredOutput` spec so the shim's `--output-schema` flag works for them:
+
+```ts
+const config = {
+	targets: [
+		{
+			id: "acme",
+			cli: {
+				modes: {
+					interactive: { command: "acme" },
+					oneShot: { command: "acme", args: ["run"] },
+				},
+				flags: {
+					structuredOutput: {
+						// "inline": schema JSON is passed as the flag value.
+						// "file": schema is written to a temp file and its path is passed.
+						delivery: "file",
+						flag: ["--schema"],
+						// Extra args always added alongside the schema (e.g. forcing JSON output).
+						companionArgs: ["--format", "json"],
+						// How the shim extracts the final payload:
+						// { type: "json-envelope", field: "structured_output" } parses captured
+						// stdout as JSON and prints only that field, or
+						// { type: "last-message-file", flag: ["--last-message"] } passes a temp
+						// file path via the given flag and prints its contents after the run.
+						extraction: { type: "last-message-file", flag: ["--last-message"] },
+					},
+				},
+			},
+		},
+	],
+};
+```
+
+Targets inheriting a built-in (`inherits: "codex"` or `inherits: "claude"`) get the built-in's
+spec automatically. Targets that define a custom `cli.translate` function receive the resolved
+plan as `invocation.structuredOutput` and must append `invocation.structuredOutput.args`
+themselves; the default translator does this automatically.
+
 `omniagent usage` enforces a 30-second per-target timeout unless `usage.launch.timeoutMs` is
 configured. A user-supplied `--timeout` value overrides `context.launch.timeoutMs` for that run,
 so custom extractors should pass `context.launch.timeoutMs` through to any child-process or TUI

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -136,6 +136,51 @@ spec automatically. Targets that define a custom `cli.translate` function receiv
 plan as `invocation.structuredOutput` and must append `invocation.structuredOutput.args`
 themselves; the default translator does this automatically.
 
+## Structured output fallback (`cli.flags.structuredOutputFallback`)
+
+Targets without a native `structuredOutput` spec automatically use the shim's prompt-based
+fallback for `--output-schema`: the schema is embedded in the prompt, the response is captured
+and validated client-side, and failed attempts are retried with feedback (up to
+`--output-schema-retries`, default 2). The target must define `cli.prompt`; a target with no
+prompt mechanism exits with code 2 for schema runs.
+
+By default the fallback captures the agent's raw stdout as text. Declare a
+`structuredOutputFallback` spec to add one-shot args for clean capture or to unwrap a JSON
+envelope first:
+
+```ts
+const config = {
+	targets: [
+		{
+			id: "acme",
+			cli: {
+				modes: {
+					interactive: { command: "acme" },
+					oneShot: { command: "acme", args: ["run"] },
+				},
+				prompt: { type: "flag", flag: ["-p"] },
+				flags: {
+					structuredOutputFallback: {
+						// Extra one-shot args that keep stdout parseable (quiet/log flags etc.).
+						args: ["--quiet"],
+						// "text" (default): stdout is the response text.
+						// "json-envelope": stdout is JSON; the response text is read from `field`.
+						extraction: { type: "text" },
+					},
+				},
+			},
+		},
+	],
+};
+```
+
+The built-in gemini target uses `{ args: ["--output-format", "json"], extraction: { type:
+"json-envelope", field: "response" } }`; copilot uses `{ args: ["--silent"], extraction: { type:
+"text" } }`. Targets with a custom `cli.translate` function receive fallback plans as
+`invocation.structuredOutput` too — append `invocation.structuredOutput.args` yourself, and note
+the prompt passed to `translate` is already augmented with the schema instructions on each
+attempt.
+
 `omniagent usage` enforces a 30-second per-target timeout unless `usage.launch.timeoutMs` is
 configured. A user-supplied `--timeout` value overrides `context.launch.timeoutMs` for that run,
 so custom extractors should pass `context.launch.timeoutMs` through to any child-process or TUI

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@xterm/headless": "^5.5.0",
+        "ajv": "^8.20.0",
         "jiti": "^2.6.1",
         "minimatch": "^10.2.5",
         "node-pty": "^1.0.0",
@@ -1370,6 +1371,22 @@
       "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==",
       "license": "MIT"
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1578,6 +1595,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1714,6 +1753,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/magic-string": {
@@ -1882,6 +1927,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@xterm/headless": "^5.5.0",
+    "ajv": "^8.20.0",
     "jiti": "^2.6.1",
     "minimatch": "^10.2.5",
     "node-pty": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@xterm/headless':
         specifier: ^5.5.0
         version: 5.5.0
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -655,6 +658,9 @@ packages:
   '@xterm/headless@5.5.0':
     resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -720,6 +726,12 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -768,6 +780,9 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -812,6 +827,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   rollup@4.55.1:
@@ -1388,6 +1407,13 @@ snapshots:
 
   '@xterm/headless@5.5.0': {}
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -1489,6 +1515,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.3: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -1520,6 +1550,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@9.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1562,6 +1594,8 @@ snapshots:
       source-map-js: 1.2.1
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   rollup@4.55.1:
     dependencies:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,11 +39,12 @@ const VERSION = resolveVersion();
 const KNOWN_COMMANDS = new Set(["hello", "greet", "echo", "sync", "dev", "profiles", "usage"]);
 const SHIM_CAPABILITIES = [
 	"Capabilities by agent:",
-	"  codex: approval, sandbox, output, model, web",
-	"  claude: approval, output, model",
+	"  codex: approval, sandbox, output, model, web, output-schema",
+	"  claude: approval, output, model, output-schema",
 	"  gemini: approval, sandbox, output, model, web",
 	"  copilot: approval, model",
 	"Unsupported shared flags for a selected agent emit a warning and are ignored.",
+	"--output-schema is one-shot only and errors on agents without native support.",
 ].join("\n");
 
 function formatError(message: string, args: string[]) {
@@ -170,6 +171,11 @@ export function runCli(argv = process.argv, options: RunCliOptions = {}) {
 					.option("agent", {
 						type: "string",
 						describe: "Select the agent (built-in id or configured alias).",
+					})
+					.option("output-schema", {
+						type: "string",
+						describe:
+							"JSON schema file path or inline JSON; emit the final response as schema-conforming JSON (one-shot only).",
 					})
 					.option("trace-translate", {
 						type: "boolean",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,10 +41,11 @@ const SHIM_CAPABILITIES = [
 	"Capabilities by agent:",
 	"  codex: approval, sandbox, output, model, web, output-schema",
 	"  claude: approval, output, model, output-schema",
-	"  gemini: approval, sandbox, output, model, web",
-	"  copilot: approval, model",
+	"  gemini: approval, sandbox, output, model, web, output-schema (fallback)",
+	"  copilot: approval, model, output-schema (fallback)",
 	"Unsupported shared flags for a selected agent emit a warning and are ignored.",
-	"--output-schema is one-shot only and errors on agents without native support.",
+	"--output-schema is one-shot only; agents without native support use a prompt-based",
+	"fallback with client-side validation and retries (--output-schema-retries, default 2).",
 ].join("\n");
 
 function formatError(message: string, args: string[]) {
@@ -176,6 +177,11 @@ export function runCli(argv = process.argv, options: RunCliOptions = {}) {
 						type: "string",
 						describe:
 							"JSON schema file path or inline JSON; emit the final response as schema-conforming JSON (one-shot only).",
+					})
+					.option("output-schema-retries", {
+						type: "number",
+						describe:
+							"Max retries when a prompt-based --output-schema fallback response fails validation (0-10, default 2).",
 					})
 					.option("trace-translate", {
 						type: "boolean",

--- a/src/cli/shim/execute.ts
+++ b/src/cli/shim/execute.ts
@@ -1,10 +1,14 @@
 import { spawn as defaultSpawn, type StdioOptions } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import type { StructuredOutputCapture } from "../../lib/targets/config-types.js";
 import { buildAgentArgs } from "./build-args.js";
 import type { ExitCodeReason } from "./errors.js";
+import { buildFallbackPrompt, buildRetryPrompt, extractJsonPayload } from "./fallback-prompts.js";
 import type { ResolvedInvocation, StructuredOutputPlan } from "./types.js";
 
 type SpawnFn = typeof defaultSpawn;
+
+type FallbackCapture = Extract<StructuredOutputCapture, { type: "fallback" }>;
 
 export type ExecuteResult = {
 	exitCode: number;
@@ -84,6 +88,10 @@ async function finalizeStructuredOutput(options: {
 		return { exitCode: 0, reason: "success" };
 	}
 
+	if (plan.capture.type === "fallback") {
+		return { exitCode: 1, reason: "execution-error" };
+	}
+
 	let contents: string;
 	try {
 		contents = await readFile(plan.capture.path, "utf8");
@@ -99,14 +107,219 @@ async function finalizeStructuredOutput(options: {
 	return { exitCode: 0, reason: "success" };
 }
 
+type CapturedAttempt =
+	| { kind: "spawn-error" }
+	| { kind: "closed"; code: number | null; captured: string };
+
+function runCapturedAttempt(params: {
+	spawn: SpawnFn;
+	command: string;
+	args: string[];
+	stdio: StdioOptions;
+	agentId: string;
+	stderr: NodeJS.WriteStream;
+}): Promise<CapturedAttempt> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const settle = (value: CapturedAttempt) => {
+			if (!settled) {
+				settled = true;
+				resolve(value);
+			}
+		};
+		const child = params.spawn(params.command, params.args, { stdio: params.stdio });
+		const chunks: Buffer[] = [];
+		const childStdout = child.stdout;
+		if (childStdout) {
+			childStdout.on("data", (chunk: Buffer) => {
+				chunks.push(Buffer.from(chunk));
+			});
+		}
+		child.on("error", (error) => {
+			params.stderr.write(`Error: ${error.message}\n`);
+			settle({ kind: "spawn-error" });
+		});
+		child.on("close", (code) => {
+			if (!childStdout) {
+				params.stderr.write(`Error: ${params.agentId} stdout was not captured.\n`);
+				settle({ kind: "spawn-error" });
+				return;
+			}
+			settle({ kind: "closed", code, captured: Buffer.concat(chunks).toString("utf8") });
+		});
+	});
+}
+
+function extractEnvelopeText(params: {
+	captured: string;
+	field: string;
+	agentId: string;
+	stderr: NodeJS.WriteStream;
+}): { ok: true; text: string } | { ok: false } {
+	const { captured, field, agentId, stderr } = params;
+	let envelope: unknown;
+	try {
+		envelope = JSON.parse(captured);
+	} catch {
+		envelope = undefined;
+	}
+	if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
+		if (captured.length > 0) {
+			stderr.write(captured);
+		}
+		stderr.write(`Error: ${agentId} did not return a JSON envelope.\n`);
+		return { ok: false };
+	}
+	const record = envelope as Record<string, unknown>;
+	if (record.error !== undefined && record.error !== null) {
+		stderr.write(captured);
+		stderr.write(`Error: ${agentId} reported an error result.\n`);
+		return { ok: false };
+	}
+	const payload = record[field];
+	if (payload === undefined || payload === null) {
+		stderr.write(captured);
+		stderr.write(`Error: ${agentId} response is missing ${field}.\n`);
+		return { ok: false };
+	}
+	return { ok: true, text: typeof payload === "string" ? payload : JSON.stringify(payload) };
+}
+
+async function runFallbackAttempts(params: {
+	invocation: ResolvedInvocation;
+	plan: StructuredOutputPlan;
+	capture: FallbackCapture;
+	options: ExecuteOptions;
+	stdout: NodeJS.WriteStream;
+	stderr: NodeJS.WriteStream;
+}): Promise<ExecuteResult> {
+	const { invocation, plan, capture, options, stdout, stderr } = params;
+	const agentId = invocation.agent.id;
+	const spawn = options.spawn ?? defaultSpawn;
+	const stdio = withPipedStdout(options.stdio ?? "inherit");
+	const originalPrompt = invocation.prompt ?? "";
+	const validate = plan.validate ?? (() => ({ valid: true, errors: [] }));
+
+	let feedback: { output: string; errors: string[] } | null = null;
+
+	for (let attempt = 1; attempt <= capture.maxAttempts; attempt += 1) {
+		const attemptPrompt = feedback
+			? buildRetryPrompt(originalPrompt, plan.schemaJson, feedback.output, feedback.errors)
+			: buildFallbackPrompt(originalPrompt, plan.schemaJson);
+		const built = buildAgentArgs({ ...invocation, prompt: attemptPrompt });
+
+		if (attempt === 1) {
+			if (options.traceTranslate) {
+				const trace = {
+					agent: agentId,
+					mode: invocation.mode,
+					command: built.command,
+					args: built.args,
+					shimArgs: built.shimArgs,
+					passthroughArgs: built.passthroughArgs,
+					warnings: built.warnings,
+					requests: invocation.requests,
+					structuredOutput: { capture: capture.type, maxAttempts: capture.maxAttempts },
+				};
+				stderr.write(`OA_TRANSLATION=${JSON.stringify(trace)}\n`);
+			}
+			for (const warning of built.warnings) {
+				stderr.write(`${warning}\n`);
+			}
+			for (const notice of plan.notices ?? []) {
+				stderr.write(`${notice}\n`);
+			}
+		}
+
+		const attemptResult = await runCapturedAttempt({
+			spawn,
+			command: built.command,
+			args: built.args,
+			stdio,
+			agentId,
+			stderr,
+		});
+		if (attemptResult.kind === "spawn-error") {
+			return { exitCode: 1, reason: "execution-error" };
+		}
+		if (attemptResult.code !== 0) {
+			if (attemptResult.captured.length > 0) {
+				stderr.write(attemptResult.captured);
+			}
+			return mapExitCode(attemptResult.code);
+		}
+
+		let responseText = attemptResult.captured;
+		if (capture.extraction.type === "json-envelope") {
+			const outcome = extractEnvelopeText({
+				captured: attemptResult.captured,
+				field: capture.extraction.field,
+				agentId,
+				stderr,
+			});
+			if (!outcome.ok) {
+				return { exitCode: 1, reason: "execution-error" };
+			}
+			responseText = outcome.text;
+		}
+
+		const extracted = extractJsonPayload(responseText);
+		if (extracted.ok) {
+			const result = validate(extracted.value);
+			if (result.valid) {
+				stdout.write(`${JSON.stringify(extracted.value)}\n`);
+				return { exitCode: 0, reason: "success" };
+			}
+			feedback = { output: responseText, errors: result.errors };
+		} else {
+			feedback = { output: responseText, errors: [extracted.error] };
+		}
+
+		if (attempt < capture.maxAttempts) {
+			stderr.write(
+				`Attempt ${attempt} failed schema validation; retrying (${attempt + 1}/${capture.maxAttempts}).\n`,
+			);
+			for (const error of feedback.errors) {
+				stderr.write(`- ${error}\n`);
+			}
+		}
+	}
+
+	if (feedback) {
+		const lastOutput = feedback.output.trim();
+		if (lastOutput.length > 0) {
+			stderr.write(`${lastOutput}\n`);
+		}
+		for (const error of feedback.errors) {
+			stderr.write(`- ${error}\n`);
+		}
+	}
+	stderr.write(
+		`Error: ${agentId} response failed schema validation after ${capture.maxAttempts} attempts.\n`,
+	);
+	return { exitCode: 1, reason: "execution-error" };
+}
+
 export async function executeInvocation(
 	invocation: ResolvedInvocation,
 	options: ExecuteOptions = {},
 ): Promise<ExecuteResult> {
-	const { command, args, warnings, shimArgs, passthroughArgs } = buildAgentArgs(invocation);
 	const stderr = options.stderr ?? process.stderr;
 	const stdout = options.stdout ?? process.stdout;
 	const plan = invocation.structuredOutput;
+
+	if (plan && plan.capture.type === "fallback") {
+		return runFallbackAttempts({
+			invocation,
+			plan,
+			capture: plan.capture,
+			options,
+			stdout,
+			stderr,
+		});
+	}
+
+	const { command, args, warnings, shimArgs, passthroughArgs } = buildAgentArgs(invocation);
 
 	if (options.traceTranslate) {
 		const trace = {
@@ -125,6 +338,9 @@ export async function executeInvocation(
 
 	for (const warning of warnings) {
 		stderr.write(`${warning}\n`);
+	}
+	for (const notice of plan?.notices ?? []) {
+		stderr.write(`${notice}\n`);
 	}
 
 	const spawn = options.spawn ?? defaultSpawn;

--- a/src/cli/shim/execute.ts
+++ b/src/cli/shim/execute.ts
@@ -1,7 +1,8 @@
 import { spawn as defaultSpawn, type StdioOptions } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { buildAgentArgs } from "./build-args.js";
 import type { ExitCodeReason } from "./errors.js";
-import type { ResolvedInvocation } from "./types.js";
+import type { ResolvedInvocation, StructuredOutputPlan } from "./types.js";
 
 type SpawnFn = typeof defaultSpawn;
 
@@ -13,9 +14,90 @@ export type ExecuteResult = {
 export type ExecuteOptions = {
 	spawn?: SpawnFn;
 	stderr?: NodeJS.WriteStream;
+	stdout?: NodeJS.WriteStream;
 	stdio?: StdioOptions;
 	traceTranslate?: boolean;
 };
+
+function withPipedStdout(stdio: StdioOptions): StdioOptions {
+	if (Array.isArray(stdio)) {
+		return [stdio[0] ?? "inherit", "pipe", stdio[2] ?? "inherit"];
+	}
+	return [stdio, "pipe", stdio];
+}
+
+function mapExitCode(code: number | null): ExecuteResult {
+	if (code === 0) {
+		return { exitCode: 0, reason: "success" };
+	}
+	if (code === 2) {
+		return { exitCode: 2, reason: "invalid-usage" };
+	}
+	if (code === 3) {
+		return { exitCode: 3, reason: "blocked" };
+	}
+	return { exitCode: 1, reason: "execution-error" };
+}
+
+async function finalizeStructuredOutput(options: {
+	plan: StructuredOutputPlan;
+	agentId: string;
+	code: number | null;
+	captured: string;
+	stdout: NodeJS.WriteStream;
+	stderr: NodeJS.WriteStream;
+}): Promise<ExecuteResult> {
+	const { plan, agentId, code, captured, stdout, stderr } = options;
+
+	if (code !== 0) {
+		if (plan.capture.type === "json-envelope" && captured.length > 0) {
+			stderr.write(captured);
+		}
+		return mapExitCode(code);
+	}
+
+	if (plan.capture.type === "json-envelope") {
+		let envelope: unknown;
+		try {
+			envelope = JSON.parse(captured);
+		} catch {
+			envelope = undefined;
+		}
+		if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
+			stderr.write(captured);
+			stderr.write(`Error: ${agentId} did not return a JSON envelope.\n`);
+			return { exitCode: 1, reason: "execution-error" };
+		}
+		const record = envelope as Record<string, unknown>;
+		if (record.is_error === true) {
+			stderr.write(captured);
+			stderr.write(`Error: ${agentId} reported an error result.\n`);
+			return { exitCode: 1, reason: "execution-error" };
+		}
+		const payload = record[plan.capture.field];
+		if (payload === undefined || payload === null) {
+			stderr.write(captured);
+			stderr.write(`Error: ${agentId} response is missing ${plan.capture.field}.\n`);
+			return { exitCode: 1, reason: "execution-error" };
+		}
+		stdout.write(`${JSON.stringify(payload)}\n`);
+		return { exitCode: 0, reason: "success" };
+	}
+
+	let contents: string;
+	try {
+		contents = await readFile(plan.capture.path, "utf8");
+	} catch {
+		contents = "";
+	}
+	const trimmed = contents.trim();
+	if (!trimmed) {
+		stderr.write(`Error: ${agentId} did not produce a structured output message.\n`);
+		return { exitCode: 1, reason: "execution-error" };
+	}
+	stdout.write(`${trimmed}\n`);
+	return { exitCode: 0, reason: "success" };
+}
 
 export async function executeInvocation(
 	invocation: ResolvedInvocation,
@@ -23,6 +105,8 @@ export async function executeInvocation(
 ): Promise<ExecuteResult> {
 	const { command, args, warnings, shimArgs, passthroughArgs } = buildAgentArgs(invocation);
 	const stderr = options.stderr ?? process.stderr;
+	const stdout = options.stdout ?? process.stdout;
+	const plan = invocation.structuredOutput;
 
 	if (options.traceTranslate) {
 		const trace = {
@@ -34,6 +118,7 @@ export async function executeInvocation(
 			passthroughArgs,
 			warnings,
 			requests: invocation.requests,
+			...(plan ? { structuredOutput: { capture: plan.capture.type } } : {}),
 		};
 		stderr.write(`OA_TRANSLATION=${JSON.stringify(trace)}\n`);
 	}
@@ -43,7 +128,8 @@ export async function executeInvocation(
 	}
 
 	const spawn = options.spawn ?? defaultSpawn;
-	const stdio = options.stdio ?? "inherit";
+	const baseStdio = options.stdio ?? "inherit";
+	const stdio = plan ? withPipedStdout(baseStdio) : baseStdio;
 
 	return await new Promise<ExecuteResult>((resolve) => {
 		const child = spawn(command, args, { stdio });
@@ -53,20 +139,41 @@ export async function executeInvocation(
 			resolve({ exitCode: 1, reason: "execution-error" });
 		});
 
-		child.on("exit", (code) => {
-			if (code === 0) {
-				resolve({ exitCode: 0, reason: "success" });
+		if (!plan) {
+			child.on("exit", (code) => {
+				resolve(mapExitCode(code));
+			});
+			return;
+		}
+
+		const chunks: Buffer[] = [];
+		const childStdout = child.stdout;
+		if (childStdout) {
+			if (plan.capture.type === "json-envelope") {
+				childStdout.on("data", (chunk: Buffer) => {
+					chunks.push(Buffer.from(chunk));
+				});
+			} else {
+				childStdout.on("data", (chunk: Buffer) => {
+					stderr.write(chunk);
+				});
+			}
+		}
+
+		child.on("close", (code) => {
+			if (!childStdout) {
+				stderr.write(`Error: ${invocation.agent.id} stdout was not captured.\n`);
+				resolve({ exitCode: 1, reason: "execution-error" });
 				return;
 			}
-			if (code === 2) {
-				resolve({ exitCode: 2, reason: "invalid-usage" });
-				return;
-			}
-			if (code === 3) {
-				resolve({ exitCode: 3, reason: "blocked" });
-				return;
-			}
-			resolve({ exitCode: 1, reason: "execution-error" });
+			void finalizeStructuredOutput({
+				plan,
+				agentId: invocation.agent.id,
+				code,
+				captured: Buffer.concat(chunks).toString("utf8"),
+				stdout,
+				stderr,
+			}).then(resolve);
 		});
 	});
 }

--- a/src/cli/shim/fallback-prompts.ts
+++ b/src/cli/shim/fallback-prompts.ts
@@ -1,0 +1,86 @@
+const PREVIOUS_OUTPUT_LIMIT = 4000;
+
+const RESPONSE_RULES =
+	"Respond with only the JSON value - no explanations, no markdown code fences, no additional text.";
+
+function schemaBlock(schemaJson: string): string {
+	return `Your entire response must be a single JSON value that conforms to this JSON Schema:\n${schemaJson}`;
+}
+
+function truncate(text: string, limit: number): string {
+	if (text.length <= limit) {
+		return text;
+	}
+	return `${text.slice(0, limit)}\n[truncated]`;
+}
+
+export function buildFallbackPrompt(prompt: string, schemaJson: string): string {
+	const base = prompt.trim().length > 0 ? `${prompt}\n\n` : "";
+	return `${base}${schemaBlock(schemaJson)}\n\n${RESPONSE_RULES}`;
+}
+
+export function buildRetryPrompt(
+	prompt: string,
+	schemaJson: string,
+	previousOutput: string,
+	errors: string[],
+): string {
+	const base = prompt.trim().length > 0 ? `${prompt}\n\n` : "";
+	const previous =
+		previousOutput.trim().length > 0
+			? truncate(previousOutput.trim(), PREVIOUS_OUTPUT_LIMIT)
+			: "(empty response)";
+	const errorLines = errors.map((error) => `- ${error}`).join("\n");
+	return [
+		`${base}${schemaBlock(schemaJson)}`,
+		`Your previous response failed validation.\n\nPrevious response:\n${previous}`,
+		`Validation errors:\n${errorLines}`,
+		`Respond again with only the corrected JSON value. ${RESPONSE_RULES}`,
+	].join("\n\n");
+}
+
+export type ExtractedJsonPayload = { ok: true; value: unknown } | { ok: false; error: string };
+
+function tryParse(text: string): { ok: true; value: unknown } | null {
+	try {
+		return { ok: true, value: JSON.parse(text) };
+	} catch {
+		return null;
+	}
+}
+
+export function extractJsonPayload(text: string): ExtractedJsonPayload {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) {
+		return { ok: false, error: "the response was empty" };
+	}
+
+	const whole = tryParse(trimmed);
+	if (whole) {
+		return whole;
+	}
+
+	const fenced = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
+	if (fenced?.[1]) {
+		const parsed = tryParse(fenced[1].trim());
+		if (parsed) {
+			return parsed;
+		}
+	}
+
+	for (const [open, close] of [
+		["{", "}"],
+		["[", "]"],
+	] as const) {
+		const start = trimmed.indexOf(open);
+		const end = trimmed.lastIndexOf(close);
+		if (start !== -1 && end > start) {
+			const parsed = tryParse(trimmed.slice(start, end + 1));
+			if (parsed) {
+				return parsed;
+			}
+		}
+	}
+
+	return { ok: false, error: "the response did not contain parseable JSON" };
+}

--- a/src/cli/shim/flags.ts
+++ b/src/cli/shim/flags.ts
@@ -87,6 +87,8 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 	let webExplicit = false;
 	let agent: string | null = null;
 	let agentExplicit = false;
+	let outputSchema: string | null = null;
+	let outputSchemaExplicit = false;
 	let traceTranslate = false;
 	let help = false;
 	let version = false;
@@ -226,6 +228,18 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 			agentExplicit = true;
 			continue;
 		}
+		if (arg === "--output-schema") {
+			const [value, nextIndex] = readFlagValue(preArgs, index, "--output-schema");
+			outputSchema = normalizeValue(value, "--output-schema");
+			outputSchemaExplicit = true;
+			index = nextIndex;
+			continue;
+		}
+		if (arg.startsWith("--output-schema=")) {
+			outputSchema = normalizeValue(arg.slice("--output-schema=".length), "--output-schema");
+			outputSchemaExplicit = true;
+			continue;
+		}
 		if (arg === "--trace-translate") {
 			traceTranslate = true;
 			continue;
@@ -247,6 +261,12 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 		output = outputSelections[outputSelections.length - 1];
 	}
 
+	if (outputSchema !== null && outputExplicit) {
+		throw new InvalidUsageError(
+			"--output-schema cannot be combined with --output, --json, or --stream-json.",
+		);
+	}
+
 	if (approval === "yolo" && !sandboxExplicit) {
 		sandbox = "off";
 	}
@@ -266,6 +286,8 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 		webExplicit,
 		agent,
 		agentExplicit,
+		outputSchema,
+		outputSchemaExplicit,
 		traceTranslate,
 		help,
 		version,

--- a/src/cli/shim/flags.ts
+++ b/src/cli/shim/flags.ts
@@ -57,6 +57,17 @@ function readFlagValue(args: string[], index: number, label: string): [string, n
 	return [value, index + 1];
 }
 
+function parseRetriesValue(value: string): number {
+	const normalized = normalizeValue(value, "--output-schema-retries");
+	const parsed = Number(normalized);
+	if (!Number.isInteger(parsed) || parsed < 0 || parsed > 10) {
+		throw new InvalidUsageError(
+			"Invalid value for --output-schema-retries. Provide an integer between 0 and 10.",
+		);
+	}
+	return parsed;
+}
+
 function parseBooleanValue(label: string, value: string): boolean {
 	const normalized = normalizeValue(value, label).toLowerCase();
 	if (["on", "true", "1"].includes(normalized)) {
@@ -89,6 +100,7 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 	let agentExplicit = false;
 	let outputSchema: string | null = null;
 	let outputSchemaExplicit = false;
+	let outputSchemaRetries: number | null = null;
 	let traceTranslate = false;
 	let help = false;
 	let version = false;
@@ -228,6 +240,16 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 			agentExplicit = true;
 			continue;
 		}
+		if (arg === "--output-schema-retries") {
+			const [value, nextIndex] = readFlagValue(preArgs, index, "--output-schema-retries");
+			outputSchemaRetries = parseRetriesValue(value);
+			index = nextIndex;
+			continue;
+		}
+		if (arg.startsWith("--output-schema-retries=")) {
+			outputSchemaRetries = parseRetriesValue(arg.slice("--output-schema-retries=".length));
+			continue;
+		}
 		if (arg === "--output-schema") {
 			const [value, nextIndex] = readFlagValue(preArgs, index, "--output-schema");
 			outputSchema = normalizeValue(value, "--output-schema");
@@ -267,6 +289,10 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 		);
 	}
 
+	if (outputSchemaRetries !== null && outputSchema === null) {
+		throw new InvalidUsageError("--output-schema-retries requires --output-schema.");
+	}
+
 	if (approval === "yolo" && !sandboxExplicit) {
 		sandbox = "off";
 	}
@@ -288,6 +314,7 @@ export function parseShimFlags(argv: string[]): ParsedShimFlags {
 		agentExplicit,
 		outputSchema,
 		outputSchemaExplicit,
+		outputSchemaRetries,
 		traceTranslate,
 		help,
 		version,

--- a/src/cli/shim/index.ts
+++ b/src/cli/shim/index.ts
@@ -87,10 +87,17 @@ export async function runShim(argv: string[], runtime: ShimRuntime = {}): Promis
 
 export { buildAgentArgs } from "./build-args.js";
 export * from "./errors.js";
+export {
+	buildFallbackPrompt,
+	buildRetryPrompt,
+	extractJsonPayload,
+} from "./fallback-prompts.js";
 export { parseShimFlags } from "./flags.js";
 export { resolveInvocation, resolveInvocationFromFlags } from "./resolve-invocation.js";
+export { compileSchemaValidator } from "./schema-validator.js";
 export {
 	cleanupStructuredOutput,
+	DEFAULT_SCHEMA_RETRIES,
 	planStructuredOutput,
 	resolveOutputSchema,
 } from "./structured-output.js";

--- a/src/cli/shim/index.ts
+++ b/src/cli/shim/index.ts
@@ -4,15 +4,19 @@ import { exitCodeFor, ShimError } from "./errors.js";
 import { type ExecuteOptions, executeInvocation } from "./execute.js";
 import { parseShimFlags } from "./flags.js";
 import { resolveInvocationFromFlags } from "./resolve-invocation.js";
+import { cleanupStructuredOutput } from "./structured-output.js";
+import type { ResolvedInvocation } from "./types.js";
 
 type ShimRuntime = {
 	stdin?: NodeJS.ReadStream;
 	stderr?: NodeJS.WriteStream;
+	stdout?: NodeJS.WriteStream;
 	repoRoot?: string;
 	agentsDir?: string | null;
 	stdinIsTTY?: boolean;
 	stdinText?: string | null;
 	spawn?: ExecuteOptions["spawn"];
+	tempDir?: string;
 };
 
 async function readStreamText(stream: NodeJS.ReadStream): Promise<string> {
@@ -32,6 +36,7 @@ export async function runShim(argv: string[], runtime: ShimRuntime = {}): Promis
 	const stdin = runtime.stdin ?? process.stdin;
 	const repoRoot = runtime.repoRoot ?? (await findRepoRoot(process.cwd())) ?? process.cwd();
 	const stdinIsTTY = runtime.stdinIsTTY ?? stdin.isTTY ?? false;
+	let invocation: ResolvedInvocation | null = null;
 
 	try {
 		const flags = parseShimFlags(argv);
@@ -51,16 +56,18 @@ export async function runShim(argv: string[], runtime: ShimRuntime = {}): Promis
 				? (["ignore", "inherit", "inherit"] as StdioOptions)
 				: "inherit";
 
-		const invocation = await resolveInvocationFromFlags({
+		invocation = await resolveInvocationFromFlags({
 			flags,
 			stdinIsTTY,
 			stdinText,
 			repoRoot,
 			agentsDir: runtime.agentsDir,
+			tempDir: runtime.tempDir,
 		});
 		const result = await executeInvocation(invocation, {
 			spawn: runtime.spawn,
 			stderr,
+			stdout: runtime.stdout,
 			stdio,
 			traceTranslate: flags.traceTranslate,
 		});
@@ -73,6 +80,8 @@ export async function runShim(argv: string[], runtime: ShimRuntime = {}): Promis
 		const message = error instanceof Error ? error.message : String(error);
 		stderr.write(`Error: ${message}\n`);
 		return exitCodeFor("execution-error");
+	} finally {
+		await cleanupStructuredOutput(invocation?.structuredOutput);
 	}
 }
 
@@ -80,4 +89,9 @@ export { buildAgentArgs } from "./build-args.js";
 export * from "./errors.js";
 export { parseShimFlags } from "./flags.js";
 export { resolveInvocation, resolveInvocationFromFlags } from "./resolve-invocation.js";
+export {
+	cleanupStructuredOutput,
+	planStructuredOutput,
+	resolveOutputSchema,
+} from "./structured-output.js";
 export * from "./types.js";

--- a/src/cli/shim/resolve-invocation.ts
+++ b/src/cli/shim/resolve-invocation.ts
@@ -59,6 +59,9 @@ export async function resolveInvocationFromFlags(
 		mode,
 		agentId: agent.id,
 		spec: target.cli?.flags?.structuredOutput,
+		fallbackSpec: target.cli?.flags?.structuredOutputFallback,
+		retries: flags.outputSchemaRetries,
+		promptDeliverable: Boolean(target.cli?.prompt),
 		tempDir: options.tempDir,
 	});
 

--- a/src/cli/shim/resolve-invocation.ts
+++ b/src/cli/shim/resolve-invocation.ts
@@ -1,6 +1,7 @@
 import { InvalidUsageError } from "../../lib/agents/errors.js";
 import { buildRequests, buildSession, resolveAgentSelection } from "../../lib/agents/switch.js";
 import { parseShimFlags } from "./flags.js";
+import { planStructuredOutput } from "./structured-output.js";
 import type { ParsedShimFlags, ResolvedInvocation } from "./types.js";
 
 type ResolveInvocationOptions = {
@@ -9,6 +10,7 @@ type ResolveInvocationOptions = {
 	stdinText: string | null;
 	repoRoot: string;
 	agentsDir?: string | null;
+	tempDir?: string;
 };
 
 type ResolveFromFlagsOptions = {
@@ -17,6 +19,7 @@ type ResolveFromFlagsOptions = {
 	stdinText: string | null;
 	repoRoot: string;
 	agentsDir?: string | null;
+	tempDir?: string;
 };
 
 function normalizeKey(value: string): string {
@@ -51,6 +54,13 @@ export async function resolveInvocationFromFlags(
 	const agent = resolution.selection;
 	const session = buildSession(flags);
 	const requests = buildRequests(flags);
+	const structuredOutput = await planStructuredOutput({
+		rawSchema: flags.outputSchema,
+		mode,
+		agentId: agent.id,
+		spec: target.cli?.flags?.structuredOutput,
+		tempDir: options.tempDir,
+	});
 
 	return {
 		mode,
@@ -64,5 +74,6 @@ export async function resolveInvocationFromFlags(
 			hasDelimiter: flags.hasDelimiter,
 			args: flags.passthroughArgs,
 		},
+		structuredOutput,
 	};
 }

--- a/src/cli/shim/schema-validator.ts
+++ b/src/cli/shim/schema-validator.ts
@@ -1,13 +1,47 @@
-import Ajv from "ajv";
+import Ajv, { type Options, type ValidateFunction } from "ajv";
+import Ajv2019 from "ajv/dist/2019.js";
+import Ajv2020 from "ajv/dist/2020.js";
 import type { StructuredOutputValidator } from "../../lib/targets/config-types.js";
 import { InvalidUsageError } from "./errors.js";
 
-const ajv = new Ajv({ allErrors: true, strict: false, validateFormats: false });
+const AJV_OPTIONS: Options = { allErrors: true, strict: false, validateFormats: false };
+
+type SchemaDialect = "draft-07" | "2019-09" | "2020-12";
+
+type AjvLike = { compile(schema: Record<string, unknown>): ValidateFunction };
+
+const instances = new Map<SchemaDialect, AjvLike>();
+
+function resolveDialect(schema: Record<string, unknown>): SchemaDialect {
+	const declared = typeof schema.$schema === "string" ? schema.$schema : "";
+	if (declared.includes("2020-12")) {
+		return "2020-12";
+	}
+	if (declared.includes("2019-09")) {
+		return "2019-09";
+	}
+	return "draft-07";
+}
+
+function ajvForDialect(dialect: SchemaDialect): AjvLike {
+	let instance = instances.get(dialect);
+	if (!instance) {
+		instance =
+			dialect === "2020-12"
+				? new Ajv2020(AJV_OPTIONS)
+				: dialect === "2019-09"
+					? new Ajv2019(AJV_OPTIONS)
+					: new Ajv(AJV_OPTIONS);
+		instances.set(dialect, instance);
+	}
+	return instance;
+}
 
 export function compileSchemaValidator(schemaJson: string): StructuredOutputValidator {
-	let compiled: ReturnType<typeof ajv.compile>;
+	let compiled: ValidateFunction;
 	try {
-		compiled = ajv.compile(JSON.parse(schemaJson));
+		const schema = JSON.parse(schemaJson) as Record<string, unknown>;
+		compiled = ajvForDialect(resolveDialect(schema)).compile(schema);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new InvalidUsageError(`Invalid value for --output-schema: ${message}.`);

--- a/src/cli/shim/schema-validator.ts
+++ b/src/cli/shim/schema-validator.ts
@@ -1,0 +1,22 @@
+import Ajv from "ajv";
+import type { StructuredOutputValidator } from "../../lib/targets/config-types.js";
+import { InvalidUsageError } from "./errors.js";
+
+const ajv = new Ajv({ allErrors: true, strict: false, validateFormats: false });
+
+export function compileSchemaValidator(schemaJson: string): StructuredOutputValidator {
+	let compiled: ReturnType<typeof ajv.compile>;
+	try {
+		compiled = ajv.compile(JSON.parse(schemaJson));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new InvalidUsageError(`Invalid value for --output-schema: ${message}.`);
+	}
+	return (data: unknown) => {
+		const valid = compiled(data) === true;
+		const errors = (compiled.errors ?? []).map(
+			(error) => `${error.instancePath || "/"}: ${error.message ?? "is invalid"}`,
+		);
+		return { valid, errors };
+	};
+}

--- a/src/cli/shim/structured-output.ts
+++ b/src/cli/shim/structured-output.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+	InvocationMode,
+	StructuredOutputCapture,
+	StructuredOutputPlan,
+	StructuredOutputSpec,
+} from "../../lib/targets/config-types.js";
+import { InvalidUsageError } from "./errors.js";
+
+const SCHEMA_LABEL = "--output-schema";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSchemaJson(text: string, sourceLabel: string): string {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		throw new InvalidUsageError(`Invalid value for ${SCHEMA_LABEL}: ${sourceLabel}.`);
+	}
+	if (!isPlainObject(parsed)) {
+		throw new InvalidUsageError(`Invalid value for ${SCHEMA_LABEL}: schema must be a JSON object.`);
+	}
+	return JSON.stringify(parsed);
+}
+
+export async function resolveOutputSchema(raw: string): Promise<string> {
+	const trimmed = raw.trim();
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		return parseSchemaJson(trimmed, "schema is not valid JSON");
+	}
+	let contents: string;
+	try {
+		contents = await readFile(trimmed, "utf8");
+	} catch {
+		throw new InvalidUsageError(
+			`Invalid value for ${SCHEMA_LABEL}: cannot read schema file ${trimmed}.`,
+		);
+	}
+	return parseSchemaJson(contents, `schema file ${trimmed} is not valid JSON`);
+}
+
+export type PlanStructuredOutputOptions = {
+	rawSchema: string | null;
+	mode: InvocationMode;
+	agentId: string;
+	spec: StructuredOutputSpec | undefined;
+	tempDir?: string;
+};
+
+export async function planStructuredOutput(
+	options: PlanStructuredOutputOptions,
+): Promise<StructuredOutputPlan | null> {
+	const { rawSchema, mode, agentId, spec } = options;
+	if (rawSchema === null) {
+		return null;
+	}
+	if (!spec) {
+		throw new InvalidUsageError(`${agentId} does not support ${SCHEMA_LABEL}.`);
+	}
+	if (mode !== "one-shot") {
+		throw new InvalidUsageError(
+			`${SCHEMA_LABEL} requires one-shot mode; provide -p/--prompt or pipe stdin.`,
+		);
+	}
+
+	const schemaJson = await resolveOutputSchema(rawSchema);
+
+	const needsTempDir = spec.delivery === "file" || spec.extraction.type === "last-message-file";
+	const tempPaths: string[] = [];
+	let tempDirPath: string | null = null;
+	if (needsTempDir) {
+		tempDirPath = await mkdtemp(path.join(options.tempDir ?? os.tmpdir(), "omniagent-schema-"));
+		tempPaths.push(tempDirPath);
+	}
+
+	let deliveryValue = schemaJson;
+	if (spec.delivery === "file" && tempDirPath) {
+		deliveryValue = path.join(tempDirPath, "schema.json");
+		await writeFile(deliveryValue, schemaJson, "utf8");
+	}
+
+	const args = [...spec.flag, deliveryValue, ...(spec.companionArgs ?? [])];
+
+	let capture: StructuredOutputCapture;
+	if (spec.extraction.type === "json-envelope") {
+		capture = { type: "json-envelope", field: spec.extraction.field };
+	} else {
+		const lastMessagePath = path.join(tempDirPath ?? os.tmpdir(), "last-message.txt");
+		args.push(...spec.extraction.flag, lastMessagePath);
+		capture = { type: "last-message-file", path: lastMessagePath };
+	}
+
+	return { schemaJson, args, capture, tempPaths };
+}
+
+export async function cleanupStructuredOutput(
+	plan: StructuredOutputPlan | null | undefined,
+): Promise<void> {
+	if (!plan) {
+		return;
+	}
+	for (const tempPath of plan.tempPaths) {
+		try {
+			await rm(tempPath, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup; leftover temp dirs are harmless.
+		}
+	}
+}

--- a/src/cli/shim/structured-output.ts
+++ b/src/cli/shim/structured-output.ts
@@ -4,12 +4,16 @@ import path from "node:path";
 import type {
 	InvocationMode,
 	StructuredOutputCapture,
+	StructuredOutputFallbackSpec,
 	StructuredOutputPlan,
 	StructuredOutputSpec,
 } from "../../lib/targets/config-types.js";
 import { InvalidUsageError } from "./errors.js";
+import { compileSchemaValidator } from "./schema-validator.js";
 
 const SCHEMA_LABEL = "--output-schema";
+
+export const DEFAULT_SCHEMA_RETRIES = 2;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -49,6 +53,9 @@ export type PlanStructuredOutputOptions = {
 	mode: InvocationMode;
 	agentId: string;
 	spec: StructuredOutputSpec | undefined;
+	fallbackSpec?: StructuredOutputFallbackSpec;
+	retries?: number | null;
+	promptDeliverable?: boolean;
 	tempDir?: string;
 };
 
@@ -59,12 +66,19 @@ export async function planStructuredOutput(
 	if (rawSchema === null) {
 		return null;
 	}
-	if (!spec) {
-		throw new InvalidUsageError(`${agentId} does not support ${SCHEMA_LABEL}.`);
-	}
 	if (mode !== "one-shot") {
 		throw new InvalidUsageError(
 			`${SCHEMA_LABEL} requires one-shot mode; provide -p/--prompt or pipe stdin.`,
+		);
+	}
+	if (!spec) {
+		return planFallback(options);
+	}
+
+	const notices: string[] = [];
+	if (options.retries !== null && options.retries !== undefined) {
+		notices.push(
+			`Warning: ${agentId} uses native ${SCHEMA_LABEL} support; ignoring ${SCHEMA_LABEL}-retries.`,
 		);
 	}
 
@@ -95,7 +109,40 @@ export async function planStructuredOutput(
 		capture = { type: "last-message-file", path: lastMessagePath };
 	}
 
-	return { schemaJson, args, capture, tempPaths };
+	return { schemaJson, args, capture, tempPaths, notices };
+}
+
+async function planFallback(
+	options: PlanStructuredOutputOptions,
+): Promise<StructuredOutputPlan | null> {
+	const { rawSchema, agentId, fallbackSpec } = options;
+	if (rawSchema === null) {
+		return null;
+	}
+	if (options.promptDeliverable === false) {
+		throw new InvalidUsageError(
+			`${agentId} cannot use the ${SCHEMA_LABEL} fallback: target defines no prompt flag.`,
+		);
+	}
+
+	const schemaJson = await resolveOutputSchema(rawSchema);
+	const validate = compileSchemaValidator(schemaJson);
+	const maxAttempts = (options.retries ?? DEFAULT_SCHEMA_RETRIES) + 1;
+
+	return {
+		schemaJson,
+		args: [...(fallbackSpec?.args ?? [])],
+		capture: {
+			type: "fallback",
+			extraction: fallbackSpec?.extraction ?? { type: "text" },
+			maxAttempts,
+		},
+		tempPaths: [],
+		validate,
+		notices: [
+			`Notice: ${agentId} lacks native ${SCHEMA_LABEL} support; using prompt-based fallback with client-side validation.`,
+		],
+	};
 }
 
 export async function cleanupStructuredOutput(

--- a/src/cli/shim/translate.ts
+++ b/src/cli/shim/translate.ts
@@ -133,6 +133,10 @@ export function translateInvocation(
 		}
 	}
 
+	if (invocation.structuredOutput) {
+		args.push(...invocation.structuredOutput.args);
+	}
+
 	if (mode === "one-shot" && base.args?.includes("exec")) {
 		const searchIndex = args.indexOf("--search");
 		if (searchIndex > -1) {

--- a/src/cli/shim/types.ts
+++ b/src/cli/shim/types.ts
@@ -5,8 +5,11 @@ import {
 	type OutputFormat,
 	SANDBOX_MODES,
 	type SandboxMode,
+	type StructuredOutputFallbackExtraction,
+	type StructuredOutputFallbackSpec,
 	type StructuredOutputPlan,
 	type StructuredOutputSpec,
+	type StructuredOutputValidator,
 } from "../../lib/targets/config-types.js";
 
 export {
@@ -16,8 +19,11 @@ export {
 	type OutputFormat,
 	SANDBOX_MODES,
 	type SandboxMode,
+	type StructuredOutputFallbackExtraction,
+	type StructuredOutputFallbackSpec,
 	type StructuredOutputPlan,
 	type StructuredOutputSpec,
+	type StructuredOutputValidator,
 };
 
 export type {

--- a/src/cli/shim/types.ts
+++ b/src/cli/shim/types.ts
@@ -5,6 +5,8 @@ import {
 	type OutputFormat,
 	SANDBOX_MODES,
 	type SandboxMode,
+	type StructuredOutputPlan,
+	type StructuredOutputSpec,
 } from "../../lib/targets/config-types.js";
 
 export {
@@ -14,6 +16,8 @@ export {
 	type OutputFormat,
 	SANDBOX_MODES,
 	type SandboxMode,
+	type StructuredOutputPlan,
+	type StructuredOutputSpec,
 };
 
 export type {

--- a/src/lib/agents/switch.ts
+++ b/src/lib/agents/switch.ts
@@ -9,6 +9,7 @@ import {
 	type ResolvedTarget,
 	SANDBOX_MODES,
 	type SandboxMode,
+	type StructuredOutputPlan,
 } from "../targets/config-types.js";
 import { validateTargetConfig } from "../targets/config-validate.js";
 import { resolveTargets } from "../targets/resolve-targets.js";
@@ -47,6 +48,8 @@ export type ParsedShimFlags = {
 	webExplicit: boolean;
 	agent: string | null;
 	agentExplicit: boolean;
+	outputSchema: string | null;
+	outputSchemaExplicit: boolean;
 	traceTranslate: boolean;
 	help: boolean;
 	version: boolean;
@@ -95,6 +98,7 @@ export type ResolvedInvocation = {
 	session: SessionConfiguration;
 	requests: FlagRequests;
 	passthrough: AgentPassthrough;
+	structuredOutput: StructuredOutputPlan | null;
 };
 
 type AgentResolution = {

--- a/src/lib/agents/switch.ts
+++ b/src/lib/agents/switch.ts
@@ -50,6 +50,7 @@ export type ParsedShimFlags = {
 	agentExplicit: boolean;
 	outputSchema: string | null;
 	outputSchemaExplicit: boolean;
+	outputSchemaRetries: number | null;
 	traceTranslate: boolean;
 	help: boolean;
 	version: boolean;

--- a/src/lib/targets/builtins/claude-code/target.test.ts
+++ b/src/lib/targets/builtins/claude-code/target.test.ts
@@ -35,6 +35,15 @@ describe("claude builtin target", () => {
 		expect(claudeTarget.displayName).toBe("Claude Code");
 	});
 
+	it("declares inline structured output with envelope extraction", () => {
+		expect(claudeTarget.cli?.flags?.structuredOutput).toEqual({
+			delivery: "inline",
+			flag: ["--json-schema"],
+			companionArgs: ["--output-format", "json"],
+			extraction: { type: "json-envelope", field: "structured_output" },
+		});
+	});
+
 	it("routes skills and subagents to .claude directories", () => {
 		const skills = expectDefined(normalizeOutputDefinition(claudeTarget.outputs?.skills), "skills");
 		expect(skills.path).toBe("{repoRoot}/.claude/skills/{itemName}");

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -27,6 +27,12 @@ export const claudeTarget: TargetDefinition = {
 				},
 			},
 			model: { flag: ["--model"] },
+			structuredOutput: {
+				delivery: "inline",
+				flag: ["--json-schema"],
+				companionArgs: ["--output-format", "json"],
+				extraction: { type: "json-envelope", field: "structured_output" },
+			},
 		},
 	},
 	outputs: {

--- a/src/lib/targets/builtins/codex/target.test.ts
+++ b/src/lib/targets/builtins/codex/target.test.ts
@@ -34,6 +34,14 @@ describe("codex builtin target", () => {
 		expect(codexTarget.displayName).toBe("OpenAI Codex");
 	});
 
+	it("declares file-based structured output with last-message extraction", () => {
+		expect(codexTarget.cli?.flags?.structuredOutput).toEqual({
+			delivery: "file",
+			flag: ["--output-schema"],
+			extraction: { type: "last-message-file", flag: ["--output-last-message"] },
+		});
+	});
+
 	it("routes skills and subagents to .codex/skills with conversion fallback", () => {
 		const skills = expectDefined(normalizeOutputDefinition(codexTarget.outputs?.skills), "skills");
 		expect(skills.path).toBe("{repoRoot}/.codex/skills/{itemName}");

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -42,6 +42,11 @@ export const codexTarget: TargetDefinition = {
 			},
 			model: { flag: ["-m"] },
 			web: { on: ["--search"], off: ["--disable", "web_search_request"] },
+			structuredOutput: {
+				delivery: "file",
+				flag: ["--output-schema"],
+				extraction: { type: "last-message-file", flag: ["--output-last-message"] },
+			},
 		},
 	},
 	outputs: {

--- a/src/lib/targets/builtins/copilot-cli/target.test.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.test.ts
@@ -35,6 +35,10 @@ describe("copilot builtin target", () => {
 		expect(copilotTarget.displayName).toBe("GitHub Copilot CLI");
 	});
 
+	it("does not declare structured output support", () => {
+		expect(copilotTarget.cli?.flags?.structuredOutput).toBeUndefined();
+	});
+
 	it("routes skills to .github/skills", () => {
 		const skills = expectDefined(
 			normalizeOutputDefinition(copilotTarget.outputs?.skills),

--- a/src/lib/targets/builtins/copilot-cli/target.test.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.test.ts
@@ -39,6 +39,13 @@ describe("copilot builtin target", () => {
 		expect(copilotTarget.cli?.flags?.structuredOutput).toBeUndefined();
 	});
 
+	it("declares a silent text structured output fallback", () => {
+		expect(copilotTarget.cli?.flags?.structuredOutputFallback).toEqual({
+			args: ["--silent"],
+			extraction: { type: "text" },
+		});
+	});
+
 	it("routes skills to .github/skills", () => {
 		const skills = expectDefined(
 			normalizeOutputDefinition(copilotTarget.outputs?.skills),

--- a/src/lib/targets/builtins/copilot-cli/target.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.ts
@@ -47,6 +47,10 @@ export const copilotTarget: TargetDefinition = {
 				},
 			},
 			model: { flag: ["--model"] },
+			structuredOutputFallback: {
+				args: ["--silent"],
+				extraction: { type: "text" },
+			},
 		},
 	},
 	outputs: {

--- a/src/lib/targets/builtins/gemini-cli/target.test.ts
+++ b/src/lib/targets/builtins/gemini-cli/target.test.ts
@@ -39,6 +39,13 @@ describe("gemini builtin target", () => {
 		expect(geminiTarget.cli?.flags?.structuredOutput).toBeUndefined();
 	});
 
+	it("declares a json-envelope structured output fallback", () => {
+		expect(geminiTarget.cli?.flags?.structuredOutputFallback).toEqual({
+			args: ["--output-format", "json"],
+			extraction: { type: "json-envelope", field: "response" },
+		});
+	});
+
 	it("routes skills and subagents to .gemini/skills with conversion fallback", () => {
 		const skills = expectDefined(normalizeOutputDefinition(geminiTarget.outputs?.skills), "skills");
 		expect(skills.path).toBe("{repoRoot}/.gemini/skills/{itemName}");

--- a/src/lib/targets/builtins/gemini-cli/target.test.ts
+++ b/src/lib/targets/builtins/gemini-cli/target.test.ts
@@ -35,6 +35,10 @@ describe("gemini builtin target", () => {
 		expect(geminiTarget.displayName).toBe("Gemini CLI");
 	});
 
+	it("does not declare structured output support", () => {
+		expect(geminiTarget.cli?.flags?.structuredOutput).toBeUndefined();
+	});
+
 	it("routes skills and subagents to .gemini/skills with conversion fallback", () => {
 		const skills = expectDefined(normalizeOutputDefinition(geminiTarget.outputs?.skills), "skills");
 		expect(skills.path).toBe("{repoRoot}/.gemini/skills/{itemName}");

--- a/src/lib/targets/builtins/gemini-cli/target.ts
+++ b/src/lib/targets/builtins/gemini-cli/target.ts
@@ -34,6 +34,10 @@ export const geminiTarget: TargetDefinition = {
 			},
 			model: { flag: ["--model"] },
 			web: { on: [], off: null },
+			structuredOutputFallback: {
+				args: ["--output-format", "json"],
+				extraction: { type: "json-envelope", field: "response" },
+			},
 		},
 	},
 	outputs: {

--- a/src/lib/targets/config-types.ts
+++ b/src/lib/targets/config-types.ts
@@ -156,15 +156,29 @@ export type StructuredOutputSpec = {
 	extraction: StructuredOutputExtraction;
 };
 
+export type StructuredOutputFallbackExtraction =
+	| { type: "text" }
+	| { type: "json-envelope"; field: string };
+
+export type StructuredOutputFallbackSpec = {
+	args?: string[];
+	extraction?: StructuredOutputFallbackExtraction;
+};
+
 export type StructuredOutputCapture =
 	| { type: "json-envelope"; field: string }
-	| { type: "last-message-file"; path: string };
+	| { type: "last-message-file"; path: string }
+	| { type: "fallback"; extraction: StructuredOutputFallbackExtraction; maxAttempts: number };
+
+export type StructuredOutputValidator = (data: unknown) => { valid: boolean; errors: string[] };
 
 export type StructuredOutputPlan = {
 	schemaJson: string;
 	args: string[];
 	capture: StructuredOutputCapture;
 	tempPaths: string[];
+	validate?: StructuredOutputValidator;
+	notices?: string[];
 };
 
 export type TargetCliDefinition = {
@@ -180,6 +194,7 @@ export type TargetCliDefinition = {
 		model?: { flag: string[]; modes?: InvocationMode[] };
 		web?: { on?: string[] | null; off?: string[] | null; modes?: InvocationMode[] };
 		structuredOutput?: StructuredOutputSpec;
+		structuredOutputFallback?: StructuredOutputFallbackSpec;
 	};
 	passthrough?: { position?: "after" | "before-prompt" };
 	translate?: (invocation: TranslationInvocation) => TranslationResult;

--- a/src/lib/targets/config-types.ts
+++ b/src/lib/targets/config-types.ts
@@ -145,6 +145,28 @@ export type FlagMap<T extends string> = {
 	byMode?: Partial<Record<InvocationMode, Partial<Record<T, string[] | null>>>>;
 };
 
+export type StructuredOutputExtraction =
+	| { type: "json-envelope"; field: string }
+	| { type: "last-message-file"; flag: string[] };
+
+export type StructuredOutputSpec = {
+	delivery: "inline" | "file";
+	flag: string[];
+	companionArgs?: string[];
+	extraction: StructuredOutputExtraction;
+};
+
+export type StructuredOutputCapture =
+	| { type: "json-envelope"; field: string }
+	| { type: "last-message-file"; path: string };
+
+export type StructuredOutputPlan = {
+	schemaJson: string;
+	args: string[];
+	capture: StructuredOutputCapture;
+	tempPaths: string[];
+};
+
 export type TargetCliDefinition = {
 	modes: {
 		interactive: ModeCommand;
@@ -157,6 +179,7 @@ export type TargetCliDefinition = {
 		output?: FlagMap<OutputFormat>;
 		model?: { flag: string[]; modes?: InvocationMode[] };
 		web?: { on?: string[] | null; off?: string[] | null; modes?: InvocationMode[] };
+		structuredOutput?: StructuredOutputSpec;
 	};
 	passthrough?: { position?: "after" | "before-prompt" };
 	translate?: (invocation: TranslationInvocation) => TranslationResult;
@@ -190,6 +213,7 @@ export type TranslationInvocation = {
 		hasDelimiter: boolean;
 		args: string[];
 	};
+	structuredOutput: StructuredOutputPlan | null;
 };
 
 export type TranslationResult = {

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -146,6 +146,37 @@ function validateStructuredOutputSpec(value: unknown, label: string, errors: str
 	errors.push(`${label}.extraction.type must be "json-envelope" or "last-message-file".`);
 }
 
+function validateStructuredOutputFallbackSpec(
+	value: unknown,
+	label: string,
+	errors: string[],
+): void {
+	if (!isPlainObject(value)) {
+		errors.push(`${label} must be an object.`);
+		return;
+	}
+	if (value.args !== undefined) {
+		validateStringArray(value.args, `${label}.args`, errors, { allowEmpty: true });
+	}
+	if (value.extraction === undefined) {
+		return;
+	}
+	if (!isPlainObject(value.extraction)) {
+		errors.push(`${label}.extraction must be an object.`);
+		return;
+	}
+	if (value.extraction.type === "text") {
+		return;
+	}
+	if (value.extraction.type === "json-envelope") {
+		if (normalizeString(value.extraction.field) === null) {
+			errors.push(`${label}.extraction.field must be a non-empty string.`);
+		}
+		return;
+	}
+	errors.push(`${label}.extraction.type must be "text" or "json-envelope".`);
+}
+
 function validateModeCommand(value: unknown, label: string, errors: string[]): void {
 	if (!isPlainObject(value)) {
 		errors.push(`${label} must be an object.`);
@@ -232,6 +263,13 @@ function validateCliDefinition(
 				validateStructuredOutputSpec(
 					cli.flags.structuredOutput,
 					`${label}.flags.structuredOutput`,
+					errors,
+				);
+			}
+			if (cli.flags.structuredOutputFallback !== undefined) {
+				validateStructuredOutputFallbackSpec(
+					cli.flags.structuredOutputFallback,
+					`${label}.flags.structuredOutputFallback`,
 					errors,
 				);
 			}

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -115,6 +115,37 @@ function validateFlagMap(
 	}
 }
 
+function validateStructuredOutputSpec(value: unknown, label: string, errors: string[]): void {
+	if (!isPlainObject(value)) {
+		errors.push(`${label} must be an object.`);
+		return;
+	}
+	if (value.delivery !== "inline" && value.delivery !== "file") {
+		errors.push(`${label}.delivery must be "inline" or "file".`);
+	}
+	validateStringArray(value.flag, `${label}.flag`, errors);
+	if (value.companionArgs !== undefined) {
+		validateStringArray(value.companionArgs, `${label}.companionArgs`, errors, {
+			allowEmpty: true,
+		});
+	}
+	if (!isPlainObject(value.extraction)) {
+		errors.push(`${label}.extraction must be an object.`);
+		return;
+	}
+	if (value.extraction.type === "json-envelope") {
+		if (normalizeString(value.extraction.field) === null) {
+			errors.push(`${label}.extraction.field must be a non-empty string.`);
+		}
+		return;
+	}
+	if (value.extraction.type === "last-message-file") {
+		validateStringArray(value.extraction.flag, `${label}.extraction.flag`, errors);
+		return;
+	}
+	errors.push(`${label}.extraction.type must be "json-envelope" or "last-message-file".`);
+}
+
 function validateModeCommand(value: unknown, label: string, errors: string[]): void {
 	if (!isPlainObject(value)) {
 		errors.push(`${label} must be an object.`);
@@ -196,6 +227,13 @@ function validateCliDefinition(
 						}
 					}
 				}
+			}
+			if (cli.flags.structuredOutput !== undefined) {
+				validateStructuredOutputSpec(
+					cli.flags.structuredOutput,
+					`${label}.flags.structuredOutput`,
+					errors,
+				);
 			}
 			if (cli.flags.web !== undefined) {
 				if (!isPlainObject(cli.flags.web)) {

--- a/tests/commands/cli-root.test.ts
+++ b/tests/commands/cli-root.test.ts
@@ -31,6 +31,8 @@ describe("CLI root command", () => {
 		expect(output).toContain("Capabilities by agent:");
 		expect(output).toContain("Unsupported shared flags for a selected agent emit a warning");
 		expect(output).toContain("output-schema");
+		expect(output).toContain("output-schema-retries");
+		expect(output).toContain("prompt-based");
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 

--- a/tests/commands/cli-root.test.ts
+++ b/tests/commands/cli-root.test.ts
@@ -30,6 +30,7 @@ describe("CLI root command", () => {
 		expect(output).toContain("Options:");
 		expect(output).toContain("Capabilities by agent:");
 		expect(output).toContain("Unsupported shared flags for a selected agent emit a warning");
+		expect(output).toContain("output-schema");
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
 

--- a/tests/commands/cli-shim-execute.test.ts
+++ b/tests/commands/cli-shim-execute.test.ts
@@ -1,5 +1,8 @@
 import type { StdioOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { executeInvocation } from "../../src/cli/shim/execute.js";
 import { parseShimFlags } from "../../src/cli/shim/flags.js";
 import { resolveInvocationFromFlags } from "../../src/cli/shim/resolve-invocation.js";
@@ -9,6 +12,7 @@ type SpawnCall = [string, string[], { stdio: StdioOptions }];
 type InvocationOptions = {
 	stdinIsTTY?: boolean;
 	stdinText?: string | null;
+	tempDir?: string;
 };
 
 function createSpawnStub(exitCode = 0) {
@@ -21,6 +25,31 @@ function createSpawnStub(exitCode = 0) {
 	});
 }
 
+function createCaptureSpawnStub(exitCode: number, chunks: string[]) {
+	return vi.fn((_command: string, _args: string[], _options: { stdio: StdioOptions }) => {
+		const stdout = new EventEmitter();
+		const child = Object.assign(new EventEmitter(), { stdout });
+		process.nextTick(() => {
+			for (const chunk of chunks) {
+				stdout.emit("data", Buffer.from(chunk));
+			}
+			child.emit("close", exitCode);
+		});
+		return child;
+	});
+}
+
+function createWriteCollector() {
+	const writes: string[] = [];
+	const stream = {
+		write: (chunk: string | Uint8Array) => {
+			writes.push(String(chunk));
+			return true;
+		},
+	} as NodeJS.WriteStream;
+	return { writes, stream };
+}
+
 async function buildInvocation(argv: string[], options: InvocationOptions = {}) {
 	const flags = parseShimFlags(argv);
 	return await resolveInvocationFromFlags({
@@ -28,6 +57,7 @@ async function buildInvocation(argv: string[], options: InvocationOptions = {}) 
 		stdinIsTTY: options.stdinIsTTY ?? true,
 		stdinText: options.stdinText ?? null,
 		repoRoot: process.cwd(),
+		tempDir: options.tempDir,
 	});
 }
 
@@ -167,6 +197,222 @@ describe("CLI shim execution", () => {
 		const [, , options] = spawn.mock.calls[0] as SpawnCall;
 		expect(options).toEqual({ stdio: "inherit" });
 		expect(result).toEqual({ exitCode: code, reason });
+	});
+
+	it("prints only the structured payload for claude schema runs", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const envelope = JSON.stringify({
+			type: "result",
+			is_error: false,
+			structured_output: { answer: "hi" },
+		});
+		const spawn = createCaptureSpawnStub(0, [envelope.slice(0, 10), envelope.slice(10)]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		const [, , options] = spawn.mock.calls[0] as SpawnCall;
+		expect(options).toEqual({ stdio: ["inherit", "pipe", "inherit"] });
+		expect(stdout.writes.join("")).toBe('{"answer":"hi"}\n');
+		expect(result).toEqual({ exitCode: 0, reason: "success" });
+	});
+
+	it("fails when the claude envelope reports an error", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const envelope = JSON.stringify({ type: "result", is_error: true, result: "boom" });
+		const spawn = createCaptureSpawnStub(0, [envelope]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(stdout.writes).toEqual([]);
+		expect(stderr.writes.join("")).toContain(envelope);
+		expect(stderr.writes.join("")).toContain("Error: claude reported an error result.");
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+	});
+
+	it("fails when the claude envelope is missing structured output", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const spawn = createCaptureSpawnStub(0, ['{"type":"result","structured_output":null}']);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(stdout.writes).toEqual([]);
+		expect(stderr.writes.join("")).toContain(
+			"Error: claude response is missing structured_output.",
+		);
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+	});
+
+	it("fails when claude stdout is not a JSON envelope", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const spawn = createCaptureSpawnStub(0, ["plain text output"]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(stdout.writes).toEqual([]);
+		expect(stderr.writes.join("")).toContain("Error: claude did not return a JSON envelope.");
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+	});
+
+	it("dumps captured stdout to stderr when a schema run exits nonzero", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const spawn = createCaptureSpawnStub(1, ["diagnostic output"]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(stdout.writes).toEqual([]);
+		expect(stderr.writes.join("")).toContain("diagnostic output");
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+	});
+
+	it("prints the codex last message and forwards the session log to stderr", async () => {
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "oa-exec-test-"));
+		try {
+			const invocation = await buildInvocation(
+				["--agent", "codex", "--output-schema", '{"type":"object"}', "-p", "Hello"],
+				{ tempDir },
+			);
+			const plan = invocation.structuredOutput;
+			if (!plan || plan.capture.type !== "last-message-file") {
+				throw new Error("expected a codex last-message plan");
+			}
+			await writeFile(plan.capture.path, '{"answer":"hi"}\n', "utf8");
+
+			const spawn = createCaptureSpawnStub(0, ["session log line\n"]);
+			const stdout = createWriteCollector();
+			const stderr = createWriteCollector();
+
+			const result = await executeInvocation(invocation, {
+				spawn,
+				stdout: stdout.stream,
+				stderr: stderr.stream,
+			});
+
+			expect(stderr.writes.join("")).toContain("session log line");
+			expect(stdout.writes.join("")).toBe('{"answer":"hi"}\n');
+			expect(result).toEqual({ exitCode: 0, reason: "success" });
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails when codex does not write a last message", async () => {
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "oa-exec-test-"));
+		try {
+			const invocation = await buildInvocation(
+				["--agent", "codex", "--output-schema", '{"type":"object"}', "-p", "Hello"],
+				{ tempDir },
+			);
+			const spawn = createCaptureSpawnStub(0, []);
+			const stdout = createWriteCollector();
+			const stderr = createWriteCollector();
+
+			const result = await executeInvocation(invocation, {
+				spawn,
+				stdout: stdout.stream,
+				stderr: stderr.stream,
+			});
+
+			expect(stdout.writes).toEqual([]);
+			expect(stderr.writes.join("")).toContain(
+				"Error: codex did not produce a structured output message.",
+			);
+			expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("includes structured output metadata in the translation trace", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			'{"type":"object"}',
+			"-p",
+			"Hello",
+		]);
+		const envelope = JSON.stringify({ structured_output: {} });
+		const spawn = createCaptureSpawnStub(0, [envelope]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+			traceTranslate: true,
+		});
+
+		const traceLine = stderr.writes.find((line) => line.startsWith("OA_TRANSLATION="));
+		expect(traceLine).toBeDefined();
+		const payload = JSON.parse(traceLine?.replace("OA_TRANSLATION=", "").trim() ?? "{}");
+		expect(payload.structuredOutput).toEqual({ capture: "json-envelope" });
+		expect(result.exitCode).toBe(0);
 	});
 
 	it("emits a translation trace when enabled", async () => {

--- a/tests/commands/cli-shim-fallback.test.ts
+++ b/tests/commands/cli-shim-fallback.test.ts
@@ -135,6 +135,41 @@ describe("compileSchemaValidator", () => {
 	it("throws InvalidUsageError for uncompilable schemas", () => {
 		expect(() => compileSchemaValidator('{"type":"nonsense"}')).toThrow(InvalidUsageError);
 	});
+
+	it("compiles schemas declaring the 2020-12 dialect", () => {
+		const validate = compileSchemaValidator(
+			JSON.stringify({
+				$schema: "https://json-schema.org/draft/2020-12/schema",
+				type: "array",
+				prefixItems: [{ type: "integer" }],
+				items: false,
+			}),
+		);
+		expect(validate([5])).toEqual({ valid: true, errors: [] });
+		expect(validate(["five"]).valid).toBe(false);
+		expect(validate([5, 6]).valid).toBe(false);
+	});
+
+	it("compiles schemas declaring the 2019-09 dialect", () => {
+		const validate = compileSchemaValidator(
+			JSON.stringify({
+				$schema: "https://json-schema.org/draft/2019-09/schema",
+				...SCHEMA,
+			}),
+		);
+		expect(validate({ answer: 5 })).toEqual({ valid: true, errors: [] });
+		expect(validate({ answer: "five" }).valid).toBe(false);
+	});
+
+	it("compiles schemas declaring the draft-07 dialect", () => {
+		const validate = compileSchemaValidator(
+			JSON.stringify({
+				$schema: "http://json-schema.org/draft-07/schema#",
+				...SCHEMA,
+			}),
+		);
+		expect(validate({ answer: 5 })).toEqual({ valid: true, errors: [] });
+	});
 });
 
 describe("planStructuredOutput fallback", () => {

--- a/tests/commands/cli-shim-fallback.test.ts
+++ b/tests/commands/cli-shim-fallback.test.ts
@@ -1,0 +1,521 @@
+import type { StdioOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { InvalidUsageError } from "../../src/cli/shim/errors.js";
+import { executeInvocation } from "../../src/cli/shim/execute.js";
+import { extractJsonPayload } from "../../src/cli/shim/fallback-prompts.js";
+import { parseShimFlags } from "../../src/cli/shim/flags.js";
+import { resolveInvocationFromFlags } from "../../src/cli/shim/resolve-invocation.js";
+import { compileSchemaValidator } from "../../src/cli/shim/schema-validator.js";
+import { planStructuredOutput } from "../../src/cli/shim/structured-output.js";
+import { claudeTarget } from "../../src/lib/targets/builtins/claude-code/target.js";
+import { geminiTarget } from "../../src/lib/targets/builtins/gemini-cli/target.js";
+
+const SCHEMA = {
+	type: "object",
+	properties: { answer: { type: "integer" } },
+	required: ["answer"],
+	additionalProperties: false,
+};
+const SCHEMA_JSON = JSON.stringify(SCHEMA);
+
+type SpawnCall = [string, string[], { stdio: StdioOptions }];
+
+type FakeAttempt = {
+	exitCode?: number;
+	chunks?: string[];
+	error?: Error;
+};
+
+function createSequenceSpawnStub(attempts: FakeAttempt[]) {
+	let call = 0;
+	return vi.fn((_command: string, _args: string[], _options: { stdio: StdioOptions }) => {
+		const attempt = attempts[Math.min(call, attempts.length - 1)];
+		call += 1;
+		const stdout = new EventEmitter();
+		const child = Object.assign(new EventEmitter(), { stdout });
+		process.nextTick(() => {
+			if (attempt.error) {
+				child.emit("error", attempt.error);
+				return;
+			}
+			for (const chunk of attempt.chunks ?? []) {
+				stdout.emit("data", Buffer.from(chunk));
+			}
+			child.emit("close", attempt.exitCode ?? 0);
+		});
+		return child;
+	});
+}
+
+function createWriteCollector() {
+	const writes: string[] = [];
+	const stream = {
+		write: (chunk: string | Uint8Array) => {
+			writes.push(String(chunk));
+			return true;
+		},
+	} as NodeJS.WriteStream;
+	return { writes, stream };
+}
+
+async function buildInvocation(argv: string[]) {
+	const flags = parseShimFlags(argv);
+	return await resolveInvocationFromFlags({
+		flags,
+		stdinIsTTY: true,
+		stdinText: null,
+		repoRoot: process.cwd(),
+	});
+}
+
+function envelope(response: string): string {
+	return JSON.stringify({ response, stats: {} });
+}
+
+function promptArg(call: SpawnCall): string {
+	const args = call[1];
+	const index = args.indexOf("-p");
+	return index === -1 ? "" : (args[index + 1] ?? "");
+}
+
+describe("extractJsonPayload", () => {
+	it("parses a bare JSON object", () => {
+		expect(extractJsonPayload('{"answer":5}')).toEqual({ ok: true, value: { answer: 5 } });
+	});
+
+	it("parses a bare JSON array", () => {
+		expect(extractJsonPayload("[1,2]")).toEqual({ ok: true, value: [1, 2] });
+	});
+
+	it("parses fenced JSON with and without a language tag", () => {
+		expect(extractJsonPayload('```json\n{"answer":5}\n```')).toEqual({
+			ok: true,
+			value: { answer: 5 },
+		});
+		expect(extractJsonPayload('```\n{"answer":5}\n```')).toEqual({
+			ok: true,
+			value: { answer: 5 },
+		});
+	});
+
+	it("extracts JSON embedded in prose", () => {
+		expect(extractJsonPayload('Here you go: {"answer": 5} - enjoy!')).toEqual({
+			ok: true,
+			value: { answer: 5 },
+		});
+	});
+
+	it("rejects empty responses", () => {
+		expect(extractJsonPayload("  \n ")).toEqual({ ok: false, error: "the response was empty" });
+	});
+
+	it("rejects responses without parseable JSON", () => {
+		const result = extractJsonPayload("no json here");
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("compileSchemaValidator", () => {
+	it("validates conforming and non-conforming data", () => {
+		const validate = compileSchemaValidator(SCHEMA_JSON);
+		expect(validate({ answer: 5 })).toEqual({ valid: true, errors: [] });
+
+		const invalid = validate({ answer: "five" });
+		expect(invalid.valid).toBe(false);
+		expect(invalid.errors).toEqual(["/answer: must be integer"]);
+	});
+
+	it("reports root-level errors with a / path", () => {
+		const validate = compileSchemaValidator(SCHEMA_JSON);
+		const invalid = validate("not an object");
+		expect(invalid.valid).toBe(false);
+		expect(invalid.errors[0]).toMatch(/^\/: /);
+	});
+
+	it("throws InvalidUsageError for uncompilable schemas", () => {
+		expect(() => compileSchemaValidator('{"type":"nonsense"}')).toThrow(InvalidUsageError);
+	});
+});
+
+describe("planStructuredOutput fallback", () => {
+	it("builds a prompt fallback plan when no native spec exists", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "gemini",
+			spec: undefined,
+			fallbackSpec: geminiTarget.cli?.flags?.structuredOutputFallback,
+		});
+
+		expect(plan?.args).toEqual(["--output-format", "json"]);
+		expect(plan?.capture).toEqual({
+			type: "fallback",
+			extraction: { type: "json-envelope", field: "response" },
+			maxAttempts: 3,
+		});
+		expect(plan?.tempPaths).toEqual([]);
+		expect(plan?.validate?.({ answer: 5 })).toEqual({ valid: true, errors: [] });
+		expect(plan?.notices).toEqual([
+			"Notice: gemini lacks native --output-schema support; using prompt-based fallback with client-side validation.",
+		]);
+	});
+
+	it("defaults to text extraction with no fallback spec", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "custom",
+			spec: undefined,
+		});
+
+		expect(plan?.args).toEqual([]);
+		expect(plan?.capture).toEqual({
+			type: "fallback",
+			extraction: { type: "text" },
+			maxAttempts: 3,
+		});
+	});
+
+	it("honors --output-schema-retries for fallback plans", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "gemini",
+			spec: undefined,
+			retries: 0,
+		});
+		expect(plan?.capture).toMatchObject({ type: "fallback", maxAttempts: 1 });
+	});
+
+	it("warns when retries are requested for a native agent", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "claude",
+			spec: claudeTarget.cli?.flags?.structuredOutput,
+			retries: 3,
+		});
+		expect(plan?.capture.type).toBe("json-envelope");
+		expect(plan?.notices).toEqual([
+			"Warning: claude uses native --output-schema support; ignoring --output-schema-retries.",
+		]);
+	});
+
+	it("rejects targets that cannot deliver a prompt", async () => {
+		await expect(
+			planStructuredOutput({
+				rawSchema: SCHEMA_JSON,
+				mode: "one-shot",
+				agentId: "acme",
+				spec: undefined,
+				promptDeliverable: false,
+			}),
+		).rejects.toThrow(
+			"acme cannot use the --output-schema fallback: target defines no prompt flag.",
+		);
+	});
+
+	it("rejects uncompilable schemas before spawning", async () => {
+		await expect(
+			planStructuredOutput({
+				rawSchema: '{"type":"nonsense"}',
+				mode: "one-shot",
+				agentId: "gemini",
+				spec: undefined,
+			}),
+		).rejects.toBeInstanceOf(InvalidUsageError);
+	});
+});
+
+describe("fallback execution", () => {
+	it("succeeds on the first attempt for gemini and prints only the payload", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([{ chunks: [envelope('```json\n{"answer":5}\n```')] }]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 0, reason: "success" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stdout.writes).toEqual(['{"answer":5}\n']);
+
+		const call = spawn.mock.calls[0] as SpawnCall;
+		expect(call[0]).toBe("gemini");
+		expect(call[1]).toContain("--output-format");
+		expect(call[1]).toContain("json");
+		expect(call[2]).toEqual({ stdio: ["inherit", "pipe", "inherit"] });
+		const prompt = promptArg(call);
+		expect(prompt).toContain("Give me five");
+		expect(prompt).toContain(SCHEMA_JSON);
+		expect(stderr.writes.join("")).toContain("Notice: gemini lacks native --output-schema support");
+	});
+
+	it("retries with validation feedback and succeeds", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([
+			{ chunks: [envelope('{"answer":"five"}')] },
+			{ chunks: [envelope('{"answer":5}')] },
+		]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 0, reason: "success" });
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(stdout.writes).toEqual(['{"answer":5}\n']);
+
+		const retryPrompt = promptArg(spawn.mock.calls[1] as SpawnCall);
+		expect(retryPrompt).toContain("Your previous response failed validation.");
+		expect(retryPrompt).toContain('{"answer":"five"}');
+		expect(retryPrompt).toContain("/answer: must be integer");
+
+		const stderrText = stderr.writes.join("");
+		expect(stderrText).toContain("Attempt 1 failed schema validation; retrying (2/3).");
+		const notices = stderr.writes.filter((chunk) => chunk.startsWith("Notice:"));
+		expect(notices).toHaveLength(1);
+	});
+
+	it("exits 1 after exhausting all attempts", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([{ chunks: [envelope('{"answer":"five"}')] }]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		expect(spawn).toHaveBeenCalledTimes(3);
+		expect(stdout.writes).toEqual([]);
+		const stderrText = stderr.writes.join("");
+		expect(stderrText).toContain('{"answer":"five"}');
+		expect(stderrText).toContain("- /answer: must be integer");
+		expect(stderrText).toContain(
+			"Error: gemini response failed schema validation after 3 attempts.",
+		);
+	});
+
+	it("does not retry when the agent exits nonzero", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([{ exitCode: 2, chunks: ["agent usage error"] }]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 2, reason: "invalid-usage" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stderr.writes.join("")).toContain("agent usage error");
+	});
+
+	it("does not retry when the envelope reports an error", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([
+			{
+				chunks: [
+					JSON.stringify({ response: null, error: { type: "ApiError", message: "boom", code: 1 } }),
+				],
+			},
+		]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stderr.writes.join("")).toContain("Error: gemini reported an error result.");
+	});
+
+	it("does not retry when the envelope is unparseable", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([{ chunks: ["not an envelope"] }]);
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: createWriteCollector().stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stderr.writes.join("")).toContain("Error: gemini did not return a JSON envelope.");
+	});
+
+	it("captures copilot text output with --silent and retries on empty responses", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"copilot",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+			"--output-schema-retries",
+			"1",
+		]);
+		const spawn = createSequenceSpawnStub([
+			{ chunks: [] },
+			{ chunks: ['The result is:\n```json\n{"answer": 5}\n```\n'] },
+		]);
+		const stdout = createWriteCollector();
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 0, reason: "success" });
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(stdout.writes).toEqual(['{"answer":5}\n']);
+
+		const call = spawn.mock.calls[0] as SpawnCall;
+		expect(call[0]).toBe("copilot");
+		expect(call[1]).toContain("--silent");
+		expect(stderr.writes.join("")).toContain("- the response was empty");
+	});
+
+	it("exits 1 without retrying when spawn fails", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([{ error: new Error("spawn gemini ENOENT") }]);
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: createWriteCollector().stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stderr.writes.join("")).toContain("spawn gemini ENOENT");
+	});
+
+	it("makes exactly one attempt with --output-schema-retries 0", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+			"--output-schema-retries",
+			"0",
+		]);
+		const spawn = createSequenceSpawnStub([{ chunks: [envelope("no json at all")] }]);
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: createWriteCollector().stream,
+			stderr: stderr.stream,
+		});
+
+		expect(result).toEqual({ exitCode: 1, reason: "execution-error" });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(stderr.writes.join("")).toContain(
+			"Error: gemini response failed schema validation after 1 attempts.",
+		);
+	});
+
+	it("emits fallback trace metadata once", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"gemini",
+			"-p",
+			"Give me five",
+			"--output-schema",
+			SCHEMA_JSON,
+		]);
+		const spawn = createSequenceSpawnStub([
+			{ chunks: [envelope('{"answer":"five"}')] },
+			{ chunks: [envelope('{"answer":5}')] },
+		]);
+		const stderr = createWriteCollector();
+
+		const result = await executeInvocation(invocation, {
+			spawn,
+			stdout: createWriteCollector().stream,
+			stderr: stderr.stream,
+			traceTranslate: true,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const traceLines = stderr.writes.filter((chunk) => chunk.startsWith("OA_TRANSLATION="));
+		expect(traceLines).toHaveLength(1);
+		const trace = JSON.parse(traceLines[0].slice("OA_TRANSLATION=".length));
+		expect(trace.structuredOutput).toEqual({ capture: "fallback", maxAttempts: 3 });
+	});
+});

--- a/tests/commands/cli-shim-flags.test.ts
+++ b/tests/commands/cli-shim-flags.test.ts
@@ -1,5 +1,8 @@
 import type { StdioOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
 	buildAgentArgs,
 	parseShimFlags,
@@ -10,6 +13,7 @@ import {
 type InvocationOptions = {
 	stdinIsTTY?: boolean;
 	stdinText?: string | null;
+	tempDir?: string;
 };
 
 function createSpawnStub(exitCode = 0) {
@@ -29,6 +33,7 @@ async function buildInvocation(argv: string[], options: InvocationOptions = {}) 
 		stdinIsTTY: options.stdinIsTTY ?? true,
 		stdinText: options.stdinText ?? null,
 		repoRoot: process.cwd(),
+		tempDir: options.tempDir,
 	});
 }
 
@@ -101,6 +106,82 @@ describe("CLI shim flag parsing", () => {
 		expect(parseShimFlags(["--trace-translate"]).traceTranslate).toBe(true);
 		expect(parseShimFlags(["--trace-translate=1"]).traceTranslate).toBe(true);
 		expect(parseShimFlags(["--trace-translate=false"]).traceTranslate).toBe(false);
+	});
+
+	it("parses --output-schema in both value forms", () => {
+		expect(parseShimFlags([]).outputSchema).toBeNull();
+		expect(parseShimFlags([]).outputSchemaExplicit).toBe(false);
+
+		const spaced = parseShimFlags(["--output-schema", "./schema.json"]);
+		expect(spaced.outputSchema).toBe("./schema.json");
+		expect(spaced.outputSchemaExplicit).toBe(true);
+
+		const inline = parseShimFlags(['--output-schema={"type":"object"}']);
+		expect(inline.outputSchema).toBe('{"type":"object"}');
+		expect(inline.outputSchemaExplicit).toBe(true);
+	});
+
+	it("rejects --output-schema without a value", () => {
+		expect(() => parseShimFlags(["--output-schema"])).toThrow("Missing value for --output-schema");
+	});
+
+	it("rejects --output-schema combined with explicit output flags", () => {
+		const conflicts = [
+			["--output-schema", "s.json", "--output", "json"],
+			["--output-schema", "s.json", "--output", "text"],
+			["--output-schema", "s.json", "--json"],
+			["--stream-json", "--output-schema", "s.json"],
+		];
+		for (const argv of conflicts) {
+			expect(() => parseShimFlags(argv)).toThrow(
+				"--output-schema cannot be combined with --output, --json, or --stream-json.",
+			);
+		}
+	});
+
+	it("appends claude structured output args before the prompt", async () => {
+		const schema = '{"type":"object","properties":{}}';
+		const invocation = await buildInvocation([
+			"--agent",
+			"claude",
+			"--output-schema",
+			schema,
+			"-p",
+			"Hello",
+		]);
+		const result = buildAgentArgs(invocation);
+
+		expect(result.warnings).toEqual([]);
+		expect(result.args).toEqual([
+			"--json-schema",
+			'{"type":"object","properties":{}}',
+			"--output-format",
+			"json",
+			"-p",
+			"Hello",
+		]);
+	});
+
+	it("appends codex structured output file args before the positional prompt", async () => {
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "oa-flags-test-"));
+		try {
+			const invocation = await buildInvocation(
+				["--agent", "codex", "--output-schema", '{"type":"object"}', "-p", "Hello"],
+				{ tempDir },
+			);
+			const result = buildAgentArgs(invocation);
+
+			expect(result.warnings).toEqual([]);
+			expect(result.args.slice(0, 3)).toEqual(["exec", "--sandbox", "workspace-write"]);
+			const schemaIndex = result.args.indexOf("--output-schema");
+			expect(schemaIndex).toBeGreaterThan(-1);
+			expect(result.args[schemaIndex + 1]).toMatch(/schema\.json$/);
+			expect(result.args[schemaIndex + 2]).toBe("--output-last-message");
+			expect(result.args[schemaIndex + 3]).toMatch(/last-message\.txt$/);
+			expect(result.args[result.args.length - 1]).toBe("Hello");
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("returns invalid usage for bad flag values", async () => {

--- a/tests/commands/cli-shim-flags.test.ts
+++ b/tests/commands/cli-shim-flags.test.ts
@@ -139,6 +139,30 @@ describe("CLI shim flag parsing", () => {
 		}
 	});
 
+	it("parses --output-schema-retries in both value forms", () => {
+		expect(parseShimFlags([]).outputSchemaRetries).toBeNull();
+
+		const spaced = parseShimFlags(["--output-schema", "s.json", "--output-schema-retries", "4"]);
+		expect(spaced.outputSchemaRetries).toBe(4);
+
+		const inline = parseShimFlags(["--output-schema", "s.json", "--output-schema-retries=0"]);
+		expect(inline.outputSchemaRetries).toBe(0);
+	});
+
+	it("rejects invalid --output-schema-retries values", () => {
+		for (const value of ["1.5", "eleven", "11"]) {
+			expect(() =>
+				parseShimFlags(["--output-schema", "s.json", "--output-schema-retries", value]),
+			).toThrow("Invalid value for --output-schema-retries. Provide an integer between 0 and 10.");
+		}
+	});
+
+	it("rejects --output-schema-retries without --output-schema", () => {
+		expect(() => parseShimFlags(["--output-schema-retries", "2"])).toThrow(
+			"--output-schema-retries requires --output-schema.",
+		);
+	});
+
 	it("appends claude structured output args before the prompt", async () => {
 		const schema = '{"type":"object","properties":{}}';
 		const invocation = await buildInvocation([

--- a/tests/commands/cli-shim-structured-output.test.ts
+++ b/tests/commands/cli-shim-structured-output.test.ts
@@ -1,0 +1,249 @@
+import type { StdioOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { InvalidUsageError } from "../../src/cli/shim/errors.js";
+import {
+	cleanupStructuredOutput,
+	planStructuredOutput,
+	resolveOutputSchema,
+	runShim,
+} from "../../src/cli/shim/index.js";
+import { claudeTarget } from "../../src/lib/targets/builtins/claude-code/target.js";
+import { codexTarget } from "../../src/lib/targets/builtins/codex/target.js";
+
+const SCHEMA = {
+	type: "object",
+	properties: { answer: { type: "string" } },
+	required: ["answer"],
+	additionalProperties: false,
+};
+const SCHEMA_JSON = JSON.stringify(SCHEMA);
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(path.join(os.tmpdir(), "oa-schema-test-"));
+});
+
+afterEach(async () => {
+	await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("resolveOutputSchema", () => {
+	it("accepts inline JSON objects and canonicalizes them", async () => {
+		const resolved = await resolveOutputSchema(`  {"type": "object",\n "properties": {}}  `);
+		expect(resolved).toBe(JSON.stringify({ type: "object", properties: {} }));
+	});
+
+	it("reads schemas from a file path", async () => {
+		const schemaPath = path.join(tempDir, "schema.json");
+		await writeFile(schemaPath, JSON.stringify(SCHEMA, null, 2), "utf8");
+		const resolved = await resolveOutputSchema(schemaPath);
+		expect(resolved).toBe(SCHEMA_JSON);
+	});
+
+	it("rejects inline JSON arrays", async () => {
+		await expect(resolveOutputSchema('["not", "an", "object"]')).rejects.toThrow(
+			"schema must be a JSON object",
+		);
+	});
+
+	it("rejects invalid inline JSON", async () => {
+		await expect(resolveOutputSchema("{not json")).rejects.toThrow(
+			"Invalid value for --output-schema",
+		);
+	});
+
+	it("rejects unreadable schema files", async () => {
+		const missing = path.join(tempDir, "missing.json");
+		await expect(resolveOutputSchema(missing)).rejects.toThrow(
+			`cannot read schema file ${missing}`,
+		);
+	});
+
+	it("rejects schema files that are not JSON objects", async () => {
+		const schemaPath = path.join(tempDir, "scalar.json");
+		await writeFile(schemaPath, '"just a string"', "utf8");
+		await expect(resolveOutputSchema(schemaPath)).rejects.toThrow("schema must be a JSON object");
+	});
+
+	it("throws InvalidUsageError for all failures", async () => {
+		await expect(resolveOutputSchema("{oops")).rejects.toBeInstanceOf(InvalidUsageError);
+	});
+});
+
+describe("planStructuredOutput", () => {
+	it("returns null when no schema was requested", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: null,
+			mode: "one-shot",
+			agentId: "claude",
+			spec: claudeTarget.cli?.flags?.structuredOutput,
+		});
+		expect(plan).toBeNull();
+	});
+
+	it("rejects agents without a structured output spec", async () => {
+		await expect(
+			planStructuredOutput({
+				rawSchema: SCHEMA_JSON,
+				mode: "one-shot",
+				agentId: "gemini",
+				spec: undefined,
+			}),
+		).rejects.toThrow("gemini does not support --output-schema.");
+	});
+
+	it("rejects interactive mode", async () => {
+		await expect(
+			planStructuredOutput({
+				rawSchema: SCHEMA_JSON,
+				mode: "interactive",
+				agentId: "claude",
+				spec: claudeTarget.cli?.flags?.structuredOutput,
+			}),
+		).rejects.toThrow("--output-schema requires one-shot mode");
+	});
+
+	it("builds inline delivery args for claude without temp files", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "claude",
+			spec: claudeTarget.cli?.flags?.structuredOutput,
+			tempDir,
+		});
+
+		expect(plan?.args).toEqual(["--json-schema", SCHEMA_JSON, "--output-format", "json"]);
+		expect(plan?.capture).toEqual({ type: "json-envelope", field: "structured_output" });
+		expect(plan?.tempPaths).toEqual([]);
+	});
+
+	it("materializes a schema file and last-message path for codex", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "codex",
+			spec: codexTarget.cli?.flags?.structuredOutput,
+			tempDir,
+		});
+
+		expect(plan?.args).toHaveLength(4);
+		expect(plan?.args[0]).toBe("--output-schema");
+		expect(plan?.args[1]).toMatch(/omniagent-schema-.*schema\.json$/);
+		expect(plan?.args[2]).toBe("--output-last-message");
+		expect(plan?.args[3]).toMatch(/omniagent-schema-.*last-message\.txt$/);
+		expect(plan?.tempPaths).toHaveLength(1);
+
+		const written = await stat(plan?.args[1] ?? "");
+		expect(written.isFile()).toBe(true);
+		expect(plan?.capture).toEqual({ type: "last-message-file", path: plan?.args[3] });
+	});
+
+	it("cleans up temp directories idempotently", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "codex",
+			spec: codexTarget.cli?.flags?.structuredOutput,
+			tempDir,
+		});
+
+		await cleanupStructuredOutput(plan);
+		await cleanupStructuredOutput(plan);
+		await cleanupStructuredOutput(null);
+
+		expect(await readdir(tempDir)).toEqual([]);
+	});
+});
+
+describe("runShim with --output-schema", () => {
+	function createSpawnStub(exitCode = 0) {
+		return vi.fn((_command: string, _args: string[], _options: { stdio: StdioOptions }) => {
+			const emitter = new EventEmitter();
+			process.nextTick(() => {
+				emitter.emit("exit", exitCode);
+				emitter.emit("close", exitCode);
+			});
+			return emitter;
+		});
+	}
+
+	function collectStderr() {
+		const writes: string[] = [];
+		const stderr = {
+			write: (chunk: string | Uint8Array) => {
+				writes.push(String(chunk));
+				return true;
+			},
+		} as NodeJS.WriteStream;
+		return { writes, stderr };
+	}
+
+	it.each(["gemini", "copilot"])("fails with exit 2 for %s", async (agent) => {
+		const { writes, stderr } = collectStderr();
+		const spawn = createSpawnStub(0);
+
+		const exitCode = await runShim(
+			["--agent", agent, "-p", "Hello", "--output-schema", SCHEMA_JSON],
+			{ stdinIsTTY: true, stderr, spawn, repoRoot: process.cwd(), tempDir },
+		);
+
+		expect(exitCode).toBe(2);
+		expect(writes.join("")).toContain(`Error: ${agent} does not support --output-schema.`);
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("fails with exit 2 in interactive mode", async () => {
+		const { writes, stderr } = collectStderr();
+		const spawn = createSpawnStub(0);
+
+		const exitCode = await runShim(["--agent", "claude", "--output-schema", SCHEMA_JSON], {
+			stdinIsTTY: true,
+			stderr,
+			spawn,
+			repoRoot: process.cwd(),
+			tempDir,
+		});
+
+		expect(exitCode).toBe(2);
+		expect(writes.join("")).toContain("--output-schema requires one-shot mode");
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("fails with exit 2 when combined with explicit output flags", async () => {
+		for (const conflicting of [
+			["--output", "json"],
+			["--output", "text"],
+			["--json"],
+			["--stream-json"],
+		]) {
+			const { writes, stderr } = collectStderr();
+			const exitCode = await runShim(
+				["--agent", "claude", "-p", "Hello", "--output-schema", SCHEMA_JSON, ...conflicting],
+				{ stdinIsTTY: true, stderr, repoRoot: process.cwd(), tempDir },
+			);
+
+			expect(exitCode).toBe(2);
+			expect(writes.join("")).toContain(
+				"--output-schema cannot be combined with --output, --json, or --stream-json.",
+			);
+		}
+	});
+
+	it("removes temp directories after a codex run", async () => {
+		const { stderr } = collectStderr();
+		const spawn = createSpawnStub(0);
+
+		const exitCode = await runShim(
+			["--agent", "codex", "-p", "Hello", "--output-schema", SCHEMA_JSON],
+			{ stdinIsTTY: true, stderr, spawn, repoRoot: process.cwd(), tempDir },
+		);
+
+		expect(exitCode).toBe(1);
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(await readdir(tempDir)).toEqual([]);
+	});
+});

--- a/tests/commands/cli-shim-structured-output.test.ts
+++ b/tests/commands/cli-shim-structured-output.test.ts
@@ -85,15 +85,15 @@ describe("planStructuredOutput", () => {
 		expect(plan).toBeNull();
 	});
 
-	it("rejects agents without a structured output spec", async () => {
-		await expect(
-			planStructuredOutput({
-				rawSchema: SCHEMA_JSON,
-				mode: "one-shot",
-				agentId: "gemini",
-				spec: undefined,
-			}),
-		).rejects.toThrow("gemini does not support --output-schema.");
+	it("falls back to a prompt-based plan for agents without a native spec", async () => {
+		const plan = await planStructuredOutput({
+			rawSchema: SCHEMA_JSON,
+			mode: "one-shot",
+			agentId: "gemini",
+			spec: undefined,
+		});
+		expect(plan?.capture.type).toBe("fallback");
+		expect(plan?.tempPaths).toEqual([]);
 	});
 
 	it("rejects interactive mode", async () => {
@@ -182,18 +182,39 @@ describe("runShim with --output-schema", () => {
 		return { writes, stderr };
 	}
 
-	it.each(["gemini", "copilot"])("fails with exit 2 for %s", async (agent) => {
+	it.each([
+		["gemini", JSON.stringify({ response: '{"answer":"hi"}', stats: {} })],
+		["copilot", '{"answer":"hi"}'],
+	])("runs the prompt fallback for %s", async (agent, response) => {
 		const { writes, stderr } = collectStderr();
-		const spawn = createSpawnStub(0);
+		const stdoutWrites: string[] = [];
+		const stdout = {
+			write: (chunk: string | Uint8Array) => {
+				stdoutWrites.push(String(chunk));
+				return true;
+			},
+		} as NodeJS.WriteStream;
+		const spawn = vi.fn((_command: string, _args: string[], _options: { stdio: StdioOptions }) => {
+			const childStdout = new EventEmitter();
+			const child = Object.assign(new EventEmitter(), { stdout: childStdout });
+			process.nextTick(() => {
+				childStdout.emit("data", Buffer.from(response));
+				child.emit("close", 0);
+			});
+			return child;
+		});
 
 		const exitCode = await runShim(
 			["--agent", agent, "-p", "Hello", "--output-schema", SCHEMA_JSON],
-			{ stdinIsTTY: true, stderr, spawn, repoRoot: process.cwd(), tempDir },
+			{ stdinIsTTY: true, stderr, stdout, spawn, repoRoot: process.cwd(), tempDir },
 		);
 
-		expect(exitCode).toBe(2);
-		expect(writes.join("")).toContain(`Error: ${agent} does not support --output-schema.`);
-		expect(spawn).not.toHaveBeenCalled();
+		expect(exitCode).toBe(0);
+		expect(stdoutWrites).toEqual(['{"answer":"hi"}\n']);
+		expect(writes.join("")).toContain(
+			`Notice: ${agent} lacks native --output-schema support; using prompt-based fallback with client-side validation.`,
+		);
+		expect(spawn).toHaveBeenCalledTimes(1);
 	});
 
 	it("fails with exit 2 in interactive mode", async () => {

--- a/tests/e2e/cli-shim/cases.ts
+++ b/tests/e2e/cli-shim/cases.ts
@@ -18,6 +18,15 @@ export type ShimCase = {
 
 export const PROMPT = "Output exactly: 5";
 
+export const STRUCTURED_PROMPT = "Set answer to the integer 5.";
+
+export const STRUCTURED_SCHEMA = JSON.stringify({
+	type: "object",
+	properties: { answer: { type: "integer" } },
+	required: ["answer"],
+	additionalProperties: false,
+});
+
 export const SHARED_CASES: ShimCase[] = [
 	{
 		id: "basic-oneshot",
@@ -68,5 +77,9 @@ export const SHARED_CASES: ShimCase[] = [
 			agent.passthroughArgs && agent.passthroughArgs.length > 0
 				? null
 				: "passthrough args not configured",
+	},
+	{
+		id: "output-schema-inline",
+		buildArgs: () => ["-p", STRUCTURED_PROMPT, "--output-schema", STRUCTURED_SCHEMA],
 	},
 ];

--- a/tests/e2e/cli-shim/cli-shim.e2e.test.ts
+++ b/tests/e2e/cli-shim/cli-shim.e2e.test.ts
@@ -6,7 +6,11 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { AGENT_MODULES } from "./agents.js";
 import { type AgentE2EConfig, SHARED_CASES } from "./cases.js";
-import { type ExpectedInvocation, getExpectedInvocation } from "./expected-invocations.js";
+import {
+	type ExpectedInvocation,
+	getExpectedInvocation,
+	TMPFILE_PLACEHOLDER,
+} from "./expected-invocations.js";
 
 type TracePayload = {
 	agent: string;
@@ -35,6 +39,9 @@ const SUITE = ENABLE_E2E && CLI_EXISTS ? describe : describe.skip;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const TRACE_PREFIX = "OA_TRANSLATION=";
 const JSON_CASES = new Set(["output-json", "output-flag-json", "output-stream-json"]);
+// Structured-output runs involve nondeterministic temp paths and model output, so they are
+// asserted structurally instead of against recorded baselines.
+const STRUCTURED_CASES = new Set(["output-schema-inline"]);
 
 if (ENABLE_E2E && !CLI_EXISTS) {
 	console.warn("dist/cli.js not found. Run the build before E2E tests.");
@@ -253,6 +260,17 @@ function normalizeStderr(agentId: string, stderr: string): string {
 	return stderr;
 }
 
+function normalizeTempPaths(args: string[]): string[] {
+	const tempValueFlags = new Set(["--output-schema", "--output-last-message"]);
+	return args.map((arg, index) => {
+		const previous = index > 0 ? args[index - 1] : null;
+		if (previous && tempValueFlags.has(previous) && path.isAbsolute(arg)) {
+			return TMPFILE_PLACEHOLDER;
+		}
+		return arg;
+	});
+}
+
 function ensureCodexModel(agent: AgentE2EConfig, args: string[]): string[] {
 	if (agent.agentId !== "codex" || !agent.model) {
 		return args;
@@ -304,6 +322,11 @@ SUITE("CLI shim e2e", () => {
 				const expectedInvocation = getExpectedInvocation(testCase.id, agent);
 				if (!expectedInvocation) {
 					it.skip(`${agent.agentId} ${testCase.id} (unsupported)`, () => {});
+					continue;
+				}
+
+				if (RECORD_BASELINE && STRUCTURED_CASES.has(testCase.id)) {
+					it.skip(`${agent.agentId} ${testCase.id} (no baseline; asserted structurally)`, () => {});
 					continue;
 				}
 
@@ -373,6 +396,14 @@ SUITE("CLI shim e2e", () => {
 						const { trace, cleaned } = extractTrace(stderr);
 						if (!trace) {
 							throw new Error("Missing translation trace in stderr.");
+						}
+
+						if (STRUCTURED_CASES.has(testCase.id)) {
+							const payload = JSON.parse(stdout) as Record<string, unknown>;
+							expect(payload).toEqual({ answer: 5 });
+							expect(trace.command).toBe(expectedInvocation.command);
+							expect(normalizeTempPaths(trace.args)).toEqual(expectedInvocation.args);
+							return;
 						}
 
 						const cleanedWithoutWarnings = stripWarnings(cleaned, trace.warnings ?? []);

--- a/tests/e2e/cli-shim/expected-invocations.ts
+++ b/tests/e2e/cli-shim/expected-invocations.ts
@@ -1,10 +1,18 @@
-import { type AgentE2EConfig, PROMPT, type SHARED_CASES } from "./cases.js";
+import {
+	type AgentE2EConfig,
+	PROMPT,
+	type SHARED_CASES,
+	STRUCTURED_PROMPT,
+	STRUCTURED_SCHEMA,
+} from "./cases.js";
 
 export type ExpectedInvocation = {
 	command: string;
 	args: string[];
 	warnings?: string[];
 };
+
+export const TMPFILE_PLACEHOLDER = "<TMPFILE>";
 
 type CaseId = (typeof SHARED_CASES)[number]["id"];
 type AgentId = "codex" | "claude" | "gemini" | "copilot";
@@ -65,10 +73,11 @@ function buildCodexInvocation(
 	flags: string[],
 	passthrough: string[],
 	prefixFlags: string[] = [],
+	prompt: string = PROMPT,
 ): ExpectedInvocation {
 	return {
 		command: agent.cliCommand,
-		args: [...prefixFlags, "exec", ...flags, ...passthrough, PROMPT],
+		args: [...prefixFlags, "exec", ...flags, ...passthrough, prompt],
 	};
 }
 
@@ -76,10 +85,11 @@ function buildFlagPromptInvocation(
 	agent: AgentE2EConfig,
 	flags: string[],
 	passthrough: string[],
+	prompt: string = PROMPT,
 ): ExpectedInvocation {
 	return {
 		command: agent.cliCommand,
-		args: [...flags, "-p", PROMPT, ...passthrough],
+		args: [...flags, "-p", prompt, ...passthrough],
 	};
 }
 
@@ -125,6 +135,16 @@ function buildCodex(caseId: CaseId, agent: AgentE2EConfig): ExpectedInvocation |
 		flags.push("--disable", "web_search_request");
 	}
 
+	if (caseId === "output-schema-inline") {
+		flags.push(
+			"--output-schema",
+			TMPFILE_PLACEHOLDER,
+			"--output-last-message",
+			TMPFILE_PLACEHOLDER,
+		);
+		return buildCodexInvocation(agent, flags, passthrough, prefixFlags, STRUCTURED_PROMPT);
+	}
+
 	if (caseId === "web-on") {
 		return buildCodexInvocation(agent, flags, passthrough, prefixFlags);
 	}
@@ -153,6 +173,7 @@ function buildClaude(caseId: CaseId, agent: AgentE2EConfig): ExpectedInvocation 
 			? collectPassthrough(agent, agent.passthroughArgs ?? [])
 			: collectPassthrough(agent);
 	let flags: string[] = [];
+	let prompt = PROMPT;
 	const warnings: string[] = [];
 
 	switch (caseId) {
@@ -186,11 +207,15 @@ function buildClaude(caseId: CaseId, agent: AgentE2EConfig): ExpectedInvocation 
 			break;
 		case "passthrough":
 			break;
+		case "output-schema-inline":
+			flags = ["--json-schema", STRUCTURED_SCHEMA, "--output-format", "json"];
+			prompt = STRUCTURED_PROMPT;
+			break;
 		default:
 			return null;
 	}
 
-	const invocation = buildFlagPromptInvocation(agent, flags, passthrough);
+	const invocation = buildFlagPromptInvocation(agent, flags, passthrough, prompt);
 	return withWarnings(invocation, warnings);
 }
 

--- a/tests/lib/targets/config.test.ts
+++ b/tests/lib/targets/config.test.ts
@@ -172,6 +172,99 @@ describe("target config validation", () => {
 		expect(validation.errors).toEqual([]);
 	});
 
+	it("allows custom targets with valid structured output specs", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom", args: ["run"] },
+						},
+						flags: {
+							structuredOutput: {
+								delivery: "file",
+								flag: ["--schema"],
+								companionArgs: ["--format", "json"],
+								extraction: { type: "last-message-file", flag: ["--last-message"] },
+							},
+						},
+					},
+				},
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(true);
+		expect(validation.errors).toEqual([]);
+	});
+
+	it("rejects invalid structured output specs", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						flags: {
+							structuredOutput: {
+								delivery: "socket",
+								flag: [],
+								extraction: { type: "telepathy" },
+							},
+						},
+					},
+				} as unknown as TargetDefinition,
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toEqual(
+			expect.arrayContaining([
+				'targets[0].cli.flags.structuredOutput.delivery must be "inline" or "file".',
+				"targets[0].cli.flags.structuredOutput.flag must include at least one entry.",
+				'targets[0].cli.flags.structuredOutput.extraction.type must be "json-envelope" or "last-message-file".',
+			]),
+		);
+	});
+
+	it("rejects json-envelope extraction without a field", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						flags: {
+							structuredOutput: {
+								delivery: "inline",
+								flag: ["--schema"],
+								extraction: { type: "json-envelope", field: " " },
+							},
+						},
+					},
+				} as unknown as TargetDefinition,
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toContain(
+			"targets[0].cli.flags.structuredOutput.extraction.field must be a non-empty string.",
+		);
+	});
+
 	it("allows custom usage extract functions", () => {
 		const config: OmniagentConfig = {
 			targets: [

--- a/tests/lib/targets/config.test.ts
+++ b/tests/lib/targets/config.test.ts
@@ -235,6 +235,66 @@ describe("target config validation", () => {
 		);
 	});
 
+	it("accepts custom structured output fallback specs", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						prompt: { type: "flag", flag: ["-p"] },
+						flags: {
+							structuredOutputFallback: {
+								args: ["--quiet"],
+								extraction: { type: "json-envelope", field: "response" },
+							},
+						},
+					},
+				},
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(true);
+		expect(validation.errors).toEqual([]);
+	});
+
+	it("rejects invalid structured output fallback specs", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						flags: {
+							structuredOutputFallback: {
+								args: [42],
+								extraction: { type: "telepathy" },
+							},
+						},
+					},
+				} as unknown as TargetDefinition,
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toEqual(
+			expect.arrayContaining([
+				"targets[0].cli.flags.structuredOutputFallback.args[0] must be a non-empty string.",
+				'targets[0].cli.flags.structuredOutputFallback.extraction.type must be "text" or "json-envelope".',
+			]),
+		);
+	});
+
 	it("rejects json-envelope extraction without a field", () => {
 		const config: OmniagentConfig = {
 			targets: [


### PR DESCRIPTION
## Summary

Adds a shared `--output-schema` flag to the CLI shim — the coding-agent equivalent of API "structured outputs". Pass a JSON schema (file path or inline JSON object) and stdout is guaranteed to be exactly the schema-conforming JSON, identical across agents:

```bash
omniagent --agent claude -p "Top 3 TS benefits" --output-schema ./schema.json | jq .answer
omniagent --agent codex  -p "Top 3 TS benefits" --output-schema '{"type":"object",...}' | jq .answer
```

Two layers of support:

1. **Native** (claude, codex): the schema is passed through to the agent's own enforcement.
2. **Prompt-based fallback** (gemini, copilot, custom targets): the shim embeds the schema in the prompt, validates the response client-side with ajv, and retries with feedback on validation failure — so `--output-schema` works on every agent with the same stdout contract.

## Behavior

- **claude** (native): translates to `--json-schema`, forces `--output-format json`, captures the result envelope, and prints only its `structured_output` payload.
- **codex** (native): writes the schema to a temp file for `--output-schema`, captures the final message via `--output-last-message`, forwards the session log to stderr, and prints the final message to stdout. Temp files are cleaned up on every exit path.
- **gemini / copilot / custom targets** (fallback): no native schema support exists upstream (gemini's feature request was closed as not planned — google-gemini/gemini-cli#13388; copilot has nothing shipped through v1.0.68). The shim embeds the schema in the prompt with strict output instructions, captures the response cleanly (gemini: `--output-format json` envelope `response` field; copilot: `--silent` text mode), extracts the JSON (tolerating prose/code fences), and validates against the schema with ajv. Invalid responses are retried with the previous output and the specific validation errors, up to `--output-schema-retries` retries (0–10, default 2). A one-line `Notice:` on stderr flags fallback runs.

Rules: one-shot only (interactive exits 2); conflicts with explicit `--output`/`--json`/`--stream-json` (exit 2); schema must be a JSON object; retries flag requires `--output-schema` and warns-and-ignores on native agents. Native extraction failures and exhausted fallback retries exit 1 with diagnostics on stderr; nonzero agent exits pass through without retrying. Fallback schemas that fail to compile exit 2 before any agent is spawned; a fallback target with no prompt mechanism also exits 2. Native responses are not re-validated client-side; fallback validation uses ajv with `strict: false` (unknown keywords and `format` are not enforced).

## Implementation

Follows the existing declarative target pattern: a `structuredOutput` spec on `TargetCliDefinition.flags` (delivery style, flag, companion args, extraction strategy) plus a `structuredOutputFallback` spec (capture args, text or json-envelope extraction) with a plain-text default so custom targets work with zero config. A new async planner (`src/cli/shim/structured-output.ts`) resolves the schema, compiles the ajv validator, and materializes temp files before translation so `translateInvocation` stays pure. Execution branches: native plans use an opt-in capture mode, fallback plans run an attempt loop (`runFallbackAttempts` in `execute.ts`) that rebuilds agent args per attempt with an augmented prompt — trace, warnings, and notices are emitted once. The no-schema path is byte-for-byte unchanged. New modules: `fallback-prompts.ts` (prompt builders + JSON extraction) and `schema-validator.ts` (ajv wrapper). `ajv` is added as a runtime dependency (both `package-lock.json` and `pnpm-lock.yaml` updated; CI installs with `npm ci`).

## Testing

- 70 new unit tests across both commits (schema resolution, planning, arg translation, capture/extraction paths, cleanup, config validation, capability declarations, JSON extraction, validator compile/errors, retry loop: retry-then-success, exhaustion, no-retry on agent failure, spawn errors, retries=0, trace metadata); full suite: 622 passing.
- New `output-schema-inline` E2E case asserted structurally (temp paths and model output are nondeterministic, so no recorded baselines).
- Live smoke tests: claude and codex native runs produce identical bare-JSON stdout; copilot fallback verified end-to-end including a live retry-exhaustion run (unsatisfiable schema → feedback retry → exit 1 with clean stdout). gemini could not be happy-path tested locally (Google shut down Gemini CLI for individual tiers on 2026-06-18 — see #48); the shim's error passthrough was verified against it and the envelope format is unit-tested against the documented shape.
- Exit codes verified for all error paths; no leftover temp dirs.

## Docs

- `docs/cli-shim.md`: shared-flag entries, capability matrix (native vs fallback), "Structured output" section with a "Prompt-based fallback" subsection.
- `docs/custom-targets.md`: `cli.flags.structuredOutput` and `cli.flags.structuredOutputFallback` references for custom targets.
- README: shim example and native/fallback note.
