### PR TITLE
Fix Antigravity usage extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ is not supported for usage extraction yet. Usage extraction may launch agent TUI
 cost if an agent reads repo context or instructions on startup; omniagent uses cheap/minimal
 launch settings where possible. Usage extraction times out after 30 seconds unless the target
 config defines a target-specific timeout; built-in TUI probes may use longer defaults. Some CLIs
-gate usage inspection behind auth or onboarding state; omniagent does not complete those prompts
-for you. Pass `--timeout=<seconds>` to override the per-agent timeout for the current run.
+gate usage inspection behind auth or onboarding state. When Antigravity requests directory trust,
+interactive usage shows the exact directory and forwards approval only after you confirm;
+omniagent never accepts trust automatically or completes authentication prompts. If Antigravity
+requests directory trust, JSON, debug, and non-interactive runs return a `trust_required` error
+instead of prompting. Pass `--timeout=<seconds>` to override the per-agent timeout for the current
+run.
 
 ## Local Overrides (`.local`)
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,8 @@ is not supported for usage extraction yet. Usage extraction may launch agent TUI
 cost if an agent reads repo context or instructions on startup; omniagent uses cheap/minimal
 launch settings where possible. Usage extraction times out after 30 seconds unless the target
 config defines a target-specific timeout; built-in TUI probes may use longer defaults. Some CLIs
-gate usage inspection behind onboarding state — Antigravity requires the project to be trusted
-(run `agy` once and accept the trust prompt); omniagent does not complete auth or onboarding
-prompts for you. Pass `--timeout=<seconds>` to override the per-agent timeout for the current
-run.
+gate usage inspection behind auth or onboarding state; omniagent does not complete those prompts
+for you. Pass `--timeout=<seconds>` to override the per-agent timeout for the current run.
 
 ## Local Overrides (`.local`)
 

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -94,9 +94,9 @@ const config = {
 export default config;
 ```
 
-Limits that report an absolute balance instead of percentages (like Antigravity's AI Credits)
-can set `percentUsed`/`percentRemaining` to `null` and provide `remainingText` (for example
-`"1,234"`), which the human table renders in the Left column.
+Limits that report an absolute balance instead of percentages can set
+`percentUsed`/`percentRemaining` to `null` and provide `remainingText` (for example `"1,234"`),
+which the human table renders in the Left column.
 
 ## Structured output (`cli.flags.structuredOutput`)
 

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -98,6 +98,19 @@ Limits that report an absolute balance instead of percentages can set
 `percentUsed`/`percentRemaining` to `null` and provide `remainingText` (for example `"1,234"`),
 which the human table renders in the Left column.
 
+Extractors can return `notes: string[]` for informational, nonfatal conditions. Notes appear as
+`Note:` lines in human output and are promoted to the top-level JSON envelope. Notes do not change
+the exit code; use `errors` when the condition should make `omniagent usage` exit with code 1.
+
+```ts
+extract: async (context) => ({
+	targetId: context.targetId,
+	displayName: context.displayName,
+	limits: [],
+	notes: ["Usage reporting is not enabled for this account."],
+});
+```
+
 ## Structured output (`cli.flags.structuredOutput`)
 
 Custom targets whose CLI supports schema-constrained responses can declare a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,8 +61,9 @@ Target behavior:
 - Unknown targets and targets without usage extraction are invalid usage errors.
 - Usage extraction may launch agent TUIs. omniagent uses cheap/minimal launch settings where
   possible, but an agent may still incur cost if it reads repo context or instructions on startup.
-- Some CLIs gate usage inspection behind auth or onboarding state; omniagent does not complete
-  those prompts for you.
+- Some CLIs gate usage inspection behind auth or onboarding state. When Antigravity requests
+  directory trust, interactive human output shows the exact directory and asks before forwarding
+  approval. Declining trust stops that extraction, and authentication remains manual.
 - Antigravity reports weekly Models & Quota rows for each model group.
 - Usage extraction times out after 30 seconds unless the target config defines a target-specific
   timeout. Built-in TUI probes may use longer defaults. Pass `--timeout=<seconds>` to override the
@@ -93,6 +94,9 @@ JSON and debug:
   `errors`, and `notes`.
 - `--debug` implies JSON and includes extractor debug artifacts when available, such as raw TUI
   output or screen snapshots.
+- JSON, debug, and non-interactive runs never prompt for Antigravity directory trust. If trust is
+  requested, they return a `trust_required` extraction error with exit code 1 so automation cannot
+  grant trust implicitly.
 - Debug output may contain sensitive local agent output. Use it for troubleshooting, not routine
   logging.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,10 +61,9 @@ Target behavior:
 - Unknown targets and targets without usage extraction are invalid usage errors.
 - Usage extraction may launch agent TUIs. omniagent uses cheap/minimal launch settings where
   possible, but an agent may still incur cost if it reads repo context or instructions on startup.
-- Some CLIs gate usage inspection behind onboarding state — Antigravity requires the project to be trusted (run `agy` once and accept the trust prompt).
-- Antigravity reports a single absolute AI Credits balance in the Left column rather than
-  percent-based windows.
-- omniagent does not complete auth or onboarding prompts for you.
+- Some CLIs gate usage inspection behind auth or onboarding state; omniagent does not complete
+  those prompts for you.
+- Antigravity reports weekly Models & Quota rows for each model group.
 - Usage extraction times out after 30 seconds unless the target config defines a target-specific
   timeout. Built-in TUI probes may use longer defaults. Pass `--timeout=<seconds>` to override the
   per-agent timeout for the current run, or use explicit units such as `--timeout=500ms`,

--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -336,10 +336,14 @@ function filterTargetResult(
 		selectedWindow == null
 			? normalizedLimits
 			: normalizedLimits.filter((limit) => limit.window === selectedWindow);
+	const resultNotes = result.notes ?? [];
 	const notes =
 		selectedWindow != null && filteredLimits.length === 0
-			? [`${target.displayName} reported no usage rows for window "${selectedWindow}".`]
-			: [];
+			? [
+					...resultNotes,
+					`${target.displayName} reported no usage rows for window "${selectedWindow}".`,
+				]
+			: resultNotes;
 
 	return {
 		result: {

--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import os from "node:os";
+import { createInterface } from "node:readline/promises";
 import type { CommandModule } from "yargs";
 import { DEFAULT_AGENTS_DIR, resolveAgentsDir, validateAgentsDir } from "../../lib/agents-dir.js";
 import { findRepoRoot } from "../../lib/repo-root.js";
@@ -14,13 +15,15 @@ import {
 	validateTargetConfig,
 } from "../../lib/targets/index.js";
 import { normalizeUsageWindow } from "../../lib/usage/format.js";
-import type {
-	NormalizedUsageDebugArtifact,
-	NormalizedUsageEnvelope,
-	NormalizedUsageError,
-	NormalizedUsageLimit,
-	NormalizedUsageTargetResult,
-	UsageExtractionContext,
+import {
+	type NormalizedUsageDebugArtifact,
+	type NormalizedUsageEnvelope,
+	type NormalizedUsageError,
+	type NormalizedUsageLimit,
+	type NormalizedUsageTargetResult,
+	type UsageConfirmationRequest,
+	type UsageExtractionContext,
+	UsageExtractionError,
 } from "../../lib/usage/types.js";
 
 type UsageArgs = {
@@ -103,6 +106,11 @@ type UsageTableWidths = {
 
 type UsageSortKey = "reset" | "left";
 
+type UsageConfirmationPrompt = (
+	request: UsageConfirmationRequest,
+	signal: AbortSignal,
+) => Promise<boolean>;
+
 const DEFAULT_USAGE_TIMEOUT_MS = 30_000;
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 3_600_000;
@@ -124,6 +132,13 @@ const RESET_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
 class UsageExtractionTimeoutError extends Error {
 	constructor(readonly timeoutMs: number) {
 		super(`Usage extraction timed out after ${formatDuration(timeoutMs)}.`);
+	}
+}
+
+class UsageCommandInterruptedError extends Error {
+	constructor() {
+		super("Usage cancelled.");
+		this.name = "UsageCommandInterruptedError";
 	}
 }
 
@@ -209,6 +224,72 @@ function uniqueNormalizedWindows(values: string[]): string[] {
 	return result;
 }
 
+class UsageConfirmationPrompter {
+	private rl: ReturnType<typeof createInterface> | null = null;
+	private queue: Promise<void> = Promise.resolve();
+	private closed = false;
+	private readonly interrupt: () => void;
+
+	constructor(interrupt: () => void) {
+		this.interrupt = interrupt;
+	}
+
+	readonly confirm: UsageConfirmationPrompt = (request, signal) => {
+		const confirmation = this.queue.then(() => this.ask(request, signal));
+		this.queue = confirmation.then(
+			() => undefined,
+			() => undefined,
+		);
+		return confirmation;
+	};
+
+	close(): void {
+		this.closed = true;
+		this.rl?.close();
+		this.rl = null;
+	}
+
+	private async ask(request: UsageConfirmationRequest, signal: AbortSignal): Promise<boolean> {
+		if (this.closed) {
+			throw new Error("Usage confirmation is no longer available.");
+		}
+		if (signal.aborted) {
+			throw signal.reason instanceof Error
+				? signal.reason
+				: new Error("Usage confirmation was cancelled.");
+		}
+		const scope = request.managed ? "managed usage directory" : "project directory";
+		const question = `${request.displayName} needs to trust this ${scope}:\n${request.path}\n\nAllow this? [y/N] `;
+		const rl = createInterface({ input: process.stdin, output: process.stderr });
+		this.rl = rl;
+		const handleInterrupt = () => this.interrupt();
+		rl.once("SIGINT", handleInterrupt);
+		try {
+			while (true) {
+				const answer = (await rl.question(question, { signal })).trim().toLowerCase();
+				if (!answer || answer === "n" || answer === "no") {
+					return false;
+				}
+				if (answer === "y" || answer === "yes") {
+					return true;
+				}
+				console.error("Please enter yes or no.");
+			}
+		} catch (error) {
+			if (signal.aborted && signal.reason instanceof Error) {
+				throw signal.reason;
+			}
+			throw error;
+		} finally {
+			rl.removeListener("SIGINT", handleInterrupt);
+			rl.close();
+			if (this.rl === rl) {
+				this.rl = null;
+			}
+		}
+	}
+}
+
 function formatUsageTargetLabel(targets: ResolvedTarget[]): string {
 	return buildSupportedTargetLabel(targets);
 }
@@ -222,6 +303,15 @@ function formatSupportedUsageTargetsMessage(targets: ResolvedTarget[]): string {
 
 function getUsageCommand(target: ResolvedTarget): string | undefined {
 	return target.usage?.launch?.command;
+}
+
+function supportsUsageConfirmation(target: ResolvedTarget): boolean {
+	if (target.id.trim().toLowerCase() === "agy") {
+		return true;
+	}
+	const builtInAgyExtractor = BUILTIN_TARGETS.find((candidate) => candidate.id === "agy")?.usage
+		?.extract;
+	return builtInAgyExtractor != null && target.usage?.extract === builtInAgyExtractor;
 }
 
 async function checkUsageCommandAvailability(
@@ -297,8 +387,10 @@ function buildContext(options: {
 	now: Date;
 	command?: string;
 	signal: AbortSignal;
+	confirm?: UsageConfirmationPrompt;
 }): UsageExtractionContext {
 	const windows = uniqueNormalizedWindows(options.target.usage?.windows ?? []);
+	const confirm = options.confirm;
 	const launch = {
 		...(options.target.usage?.launch ?? {}),
 		timeoutMs: options.timeoutMs,
@@ -315,6 +407,7 @@ function buildContext(options: {
 		homeDir: options.homeDir,
 		launch,
 		signal: options.signal,
+		confirm: confirm == null ? undefined : (request) => confirm(request, options.signal),
 		debug: {
 			enabled: options.debug,
 			includeRawOutput: options.debug,
@@ -376,6 +469,8 @@ async function extractUsageForTarget(options: {
 	debug: boolean;
 	now: Date;
 	command?: string;
+	confirm?: UsageConfirmationPrompt;
+	commandSignal?: AbortSignal;
 }): Promise<TargetExtractionOutcome> {
 	try {
 		const extractor = options.target.usage?.extract;
@@ -391,10 +486,14 @@ async function extractUsageForTarget(options: {
 				debug: [],
 			};
 		}
-		const result = await withUsageTimeout((signal) => {
-			const context = buildContext({ ...options, signal });
-			return extractor(context);
-		}, options.timeoutMs);
+		const result = await withUsageTimeout(
+			(signal) => {
+				const context = buildContext({ ...options, signal });
+				return extractor(context);
+			},
+			options.timeoutMs,
+			options.commandSignal,
+		);
 		const filtered = filterTargetResult(options.target, result, options.selectedWindow);
 		return {
 			status: "success",
@@ -408,7 +507,7 @@ async function extractUsageForTarget(options: {
 		const message = error instanceof Error ? error.message : String(error);
 		const code = isUsageTimeoutError(error)
 			? "usage_extraction_timeout"
-			: "usage_extraction_failed";
+			: getUsageExtractionErrorCode(error);
 		return {
 			status: "error",
 			target: options.target,
@@ -416,6 +515,22 @@ async function extractUsageForTarget(options: {
 			debug: options.debug ? getErrorDebugArtifacts(error) : [],
 		};
 	}
+}
+
+function getUsageExtractionErrorCode(error: unknown): string {
+	if (error instanceof UsageExtractionError) {
+		return error.code;
+	}
+	if (error && typeof error === "object") {
+		const code = (error as { code?: unknown }).code;
+		if (typeof code === "string") {
+			const normalized = code.trim();
+			if (/^[a-z][a-z0-9_]*$/.test(normalized)) {
+				return normalized;
+			}
+		}
+	}
+	return "usage_extraction_failed";
 }
 
 function isUsageTimeoutError(error: unknown): boolean {
@@ -450,18 +565,26 @@ function isDebugArtifact(value: unknown): value is NormalizedUsageDebugArtifact 
 function withUsageTimeout<T>(
 	run: (signal: AbortSignal) => Promise<T>,
 	timeoutMs: number,
+	commandSignal?: AbortSignal,
 ): Promise<T> {
 	return new Promise((resolve, reject) => {
 		const controller = new AbortController();
 		let settled = false;
 		let timeoutFired = false;
-		let timeout: NodeJS.Timeout;
+		let timeout: NodeJS.Timeout | null = null;
+		let removeCommandAbortListener: (() => void) | null = null;
+		const cleanup = () => {
+			if (timeout != null) {
+				clearTimeout(timeout);
+			}
+			removeCommandAbortListener?.();
+		};
 		const settleResolve = (value: T) => {
 			if (settled) {
 				return;
 			}
 			settled = true;
-			clearTimeout(timeout);
+			cleanup();
 			resolve(value);
 		};
 		const settleReject = (error: unknown) => {
@@ -469,7 +592,7 @@ function withUsageTimeout<T>(
 				return;
 			}
 			settled = true;
-			clearTimeout(timeout);
+			cleanup();
 			reject(error);
 		};
 		timeout = setTimeout(() => {
@@ -480,6 +603,23 @@ function withUsageTimeout<T>(
 				settleReject(error);
 			});
 		}, timeoutMs);
+		if (commandSignal) {
+			const abortFromCommand = () => {
+				const reason =
+					commandSignal.reason instanceof Error
+						? commandSignal.reason
+						: new UsageCommandInterruptedError();
+				controller.abort(reason);
+				settleReject(reason);
+			};
+			if (commandSignal.aborted) {
+				abortFromCommand();
+				return;
+			}
+			commandSignal.addEventListener("abort", abortFromCommand, { once: true });
+			removeCommandAbortListener = () =>
+				commandSignal.removeEventListener("abort", abortFromCommand);
+		}
 
 		let promise: Promise<T>;
 		try {
@@ -1178,21 +1318,52 @@ async function runUsageCommand(argv: UsageArgs): Promise<UsageRunResult | null> 
 	}
 
 	const now = new Date();
-	const outcomes = await Promise.all(
-		selectedTargets.map((target) =>
-			extractUsageForTarget({
-				target,
-				repoRoot,
-				agentsDir,
-				homeDir,
-				selectedWindow,
-				timeoutMs: resolveTargetTimeoutMs(target, cliTimeoutMs),
-				debug: debugOutput,
-				now,
-				command: resolvedUsageCommands.get(target.id),
-			}),
-		),
-	);
+	const commandController = new AbortController();
+	const confirmationPrompter =
+		!jsonOutput && Boolean(process.stdin.isTTY) && Boolean(process.stderr.isTTY)
+			? new UsageConfirmationPrompter(() => {
+					if (!commandController.signal.aborted) {
+						commandController.abort(new UsageCommandInterruptedError());
+					}
+				})
+			: null;
+	let outcomes: TargetExtractionOutcome[];
+	try {
+		let confirmationTargetChain: Promise<void> = Promise.resolve();
+		const outcomePromises = selectedTargets.map((target) => {
+			const extract = () =>
+				extractUsageForTarget({
+					target,
+					repoRoot,
+					agentsDir,
+					homeDir,
+					selectedWindow,
+					timeoutMs: resolveTargetTimeoutMs(target, cliTimeoutMs),
+					debug: debugOutput,
+					now,
+					command: resolvedUsageCommands.get(target.id),
+					confirm: supportsUsageConfirmation(target) ? confirmationPrompter?.confirm : undefined,
+					commandSignal: commandController.signal,
+				});
+			if (confirmationPrompter == null || !supportsUsageConfirmation(target)) {
+				return extract();
+			}
+			const outcome = confirmationTargetChain.then(extract);
+			confirmationTargetChain = outcome.then(
+				() => undefined,
+				() => undefined,
+			);
+			return outcome;
+		});
+		outcomes = await Promise.all(outcomePromises);
+	} finally {
+		confirmationPrompter?.close();
+	}
+	if (commandController.signal.reason instanceof UsageCommandInterruptedError) {
+		console.error(commandController.signal.reason.message);
+		process.exit(130);
+		return null;
+	}
 	const targets: NormalizedUsageTargetResult[] = [];
 	const errors: NormalizedUsageError[] = [];
 	const notes: string[] = [];
@@ -1293,7 +1464,8 @@ export const usageCommand: CommandModule<unknown, UsageArgs> = {
 			})
 			.epilog(
 				"Usage extraction may launch agent TUIs and may incur cost if an agent reads repo " +
-					"context on startup. omniagent uses cheap/minimal launch settings where possible.",
+					"context on startup. Interactive runs may ask before forwarding directory trust; " +
+					"JSON, debug, and non-interactive runs never prompt.",
 			),
 	handler: async (argv) => {
 		await runUsageCommand(argv);

--- a/src/lib/targets/builtins/antigravity-cli/target.test.ts
+++ b/src/lib/targets/builtins/antigravity-cli/target.test.ts
@@ -133,8 +133,8 @@ describe("agy builtin target", () => {
 		expect(filename).toBe("AGENTS.md");
 	});
 
-	it("declares credits-based usage extraction", () => {
-		expect(agyTarget.usage?.windows).toEqual(["credits"]);
+	it("declares weekly quota usage extraction", () => {
+		expect(agyTarget.usage?.windows).toEqual(["weekly"]);
 		expect(agyTarget.usage?.launch).toEqual({ command: "agy", timeoutMs: 70_000 });
 		expect(typeof agyTarget.usage?.extract).toBe("function");
 	});

--- a/src/lib/targets/builtins/antigravity-cli/target.ts
+++ b/src/lib/targets/builtins/antigravity-cli/target.ts
@@ -57,7 +57,7 @@ export const agyTarget: TargetDefinition = {
 		},
 	},
 	usage: {
-		windows: ["credits"],
+		windows: ["weekly"],
 		launch: {
 			command: "agy",
 			timeoutMs: 70_000,

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -121,6 +121,11 @@ export async function extractAgyUsage(
 	};
 
 	if (isCurrentTrustDialog(ptyResult)) {
+		if (!launchCwd.managed) {
+			throw buildError(
+				`Antigravity has not trusted this project yet. Run \`${command}\` in ${launchCwd.path} once, accept the trust prompt, then re-run usage.`,
+			);
+		}
 		throw buildError(
 			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`${command}\` in ${launchCwd.path} once, accept the trust prompt, then re-run usage.`,
 		);

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "node:fs/promises";
+import { access, mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import {
 	cleanControlOutput,
@@ -18,7 +18,6 @@ import type { UsageExtractionContext, UsageExtractionResult } from "./types.js";
 
 const TRUST_DIALOG_PATTERN = /Do you trust the contents of this project\?/i;
 const READY_PATTERN = /\?\s+for shortcuts/i;
-const MODELS_QUOTA_PATTERN = /Models & Quota/i;
 const USAGE_GROUP_HEADING_PATTERN = /^[A-Z][A-Z0-9 &/-]+$/;
 const LIMIT_LABEL_PATTERN = /limit$/i;
 const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
@@ -26,6 +25,7 @@ const REFRESH_PATTERN = /Refreshes\s+in\s+(?:(\d+)h)?\s*(?:(\d+)m)?/i;
 const SIGN_IN_PATTERN = /\b(?:not signed in|Signing in)\b/i;
 const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_SETTINGS_PATH = [".gemini", "antigravity-cli", "settings.json"];
+const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
 
 export type ParsedAgyUsageGroup = {
 	heading: string;
@@ -47,11 +47,7 @@ function isReadyOrTrustDialog(snapshot: PtyWaitSnapshot): boolean {
 
 function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
 	const cleanedOutput = cleanControlOutput(snapshot.raw);
-	return (
-		(MODELS_QUOTA_PATTERN.test(snapshot.screen) || MODELS_QUOTA_PATTERN.test(cleanedOutput)) &&
-		(/% remaining|\bDisabled\b/i.test(snapshot.screen) ||
-			/% remaining|\bDisabled\b/i.test(cleanedOutput))
-	);
+	return parseAgyUsage(snapshot.screen, cleanedOutput).length > 0;
 }
 
 function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
@@ -73,7 +69,7 @@ export async function extractAgyUsage(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "agy";
-	const launchCwd = await resolveAgyUsageCwd(context.homeDir);
+	const launchCwd = await resolveAgyUsageCwd(context.homeDir, context.repoRoot);
 
 	const ptyResult = await runPtyScenario({
 		command,
@@ -154,7 +150,7 @@ export async function extractAgyUsage(
 	};
 }
 
-async function resolveAgyUsageCwd(homeDir: string): Promise<string> {
+async function resolveAgyUsageCwd(homeDir: string, repoRoot: string): Promise<string> {
 	for (const workspace of await readAgyTrustedWorkspaces(homeDir)) {
 		try {
 			await access(workspace);
@@ -163,7 +159,17 @@ async function resolveAgyUsageCwd(homeDir: string): Promise<string> {
 			// Ignore stale trusted workspace entries.
 		}
 	}
-	return homeDir;
+	return ensureAgyUsageFallbackCwd(homeDir, repoRoot);
+}
+
+async function ensureAgyUsageFallbackCwd(homeDir: string, repoRoot: string): Promise<string> {
+	const fallbackDir = path.join(homeDir, ...AGY_USAGE_FALLBACK_PATH);
+	try {
+		await mkdir(fallbackDir, { recursive: true });
+		return fallbackDir;
+	} catch {
+		return repoRoot;
+	}
 }
 
 async function readAgyTrustedWorkspaces(homeDir: string): Promise<string[]> {

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -26,6 +26,11 @@ const NOT_SIGNED_IN_PATTERN = /\bnot signed in\b/i;
 const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
 
+type AgyUsageCwd = {
+	path: string;
+	managed: boolean;
+};
+
 export type ParsedAgyUsageGroup = {
 	heading: string;
 	models: string | null;
@@ -38,6 +43,18 @@ export type ParsedAgyUsageGroup = {
 
 function isTrustDialog(snapshot: PtyWaitSnapshot): boolean {
 	return TRUST_DIALOG_PATTERN.test(snapshot.raw) || TRUST_DIALOG_PATTERN.test(snapshot.screen);
+}
+
+function isCurrentTrustDialog(snapshot: PtyWaitSnapshot): boolean {
+	return TRUST_DIALOG_PATTERN.test(snapshot.screen);
+}
+
+function isNotCurrentTrustDialog(snapshot: PtyWaitSnapshot): boolean {
+	return !isCurrentTrustDialog(snapshot);
+}
+
+function isReady(snapshot: PtyWaitSnapshot): boolean {
+	return READY_PATTERN.test(snapshot.screen);
 }
 
 function isReadyOrTrustDialog(snapshot: PtyWaitSnapshot): boolean {
@@ -61,7 +78,7 @@ function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
 function withTrustSkip(step: PtyStep): PtyStep {
 	// The trust dialog swallows keystrokes; never type into it so the
 	// post-scenario check can surface an actionable error instead.
-	return { ...step, skipIf: isTrustDialog, skipIfSource: "raw" };
+	return { ...step, skipIf: isCurrentTrustDialog, skipIfSource: "screen" };
 }
 
 export async function extractAgyUsage(
@@ -73,7 +90,7 @@ export async function extractAgyUsage(
 	const ptyResult = await runPtyScenario({
 		command,
 		args: context.launch?.args ?? [],
-		cwd: launchCwd,
+		cwd: launchCwd.path,
 		cols: 120,
 		rows: 40,
 		timeoutMs: context.launch?.timeoutMs ?? 70_000,
@@ -81,6 +98,7 @@ export async function extractAgyUsage(
 		debug: context.debug,
 		steps: [
 			{ waitFor: isReadyOrTrustDialog, waitForTimeoutMs: 25_000 },
+			...buildManagedTrustSteps(launchCwd.managed),
 			...typeTextSteps("/usage", 25).map(withTrustSkip),
 			withTrustSkip({ waitMs: 250, write: enterKey() }),
 			withTrustSkip({
@@ -102,9 +120,9 @@ export async function extractAgyUsage(
 		return error;
 	};
 
-	if (isTrustDialog(ptyResult)) {
+	if (isCurrentTrustDialog(ptyResult)) {
 		throw buildError(
-			`Antigravity has not trusted the usage launch directory yet. Run \`${command}\` in ${launchCwd} once, accept the trust prompt, then re-run usage.`,
+			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`${command}\` in ${launchCwd.path} once, accept the trust prompt, then re-run usage.`,
 		);
 	}
 
@@ -149,13 +167,28 @@ export async function extractAgyUsage(
 	};
 }
 
-async function ensureAgyUsageCwd(homeDir: string, repoRoot: string): Promise<string> {
+function buildManagedTrustSteps(shouldAutoAccept: boolean): PtyStep[] {
+	if (!shouldAutoAccept) {
+		return [];
+	}
+	return [
+		{
+			skipIf: isNotCurrentTrustDialog,
+			skipIfSource: "screen",
+			waitMs: 250,
+			write: enterKey(),
+		},
+		{ waitFor: isReady, waitForTimeoutMs: 25_000 },
+	];
+}
+
+async function ensureAgyUsageCwd(homeDir: string, repoRoot: string): Promise<AgyUsageCwd> {
 	const fallbackDir = path.join(homeDir, ...AGY_USAGE_FALLBACK_PATH);
 	try {
 		await mkdir(fallbackDir, { recursive: true });
-		return fallbackDir;
+		return { path: fallbackDir, managed: true };
 	} catch {
-		return repoRoot;
+		return { path: repoRoot, managed: false };
 	}
 }
 

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -24,6 +24,7 @@ const LIMIT_LABEL_PATTERN = /limit$/i;
 const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
 const REFRESH_PATTERN = /Refreshes\s+in\s+(?:(\d+)h)?\s*(?:(\d+)m)?/i;
 const SIGN_IN_PATTERN = /\b(?:not signed in|Signing in)\b/i;
+const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_SETTINGS_PATH = [".gemini", "antigravity-cli", "settings.json"];
 
 export type ParsedAgyUsageGroup = {
@@ -32,6 +33,7 @@ export type ParsedAgyUsageGroup = {
 	limitLabel: string;
 	percentRemaining: number | null;
 	resetText: string | null;
+	disabled: boolean;
 	raw: string;
 };
 
@@ -47,7 +49,17 @@ function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
 	const cleanedOutput = cleanControlOutput(snapshot.raw);
 	return (
 		(MODELS_QUOTA_PATTERN.test(snapshot.screen) || MODELS_QUOTA_PATTERN.test(cleanedOutput)) &&
-		(/% remaining/i.test(snapshot.screen) || /% remaining/i.test(cleanedOutput))
+		(/% remaining|\bDisabled\b/i.test(snapshot.screen) ||
+			/% remaining|\bDisabled\b/i.test(cleanedOutput))
+	);
+}
+
+function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
+	const cleanedOutput = cleanControlOutput(snapshot.raw);
+	return (
+		hasUsagePanel(snapshot) ||
+		SIGN_IN_PATTERN.test(snapshot.screen) ||
+		SIGN_IN_PATTERN.test(cleanedOutput)
 	);
 }
 
@@ -77,8 +89,9 @@ export async function extractAgyUsage(
 			...typeTextSteps("/usage", 25).map(withTrustSkip),
 			withTrustSkip({ waitMs: 250, write: enterKey() }),
 			withTrustSkip({
-				waitFor: hasUsagePanel,
+				waitFor: hasUsagePanelOrKnownFailure,
 				waitForTimeoutMs: 15_000,
+				optional: true,
 				capture: "usage",
 				captureWaitMs: 500,
 			}),
@@ -117,7 +130,9 @@ export async function extractAgyUsage(
 		command,
 		limits: groups.map((group) => {
 			const percentRemaining =
-				group.percentRemaining == null ? null : clampPercent(group.percentRemaining);
+				group.disabled || group.percentRemaining == null
+					? null
+					: clampPercent(group.percentRemaining);
 			const limit = makeUsageLimit({
 				targetId: context.targetId,
 				scope: usageScope(group.heading),
@@ -125,6 +140,7 @@ export async function extractAgyUsage(
 				label: titleCase(group.heading),
 				percentUsed: percentRemaining == null ? null : 100 - percentRemaining,
 				percentRemaining,
+				remainingText: group.disabled ? "Disabled" : null,
 				resetText: group.resetText,
 				raw: group.raw,
 				now: context.now,
@@ -227,6 +243,7 @@ function parseAgyUsageLines(lines: string[]): ParsedAgyUsageGroup[] {
 		let limitLabel = "";
 		let percentRemaining: number | null = null;
 		let resetText: string | null = null;
+		let disabled = false;
 		index += 1;
 
 		while (index < lines.length && !isUsageGroupHeading(lines[index] ?? "")) {
@@ -247,16 +264,20 @@ function parseAgyUsageLines(lines: string[]): ParsedAgyUsageGroup[] {
 			if (lineResetText != null) {
 				resetText = lineResetText;
 			}
+			if (DISABLED_PATTERN.test(line)) {
+				disabled = true;
+			}
 			index += 1;
 		}
 
-		if (limitLabel && (percentRemaining != null || resetText != null)) {
+		if (limitLabel && (percentRemaining != null || resetText != null || disabled)) {
 			groups.push({
 				heading,
 				models,
 				limitLabel,
 				percentRemaining,
 				resetText,
+				disabled,
 				raw: rawLines.join("\n"),
 			});
 		}

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -6,15 +6,12 @@ import {
 	makeUsageLimit,
 	parsePercentRemaining,
 } from "./format.js";
+import { enterKey, escapeKey, type PtyStep, type PtyWaitSnapshot, runPtyScenario } from "./pty.js";
 import {
-	enterKey,
-	escapeKey,
-	type PtyStep,
-	type PtyWaitSnapshot,
-	runPtyScenario,
-	typeTextSteps,
-} from "./pty.js";
-import type { UsageExtractionContext, UsageExtractionResult } from "./types.js";
+	type UsageExtractionContext,
+	UsageExtractionError,
+	type UsageExtractionResult,
+} from "./types.js";
 
 const TRUST_DIALOG_PATTERN = /Do you trust the contents of this project\?/i;
 const READY_PATTERN = /\?\s+for shortcuts/i;
@@ -23,13 +20,18 @@ const LIMIT_LABEL_PATTERN = /limit$/i;
 const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
 const REFRESH_PATTERN = /Refreshes\s+in\s+(?:(\d+)h)?\s*(?:(\d+)m)?/i;
 const NOT_SIGNED_IN_PATTERN = /\bnot signed in\b/i;
+const SIGNING_IN_PATTERN = /\bsigning in\b/i;
 const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
+const AUTH_STABILIZATION_MS = 2_000;
+const TRUST_READY_TIMEOUT_MS = 5_000;
 
 type AgyUsageCwd = {
 	path: string;
 	managed: boolean;
 };
+
+type AgyTrustOutcome = "not-requested" | "approved" | "denied" | "required";
 
 export type ParsedAgyUsageGroup = {
 	heading: string;
@@ -40,10 +42,6 @@ export type ParsedAgyUsageGroup = {
 	disabled: boolean;
 	raw: string;
 };
-
-function isTrustDialog(snapshot: PtyWaitSnapshot): boolean {
-	return TRUST_DIALOG_PATTERN.test(snapshot.raw) || TRUST_DIALOG_PATTERN.test(snapshot.screen);
-}
 
 function isCurrentTrustDialog(snapshot: PtyWaitSnapshot): boolean {
 	return TRUST_DIALOG_PATTERN.test(snapshot.screen);
@@ -58,7 +56,27 @@ function isReady(snapshot: PtyWaitSnapshot): boolean {
 }
 
 function isReadyOrTrustDialog(snapshot: PtyWaitSnapshot): boolean {
-	return READY_PATTERN.test(snapshot.screen) || isTrustDialog(snapshot);
+	return isReady(snapshot) || isCurrentTrustDialog(snapshot);
+}
+
+function isCurrentSignInFailure(snapshot: PtyWaitSnapshot): boolean {
+	return NOT_SIGNED_IN_PATTERN.test(snapshot.screen);
+}
+
+function isInteractionBlocked(snapshot: PtyWaitSnapshot): boolean {
+	return isCurrentTrustDialog(snapshot) || isCurrentSignInFailure(snapshot);
+}
+
+function isAuthenticationTransition(snapshot: PtyWaitSnapshot): boolean {
+	return SIGNING_IN_PATTERN.test(snapshot.screen);
+}
+
+function isUsageWriteBlocked(snapshot: PtyWaitSnapshot): boolean {
+	return isInteractionBlocked(snapshot) || isAuthenticationTransition(snapshot);
+}
+
+function isReadyOrKnownGate(snapshot: PtyWaitSnapshot): boolean {
+	return isReadyOrTrustDialog(snapshot) || isCurrentSignInFailure(snapshot);
 }
 
 function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
@@ -67,18 +85,24 @@ function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
 }
 
 function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
-	const cleanedOutput = cleanControlOutput(snapshot.raw);
-	return (
-		hasUsagePanel(snapshot) ||
-		NOT_SIGNED_IN_PATTERN.test(snapshot.screen) ||
-		NOT_SIGNED_IN_PATTERN.test(cleanedOutput)
-	);
+	return hasUsagePanel(snapshot) || isInteractionBlocked(snapshot);
 }
 
-function withTrustSkip(step: PtyStep): PtyStep {
-	// The trust dialog swallows keystrokes; never type into it so the
-	// post-scenario check can surface an actionable error instead.
-	return { ...step, skipIf: isCurrentTrustDialog, skipIfSource: "screen" };
+function guardedUsageWrite(
+	value: string,
+	scenarioState: { canEnterUsage: boolean },
+	waitMs?: number,
+): PtyStep {
+	return {
+		waitMs,
+		write: (snapshot) => {
+			if (isUsageWriteBlocked(snapshot)) {
+				scenarioState.canEnterUsage = false;
+				return undefined;
+			}
+			return scenarioState.canEnterUsage ? value : undefined;
+		},
+	};
 }
 
 export async function extractAgyUsage(
@@ -86,6 +110,15 @@ export async function extractAgyUsage(
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "agy";
 	const launchCwd = await ensureAgyUsageCwd(context.homeDir, context.repoRoot);
+	const scenarioState: {
+		trustOutcome: AgyTrustOutcome;
+		canEnterUsage: boolean;
+		reachedReadyAfterTrust: boolean;
+	} = {
+		trustOutcome: "not-requested",
+		canEnterUsage: false,
+		reachedReadyAfterTrust: false,
+	};
 
 	const ptyResult = await runPtyScenario({
 		command,
@@ -97,48 +130,125 @@ export async function extractAgyUsage(
 		signal: context.signal,
 		debug: context.debug,
 		steps: [
-			{ waitFor: isReadyOrTrustDialog, waitForTimeoutMs: 25_000 },
-			...buildManagedTrustSteps(launchCwd.managed),
-			...typeTextSteps("/usage", 25).map(withTrustSkip),
-			withTrustSkip({ waitMs: 250, write: enterKey() }),
-			withTrustSkip({
+			{ waitFor: isReadyOrKnownGate, waitForTimeoutMs: 25_000 },
+			{
+				waitFor: isReadyOrTrustDialog,
+				waitForTimeoutMs: AUTH_STABILIZATION_MS,
+				optional: true,
+				capture: "startup",
+				captureWaitMs: 0,
+			},
+			{
+				skipIf: isNotCurrentTrustDialog,
+				skipIfSource: "screen",
+				write: async () => {
+					if (context.confirm == null) {
+						scenarioState.trustOutcome = "required";
+						return undefined;
+					}
+					const approved = await context.confirm({
+						type: "trust-directory",
+						targetId: context.targetId,
+						displayName: context.displayName,
+						path: launchCwd.path,
+						managed: launchCwd.managed,
+					});
+					scenarioState.trustOutcome = approved ? "approved" : "denied";
+					return undefined;
+				},
+			},
+			{
+				write: (snapshot) => {
+					if (!isCurrentTrustDialog(snapshot)) {
+						return undefined;
+					}
+					if (scenarioState.trustOutcome === "approved") {
+						return enterKey();
+					}
+					if (scenarioState.trustOutcome === "denied") {
+						return escapeKey();
+					}
+					return undefined;
+				},
+			},
+			{
+				skipIf: () => scenarioState.trustOutcome !== "approved",
+				waitFor: isReady,
+				waitForTimeoutMs: TRUST_READY_TIMEOUT_MS,
+				optional: true,
+			},
+			{
+				write: (snapshot) => {
+					const readyForUsage = isReady(snapshot) && !isInteractionBlocked(snapshot);
+					if (scenarioState.trustOutcome === "approved" && readyForUsage) {
+						scenarioState.reachedReadyAfterTrust = true;
+					}
+					scenarioState.canEnterUsage =
+						scenarioState.trustOutcome !== "denied" &&
+						scenarioState.trustOutcome !== "required" &&
+						readyForUsage;
+					return undefined;
+				},
+			},
+			...[..."/usage"].map((character) => guardedUsageWrite(character, scenarioState, 25)),
+			guardedUsageWrite(enterKey(), scenarioState, 250),
+			{
+				skipIf: () => !scenarioState.canEnterUsage,
 				waitFor: hasUsagePanelOrKnownFailure,
 				waitForTimeoutMs: 15_000,
 				optional: true,
 				capture: "usage",
 				captureWaitMs: 500,
-			}),
-			{ write: escapeKey(), waitMs: 250 },
+			},
+			guardedUsageWrite(escapeKey(), scenarioState, 250),
 		],
 	});
 
-	const buildError = (message: string): Error => {
-		const error = new Error(message);
+	const buildError = (message: string, code?: string): Error => {
+		const error = code == null ? new Error(message) : new UsageExtractionError(code, message);
 		if (ptyResult.debug.length > 0) {
 			Object.assign(error, { debug: ptyResult.debug });
 		}
 		return error;
 	};
 
-	if (isCurrentTrustDialog(ptyResult)) {
-		if (!launchCwd.managed) {
-			throw buildError(
-				`Antigravity has not trusted this project yet. Run \`${command}\` in ${launchCwd.path} once, accept the trust prompt, then re-run usage.`,
-			);
-		}
+	const trustSubject = launchCwd.managed ? "managed usage directory" : "project directory";
+	if (scenarioState.trustOutcome === "required") {
 		throw buildError(
-			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`${command}\` in ${launchCwd.path} once, accept the trust prompt, then re-run usage.`,
+			`Antigravity needs permission to trust the ${trustSubject} at ${launchCwd.path}. Re-run usage in an interactive terminal to review this request.`,
+			"trust_required",
+		);
+	}
+	if (scenarioState.trustOutcome === "denied") {
+		throw buildError(
+			`Antigravity trust was declined for the ${trustSubject} at ${launchCwd.path}.`,
+			"trust_denied",
+		);
+	}
+	if (isCurrentSignInFailure(ptyResult)) {
+		throw buildError(`Antigravity is not signed in. Run \`${command}\` and complete the login.`);
+	}
+	if (scenarioState.trustOutcome === "approved" && !scenarioState.reachedReadyAfterTrust) {
+		throw buildError(
+			`Antigravity did not accept trust for the ${trustSubject} at ${launchCwd.path}. Run \`${command}\` there once, accept the trust prompt, then re-run usage.`,
+			"trust_acceptance_failed",
+		);
+	}
+	if (isCurrentTrustDialog(ptyResult)) {
+		throw buildError(
+			`Antigravity still requires trust for the ${trustSubject} at ${launchCwd.path}.`,
+			"trust_required",
 		);
 	}
 
 	const snapshot = ptyResult.snapshots.usage ?? ptyResult;
 	const cleanedOutput = cleanControlOutput(snapshot.raw);
+	if (isCurrentSignInFailure(snapshot)) {
+		throw buildError(`Antigravity is not signed in. Run \`${command}\` and complete the login.`);
+	}
 	const groups = parseAgyUsage(snapshot.screen, cleanedOutput);
 
 	if (groups.length === 0) {
-		if (NOT_SIGNED_IN_PATTERN.test(snapshot.screen) || NOT_SIGNED_IN_PATTERN.test(cleanedOutput)) {
-			throw buildError(`Antigravity is not signed in. Run \`${command}\` and complete the login.`);
-		}
 		throw buildError("Antigravity /usage output did not include Models & Quota limit groups.");
 	}
 
@@ -170,21 +280,6 @@ export async function extractAgyUsage(
 		}),
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
-}
-
-function buildManagedTrustSteps(shouldAutoAccept: boolean): PtyStep[] {
-	if (!shouldAutoAccept) {
-		return [];
-	}
-	return [
-		{
-			skipIf: isNotCurrentTrustDialog,
-			skipIfSource: "screen",
-			waitMs: 250,
-			write: enterKey(),
-		},
-		{ waitFor: isReady, waitForTimeoutMs: 25_000 },
-	];
 }
 
 async function ensureAgyUsageCwd(homeDir: string, repoRoot: string): Promise<AgyUsageCwd> {

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {
 	cleanControlOutput,
@@ -22,9 +22,8 @@ const USAGE_GROUP_HEADING_PATTERN = /^[A-Z][A-Z0-9 &/-]+$/;
 const LIMIT_LABEL_PATTERN = /limit$/i;
 const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
 const REFRESH_PATTERN = /Refreshes\s+in\s+(?:(\d+)h)?\s*(?:(\d+)m)?/i;
-const SIGN_IN_PATTERN = /\b(?:not signed in|Signing in)\b/i;
+const NOT_SIGNED_IN_PATTERN = /\bnot signed in\b/i;
 const DISABLED_PATTERN = /^Disabled$/i;
-const AGY_SETTINGS_PATH = [".gemini", "antigravity-cli", "settings.json"];
 const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
 
 export type ParsedAgyUsageGroup = {
@@ -54,8 +53,8 @@ function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
 	const cleanedOutput = cleanControlOutput(snapshot.raw);
 	return (
 		hasUsagePanel(snapshot) ||
-		SIGN_IN_PATTERN.test(snapshot.screen) ||
-		SIGN_IN_PATTERN.test(cleanedOutput)
+		NOT_SIGNED_IN_PATTERN.test(snapshot.screen) ||
+		NOT_SIGNED_IN_PATTERN.test(cleanedOutput)
 	);
 }
 
@@ -69,7 +68,7 @@ export async function extractAgyUsage(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "agy";
-	const launchCwd = await resolveAgyUsageCwd(context.homeDir, context.repoRoot);
+	const launchCwd = await ensureAgyUsageCwd(context.homeDir, context.repoRoot);
 
 	const ptyResult = await runPtyScenario({
 		command,
@@ -114,7 +113,7 @@ export async function extractAgyUsage(
 	const groups = parseAgyUsage(snapshot.screen, cleanedOutput);
 
 	if (groups.length === 0) {
-		if (SIGN_IN_PATTERN.test(snapshot.screen) || SIGN_IN_PATTERN.test(cleanedOutput)) {
+		if (NOT_SIGNED_IN_PATTERN.test(snapshot.screen) || NOT_SIGNED_IN_PATTERN.test(cleanedOutput)) {
 			throw buildError(`Antigravity is not signed in. Run \`${command}\` and complete the login.`);
 		}
 		throw buildError("Antigravity /usage output did not include Models & Quota limit groups.");
@@ -150,19 +149,7 @@ export async function extractAgyUsage(
 	};
 }
 
-async function resolveAgyUsageCwd(homeDir: string, repoRoot: string): Promise<string> {
-	for (const workspace of await readAgyTrustedWorkspaces(homeDir)) {
-		try {
-			await access(workspace);
-			return workspace;
-		} catch {
-			// Ignore stale trusted workspace entries.
-		}
-	}
-	return ensureAgyUsageFallbackCwd(homeDir, repoRoot);
-}
-
-async function ensureAgyUsageFallbackCwd(homeDir: string, repoRoot: string): Promise<string> {
+async function ensureAgyUsageCwd(homeDir: string, repoRoot: string): Promise<string> {
 	const fallbackDir = path.join(homeDir, ...AGY_USAGE_FALLBACK_PATH);
 	try {
 		await mkdir(fallbackDir, { recursive: true });
@@ -170,59 +157,6 @@ async function ensureAgyUsageFallbackCwd(homeDir: string, repoRoot: string): Pro
 	} catch {
 		return repoRoot;
 	}
-}
-
-async function readAgyTrustedWorkspaces(homeDir: string): Promise<string[]> {
-	let raw: string;
-	try {
-		raw = await readFile(path.join(homeDir, ...AGY_SETTINGS_PATH), "utf8");
-	} catch {
-		return [];
-	}
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch {
-		return [];
-	}
-
-	if (!parsed || typeof parsed !== "object") {
-		return [];
-	}
-	const trustedWorkspaces = (parsed as { trustedWorkspaces?: unknown }).trustedWorkspaces;
-	if (!Array.isArray(trustedWorkspaces)) {
-		return [];
-	}
-
-	const seen = new Set<string>();
-	const result: string[] = [];
-	for (const value of trustedWorkspaces) {
-		if (typeof value !== "string") {
-			continue;
-		}
-		const normalized = normalizeAgyTrustedWorkspace(value, homeDir);
-		if (normalized == null || seen.has(normalized)) {
-			continue;
-		}
-		seen.add(normalized);
-		result.push(normalized);
-	}
-	return result;
-}
-
-function normalizeAgyTrustedWorkspace(value: string, homeDir: string): string | null {
-	const trimmed = value.trim();
-	if (!trimmed) {
-		return null;
-	}
-	if (trimmed === "~") {
-		return homeDir;
-	}
-	if (trimmed.startsWith("~/")) {
-		return path.resolve(homeDir, trimmed.slice(2));
-	}
-	return path.isAbsolute(trimmed) ? path.normalize(trimmed) : path.resolve(homeDir, trimmed);
 }
 
 export function parseAgyUsage(screen: string, cleanedOutput = ""): ParsedAgyUsageGroup[] {

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -33,6 +33,7 @@ const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
 const STARTUP_READY_TIMEOUT_MS = 25_000;
 const USAGE_PANEL_STABLE_MS = 1_000;
+const USAGE_PANEL_MIN_OBSERVE_MS = 2_000;
 
 type AgyUsageCwd = {
 	path: string;
@@ -63,16 +64,20 @@ function isReady(snapshot: PtyWaitSnapshot): boolean {
 	return READY_PATTERN.test(snapshot.screen);
 }
 
+function isLoginSelection(snapshot: PtyWaitSnapshot): boolean {
+	return LOGIN_SELECTION_PATTERN.test(snapshot.screen);
+}
+
 function isStartupTerminalState(snapshot: PtyWaitSnapshot): boolean {
-	return (
-		isReady(snapshot) ||
-		isCurrentTrustDialog(snapshot) ||
-		LOGIN_SELECTION_PATTERN.test(snapshot.screen)
-	);
+	return isReady(snapshot) || isCurrentTrustDialog(snapshot) || isLoginSelection(snapshot);
+}
+
+function isPostTrustTerminalState(snapshot: PtyWaitSnapshot): boolean {
+	return isReady(snapshot) || isLoginSelection(snapshot);
 }
 
 function isCurrentSignInFailure(snapshot: PtyWaitSnapshot): boolean {
-	return NOT_SIGNED_IN_PATTERN.test(snapshot.screen);
+	return NOT_SIGNED_IN_PATTERN.test(snapshot.screen) || isLoginSelection(snapshot);
 }
 
 function isInteractionBlocked(snapshot: PtyWaitSnapshot): boolean {
@@ -87,8 +92,12 @@ function isUsageWriteBlocked(snapshot: PtyWaitSnapshot): boolean {
 	return isInteractionBlocked(snapshot) || isAuthenticationTransition(snapshot);
 }
 
-function createStableUsagePanelWait(stableMs = USAGE_PANEL_STABLE_MS): PtyWaitFor {
+function createStableUsagePanelWait(
+	stableMs = USAGE_PANEL_STABLE_MS,
+	minObserveMs = USAGE_PANEL_MIN_OBSERVE_MS,
+): PtyWaitFor {
 	let previousSignature = "";
+	let firstSeenAt: number | null = null;
 	let stableSince = 0;
 
 	return (snapshot) => {
@@ -99,19 +108,23 @@ function createStableUsagePanelWait(stableMs = USAGE_PANEL_STABLE_MS): PtyWaitFo
 		const groups = parseAgyUsage(snapshot.screen, cleanControlOutput(snapshot.raw));
 		if (groups.length === 0) {
 			previousSignature = "";
+			firstSeenAt = null;
 			stableSince = 0;
 			return false;
 		}
 
 		const signature = usageGroupSignature(groups);
 		const now = Date.now();
+		if (firstSeenAt == null) {
+			firstSeenAt = now;
+		}
 		if (signature !== previousSignature) {
 			previousSignature = signature;
 			stableSince = now;
 			return false;
 		}
 
-		return now - stableSince >= stableMs;
+		return now - firstSeenAt >= minObserveMs && now - stableSince >= stableMs;
 	};
 }
 
@@ -199,7 +212,7 @@ export async function extractAgyUsage(
 			},
 			{
 				skipIf: () => scenarioState.trustOutcome !== "approved",
-				waitFor: isReady,
+				waitFor: isPostTrustTerminalState,
 				waitForTimeoutMs: STARTUP_READY_TIMEOUT_MS,
 				optional: true,
 			},

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -6,7 +6,14 @@ import {
 	makeUsageLimit,
 	parsePercentRemaining,
 } from "./format.js";
-import { enterKey, escapeKey, type PtyStep, type PtyWaitSnapshot, runPtyScenario } from "./pty.js";
+import {
+	enterKey,
+	escapeKey,
+	type PtyStep,
+	type PtyWaitFor,
+	type PtyWaitSnapshot,
+	runPtyScenario,
+} from "./pty.js";
 import {
 	type UsageExtractionContext,
 	UsageExtractionError,
@@ -23,8 +30,8 @@ const NOT_SIGNED_IN_PATTERN = /\bnot signed in\b/i;
 const SIGNING_IN_PATTERN = /\bsigning in\b/i;
 const DISABLED_PATTERN = /^Disabled$/i;
 const AGY_USAGE_FALLBACK_PATH = [".omniagent", "state", "usage", "antigravity-cli"];
-const AUTH_STABILIZATION_MS = 2_000;
-const TRUST_READY_TIMEOUT_MS = 5_000;
+const STARTUP_READY_TIMEOUT_MS = 25_000;
+const USAGE_PANEL_STABLE_MS = 1_000;
 
 type AgyUsageCwd = {
 	path: string;
@@ -75,17 +82,32 @@ function isUsageWriteBlocked(snapshot: PtyWaitSnapshot): boolean {
 	return isInteractionBlocked(snapshot) || isAuthenticationTransition(snapshot);
 }
 
-function isReadyOrKnownGate(snapshot: PtyWaitSnapshot): boolean {
-	return isReadyOrTrustDialog(snapshot) || isCurrentSignInFailure(snapshot);
-}
+function createStableUsagePanelWait(stableMs = USAGE_PANEL_STABLE_MS): PtyWaitFor {
+	let previousSignature = "";
+	let stableSince = 0;
 
-function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
-	const cleanedOutput = cleanControlOutput(snapshot.raw);
-	return parseAgyUsage(snapshot.screen, cleanedOutput).length > 0;
-}
+	return (snapshot) => {
+		if (isInteractionBlocked(snapshot)) {
+			return true;
+		}
 
-function hasUsagePanelOrKnownFailure(snapshot: PtyWaitSnapshot): boolean {
-	return hasUsagePanel(snapshot) || isInteractionBlocked(snapshot);
+		const groups = parseAgyUsage(snapshot.screen, cleanControlOutput(snapshot.raw));
+		if (groups.length === 0) {
+			previousSignature = "";
+			stableSince = 0;
+			return false;
+		}
+
+		const signature = usageGroupSignature(groups);
+		const now = Date.now();
+		if (signature !== previousSignature) {
+			previousSignature = signature;
+			stableSince = now;
+			return false;
+		}
+
+		return now - stableSince >= stableMs;
+	};
 }
 
 function guardedUsageWrite(
@@ -130,10 +152,9 @@ export async function extractAgyUsage(
 		signal: context.signal,
 		debug: context.debug,
 		steps: [
-			{ waitFor: isReadyOrKnownGate, waitForTimeoutMs: 25_000 },
 			{
 				waitFor: isReadyOrTrustDialog,
-				waitForTimeoutMs: AUTH_STABILIZATION_MS,
+				waitForTimeoutMs: STARTUP_READY_TIMEOUT_MS,
 				optional: true,
 				capture: "startup",
 				captureWaitMs: 0,
@@ -174,7 +195,7 @@ export async function extractAgyUsage(
 			{
 				skipIf: () => scenarioState.trustOutcome !== "approved",
 				waitFor: isReady,
-				waitForTimeoutMs: TRUST_READY_TIMEOUT_MS,
+				waitForTimeoutMs: STARTUP_READY_TIMEOUT_MS,
 				optional: true,
 			},
 			{
@@ -194,11 +215,11 @@ export async function extractAgyUsage(
 			guardedUsageWrite(enterKey(), scenarioState, 250),
 			{
 				skipIf: () => !scenarioState.canEnterUsage,
-				waitFor: hasUsagePanelOrKnownFailure,
+				waitFor: createStableUsagePanelWait(),
 				waitForTimeoutMs: 15_000,
 				optional: true,
 				capture: "usage",
-				captureWaitMs: 500,
+				captureWaitMs: 0,
 			},
 			guardedUsageWrite(escapeKey(), scenarioState, 250),
 		],
@@ -293,11 +314,32 @@ async function ensureAgyUsageCwd(homeDir: string, repoRoot: string): Promise<Agy
 }
 
 export function parseAgyUsage(screen: string, cleanedOutput = ""): ParsedAgyUsageGroup[] {
+	const fromRaw = parseAgyUsageLines(compactLines(cleanedOutput));
 	const fromScreen = parseAgyUsageLines(compactLines(screen));
-	if (fromScreen.length > 0) {
-		return fromScreen;
+	const merged = new Map<string, ParsedAgyUsageGroup>();
+
+	for (const group of [...fromRaw, ...fromScreen]) {
+		merged.set(usageGroupKey(group), group);
 	}
-	return parseAgyUsageLines(compactLines(cleanedOutput));
+
+	return [...merged.values()];
+}
+
+function usageGroupKey(group: ParsedAgyUsageGroup): string {
+	return `${group.heading.trim().toLowerCase()}\0${group.limitLabel.trim().toLowerCase()}`;
+}
+
+function usageGroupSignature(groups: ParsedAgyUsageGroup[]): string {
+	return JSON.stringify(
+		groups.map((group) => ({
+			heading: group.heading,
+			models: group.models,
+			limitLabel: group.limitLabel,
+			percentRemaining: group.percentRemaining,
+			resetText: group.resetText,
+			disabled: group.disabled,
+		})),
+	);
 }
 
 function parseAgyUsageLines(lines: string[]): ParsedAgyUsageGroup[] {

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -22,6 +22,7 @@ import {
 
 const TRUST_DIALOG_PATTERN = /Do you trust the contents of this project\?/i;
 const READY_PATTERN = /\?\s+for shortcuts/i;
+const LOGIN_SELECTION_PATTERN = /Select login method:/i;
 const USAGE_GROUP_HEADING_PATTERN = /^[A-Z][A-Z0-9 &/-]+$/;
 const LIMIT_LABEL_PATTERN = /limit$/i;
 const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
@@ -62,8 +63,12 @@ function isReady(snapshot: PtyWaitSnapshot): boolean {
 	return READY_PATTERN.test(snapshot.screen);
 }
 
-function isReadyOrTrustDialog(snapshot: PtyWaitSnapshot): boolean {
-	return isReady(snapshot) || isCurrentTrustDialog(snapshot);
+function isStartupTerminalState(snapshot: PtyWaitSnapshot): boolean {
+	return (
+		isReady(snapshot) ||
+		isCurrentTrustDialog(snapshot) ||
+		LOGIN_SELECTION_PATTERN.test(snapshot.screen)
+	);
 }
 
 function isCurrentSignInFailure(snapshot: PtyWaitSnapshot): boolean {
@@ -153,7 +158,7 @@ export async function extractAgyUsage(
 		debug: context.debug,
 		steps: [
 			{
-				waitFor: isReadyOrTrustDialog,
+				waitFor: isStartupTerminalState,
 				waitForTimeoutMs: STARTUP_READY_TIMEOUT_MS,
 				optional: true,
 				capture: "startup",

--- a/src/lib/usage/agy.ts
+++ b/src/lib/usage/agy.ts
@@ -1,4 +1,11 @@
-import { cleanControlOutput, compactLines, makeUsageLimit } from "./format.js";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	cleanControlOutput,
+	compactLines,
+	makeUsageLimit,
+	parsePercentRemaining,
+} from "./format.js";
 import {
 	enterKey,
 	escapeKey,
@@ -11,17 +18,21 @@ import type { UsageExtractionContext, UsageExtractionResult } from "./types.js";
 
 const TRUST_DIALOG_PATTERN = /Do you trust the contents of this project\?/i;
 const READY_PATTERN = /\?\s+for shortcuts/i;
-const REMAINING_CREDITS_PATTERN = /Remaining AI Credits:\s*(.+?)\s*$/i;
-const CREDITS_NOT_ENABLED_PATTERN = /AI Credits not enabled/i;
-const ACCOUNT_PLAN_PATTERN = /^\S+@\S+\.\S+\s+\((.+?)\)\s*$/;
-const STANDALONE_PLAN_PATTERN = /^\((.*(?:quota|plan|tier).*)\)$/i;
+const MODELS_QUOTA_PATTERN = /Models & Quota/i;
+const USAGE_GROUP_HEADING_PATTERN = /^[A-Z][A-Z0-9 &/-]+$/;
+const LIMIT_LABEL_PATTERN = /limit$/i;
+const MODELS_LINE_PATTERN = /^Models within this group:\s*(.+)$/i;
+const REFRESH_PATTERN = /Refreshes\s+in\s+(?:(\d+)h)?\s*(?:(\d+)m)?/i;
 const SIGN_IN_PATTERN = /\b(?:not signed in|Signing in)\b/i;
+const AGY_SETTINGS_PATH = [".gemini", "antigravity-cli", "settings.json"];
 
-export type ParsedAgyCredits = {
-	remaining: string | null;
-	notEnabled: boolean;
-	plan: string | null;
-	rawLine: string;
+export type ParsedAgyUsageGroup = {
+	heading: string;
+	models: string | null;
+	limitLabel: string;
+	percentRemaining: number | null;
+	resetText: string | null;
+	raw: string;
 };
 
 function isTrustDialog(snapshot: PtyWaitSnapshot): boolean {
@@ -32,10 +43,11 @@ function isReadyOrTrustDialog(snapshot: PtyWaitSnapshot): boolean {
 	return READY_PATTERN.test(snapshot.screen) || isTrustDialog(snapshot);
 }
 
-function hasCreditsPanel(snapshot: PtyWaitSnapshot): boolean {
+function hasUsagePanel(snapshot: PtyWaitSnapshot): boolean {
+	const cleanedOutput = cleanControlOutput(snapshot.raw);
 	return (
-		REMAINING_CREDITS_PATTERN.test(snapshot.screen) ||
-		REMAINING_CREDITS_PATTERN.test(cleanControlOutput(snapshot.raw))
+		(MODELS_QUOTA_PATTERN.test(snapshot.screen) || MODELS_QUOTA_PATTERN.test(cleanedOutput)) &&
+		(/% remaining/i.test(snapshot.screen) || /% remaining/i.test(cleanedOutput))
 	);
 }
 
@@ -49,11 +61,12 @@ export async function extractAgyUsage(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "agy";
+	const launchCwd = await resolveAgyUsageCwd(context.homeDir);
 
 	const ptyResult = await runPtyScenario({
 		command,
 		args: context.launch?.args ?? [],
-		cwd: context.repoRoot,
+		cwd: launchCwd,
 		cols: 120,
 		rows: 40,
 		timeoutMs: context.launch?.timeoutMs ?? 70_000,
@@ -61,13 +74,12 @@ export async function extractAgyUsage(
 		debug: context.debug,
 		steps: [
 			{ waitFor: isReadyOrTrustDialog, waitForTimeoutMs: 25_000 },
-			...typeTextSteps("/credits", 25).map(withTrustSkip),
+			...typeTextSteps("/usage", 25).map(withTrustSkip),
 			withTrustSkip({ waitMs: 250, write: enterKey() }),
 			withTrustSkip({
-				waitFor: hasCreditsPanel,
+				waitFor: hasUsagePanel,
 				waitForTimeoutMs: 15_000,
-				optional: true,
-				capture: "credits",
+				capture: "usage",
 				captureWaitMs: 500,
 			}),
 			{ write: escapeKey(), waitMs: 250 },
@@ -84,90 +96,232 @@ export async function extractAgyUsage(
 
 	if (isTrustDialog(ptyResult)) {
 		throw buildError(
-			`Antigravity has not trusted this project yet. Run \`${command}\` in ${context.repoRoot} once, accept the trust prompt, then re-run usage.`,
+			`Antigravity has not trusted the usage launch directory yet. Run \`${command}\` in ${launchCwd} once, accept the trust prompt, then re-run usage.`,
 		);
 	}
 
-	const snapshot = ptyResult.snapshots.credits ?? ptyResult;
+	const snapshot = ptyResult.snapshots.usage ?? ptyResult;
 	const cleanedOutput = cleanControlOutput(snapshot.raw);
-	const parsed = parseAgyCredits(snapshot.screen, cleanedOutput);
+	const groups = parseAgyUsage(snapshot.screen, cleanedOutput);
 
-	if (parsed.notEnabled) {
-		throw buildError(
-			"Antigravity AI Credits are not enabled for this account. Enable them via /settings in agy.",
-		);
-	}
-	if (parsed.remaining == null) {
+	if (groups.length === 0) {
 		if (SIGN_IN_PATTERN.test(snapshot.screen) || SIGN_IN_PATTERN.test(cleanedOutput)) {
 			throw buildError(`Antigravity is not signed in. Run \`${command}\` and complete the login.`);
 		}
-		throw buildError("Antigravity /credits output did not include a Remaining AI Credits value.");
+		throw buildError("Antigravity /usage output did not include Models & Quota limit groups.");
 	}
 
 	return {
 		targetId: context.targetId,
 		displayName: context.displayName,
 		command,
-		limits: [
-			// Credits are an absolute balance rather than a percentage window.
-			makeUsageLimit({
+		limits: groups.map((group) => {
+			const percentRemaining =
+				group.percentRemaining == null ? null : clampPercent(group.percentRemaining);
+			const limit = makeUsageLimit({
 				targetId: context.targetId,
-				scope: "ai_credits",
-				window: "credits",
-				label: parsed.plan ? `AI Credits (${parsed.plan})` : "AI Credits",
-				percentUsed: null,
-				percentRemaining: null,
-				remainingText: parsed.remaining,
-				resetText: null,
-				raw: parsed.rawLine,
+				scope: usageScope(group.heading),
+				window: "weekly",
+				label: titleCase(group.heading),
+				percentUsed: percentRemaining == null ? null : 100 - percentRemaining,
+				percentRemaining,
+				resetText: group.resetText,
+				raw: group.raw,
 				now: context.now,
-			}),
-		],
+			});
+			return {
+				...limit,
+				resetAt: parseAgyRefreshResetAt(group.resetText, context.now) ?? limit.resetAt,
+			};
+		}),
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
 }
 
-export function parseAgyCredits(screen: string, cleanedOutput = ""): ParsedAgyCredits {
-	const fromScreen = parseAgyCreditsLines(compactLines(screen));
-	if (fromScreen.remaining != null || fromScreen.notEnabled) {
-		return fromScreen;
+async function resolveAgyUsageCwd(homeDir: string): Promise<string> {
+	for (const workspace of await readAgyTrustedWorkspaces(homeDir)) {
+		try {
+			await access(workspace);
+			return workspace;
+		} catch {
+			// Ignore stale trusted workspace entries.
+		}
 	}
-	const fromRaw = parseAgyCreditsLines(compactLines(cleanedOutput));
-	if (fromRaw.remaining != null || fromRaw.notEnabled) {
-		return fromRaw;
-	}
-	return fromScreen.plan != null ? fromScreen : fromRaw;
+	return homeDir;
 }
 
-function parseAgyCreditsLines(lines: string[]): ParsedAgyCredits {
-	const parsed: ParsedAgyCredits = {
-		remaining: null,
-		notEnabled: false,
-		plan: null,
-		rawLine: "",
-	};
+async function readAgyTrustedWorkspaces(homeDir: string): Promise<string[]> {
+	let raw: string;
+	try {
+		raw = await readFile(path.join(homeDir, ...AGY_SETTINGS_PATH), "utf8");
+	} catch {
+		return [];
+	}
 
-	for (const line of lines) {
-		const remainingMatch = REMAINING_CREDITS_PATTERN.exec(line);
-		if (remainingMatch?.[1]) {
-			const value = remainingMatch[1].trim();
-			if (CREDITS_NOT_ENABLED_PATTERN.test(value)) {
-				parsed.notEnabled = true;
-				parsed.rawLine = line.trim();
-				continue;
-			}
-			parsed.remaining = value;
-			parsed.rawLine = line.trim();
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return [];
+	}
+
+	if (!parsed || typeof parsed !== "object") {
+		return [];
+	}
+	const trustedWorkspaces = (parsed as { trustedWorkspaces?: unknown }).trustedWorkspaces;
+	if (!Array.isArray(trustedWorkspaces)) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const value of trustedWorkspaces) {
+		if (typeof value !== "string") {
+			continue;
+		}
+		const normalized = normalizeAgyTrustedWorkspace(value, homeDir);
+		if (normalized == null || seen.has(normalized)) {
+			continue;
+		}
+		seen.add(normalized);
+		result.push(normalized);
+	}
+	return result;
+}
+
+function normalizeAgyTrustedWorkspace(value: string, homeDir: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return null;
+	}
+	if (trimmed === "~") {
+		return homeDir;
+	}
+	if (trimmed.startsWith("~/")) {
+		return path.resolve(homeDir, trimmed.slice(2));
+	}
+	return path.isAbsolute(trimmed) ? path.normalize(trimmed) : path.resolve(homeDir, trimmed);
+}
+
+export function parseAgyUsage(screen: string, cleanedOutput = ""): ParsedAgyUsageGroup[] {
+	const fromScreen = parseAgyUsageLines(compactLines(screen));
+	if (fromScreen.length > 0) {
+		return fromScreen;
+	}
+	return parseAgyUsageLines(compactLines(cleanedOutput));
+}
+
+function parseAgyUsageLines(lines: string[]): ParsedAgyUsageGroup[] {
+	const groups: ParsedAgyUsageGroup[] = [];
+	let index = 0;
+
+	while (index < lines.length) {
+		const heading = lines[index] ?? "";
+		if (!isUsageGroupHeading(heading)) {
+			index += 1;
 			continue;
 		}
 
-		if (parsed.plan == null) {
-			const planMatch = ACCOUNT_PLAN_PATTERN.exec(line) ?? STANDALONE_PLAN_PATTERN.exec(line);
-			if (planMatch?.[1]) {
-				parsed.plan = planMatch[1].trim();
+		const rawLines = [heading];
+		let models: string | null = null;
+		let limitLabel = "";
+		let percentRemaining: number | null = null;
+		let resetText: string | null = null;
+		index += 1;
+
+		while (index < lines.length && !isUsageGroupHeading(lines[index] ?? "")) {
+			const line = lines[index] ?? "";
+			rawLines.push(line);
+			const modelsMatch = MODELS_LINE_PATTERN.exec(line);
+			if (modelsMatch?.[1]) {
+				models = modelsMatch[1].trim();
 			}
+			if (LIMIT_LABEL_PATTERN.test(line)) {
+				limitLabel = line.trim();
+			}
+			const linePercentRemaining = parseAgyRemainingPercent(line);
+			if (linePercentRemaining != null && percentRemaining == null) {
+				percentRemaining = linePercentRemaining;
+			}
+			const lineResetText = parseAgyRefreshText(line);
+			if (lineResetText != null) {
+				resetText = lineResetText;
+			}
+			index += 1;
+		}
+
+		if (limitLabel && (percentRemaining != null || resetText != null)) {
+			groups.push({
+				heading,
+				models,
+				limitLabel,
+				percentRemaining,
+				resetText,
+				raw: rawLines.join("\n"),
+			});
 		}
 	}
 
-	return parsed;
+	return groups;
+}
+
+function isUsageGroupHeading(line: string): boolean {
+	if (!USAGE_GROUP_HEADING_PATTERN.test(line)) {
+		return false;
+	}
+	return !/^(MODELS|WEEKLY|MONTHLY|DAILY|ACCOUNT)$/i.test(line);
+}
+
+function parseAgyRemainingPercent(line: string): number | null {
+	return parsePercentRemaining(line) ?? parseStandalonePercent(line);
+}
+
+function parseStandalonePercent(line: string): number | null {
+	const match = /(?:^|\])\s*(\d+(?:\.\d+)?)\s*%\s*$/i.exec(line);
+	if (!match?.[1]) {
+		return null;
+	}
+	return Number(match[1]);
+}
+
+function parseAgyRefreshText(line: string): string | null {
+	const match = /(Refreshes\s+in\s+(?:(?:\d+)h)?\s*(?:(?:\d+)m)?)/i.exec(line);
+	return match?.[1]?.trim() ?? null;
+}
+
+function parseAgyRefreshResetAt(resetText: string | null, now: Date): string | null {
+	if (resetText == null) {
+		return null;
+	}
+	const match = REFRESH_PATTERN.exec(resetText);
+	if (match == null) {
+		return null;
+	}
+	const hours = Number(match[1] ?? 0);
+	const minutes = Number(match[2] ?? 0);
+	if (!Number.isFinite(hours) || !Number.isFinite(minutes) || hours + minutes <= 0) {
+		return null;
+	}
+	return new Date(now.getTime() + hours * 3_600_000 + minutes * 60_000).toISOString();
+}
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, value));
+}
+
+function usageScope(heading: string): string {
+	return heading
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+}
+
+function titleCase(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.split(/\s+/)
+		.map((word) => (word === "gpt" ? "GPT" : `${word.charAt(0).toUpperCase()}${word.slice(1)}`))
+		.join(" ");
 }

--- a/src/lib/usage/pty.ts
+++ b/src/lib/usage/pty.ts
@@ -15,7 +15,7 @@ export type PtyStep = {
 	skipIf?: PtyWaitFor;
 	skipIfSource?: "raw" | "screen";
 	waitMs?: number;
-	write?: string;
+	write?: PtyWrite;
 	waitFor?: PtyWaitFor;
 	waitForSource?: "raw" | "screen";
 	waitForTimeoutMs?: number;
@@ -30,6 +30,10 @@ export type PtyWaitSnapshot = {
 };
 
 export type PtyWaitFor = string | RegExp | ((snapshot: PtyWaitSnapshot) => boolean);
+
+export type PtyWrite =
+	| string
+	| ((snapshot: Readonly<PtyWaitSnapshot>) => string | undefined | Promise<string | undefined>);
 
 export type PtyScenarioOptions = {
 	command: string;
@@ -166,16 +170,17 @@ export async function runPtyScenario(options: PtyScenarioOptions): Promise<PtySc
 		});
 	const cancellationPromise = new Promise<never>((_, reject) => {
 		cancelScenario = (message: string) => {
-			if (!exited) {
-				timedOut = true;
-				if (child) {
-					safeKillPty(child);
-				}
+			timedOut = true;
+			if (!exited && child) {
+				safeKillPty(child);
 			}
 			reject(buildScenarioError(message));
 		};
 	});
 	cancellationPromise.catch(() => {});
+	timeout = setTimeout(() => {
+		cancelScenario?.(`PTY scenario timed out after ${formatDuration(timeoutMs)}.`);
+	}, timeoutMs);
 	if (options.signal) {
 		const abortHandler = () => {
 			cancelScenario?.(formatAbortReason(options.signal, timeoutMs));
@@ -186,10 +191,6 @@ export async function runPtyScenario(options: PtyScenarioOptions): Promise<PtySc
 			options.signal.addEventListener("abort", abortHandler, { once: true });
 			removeAbortListener = () => options.signal?.removeEventListener("abort", abortHandler);
 		}
-	} else {
-		timeout = setTimeout(() => {
-			cancelScenario?.(`PTY scenario timed out after ${formatDuration(timeoutMs)}.`);
-		}, timeoutMs);
 	}
 	const withScenarioTimeout = async <T>(promise: Promise<T>): Promise<T> =>
 		Promise.race([promise, cancellationPromise]);
@@ -258,7 +259,16 @@ export async function runPtyScenario(options: PtyScenarioOptions): Promise<PtySc
 			}
 			if (step.write != null) {
 				throwIfTimedOut();
-				child.write(step.write);
+				const write =
+					typeof step.write === "function"
+						? await withScenarioTimeout(
+								Promise.resolve(step.write({ raw, screen: readScreen(terminal) })),
+							)
+						: step.write;
+				throwIfTimedOut();
+				if (write != null && !exited) {
+					child.write(write);
+				}
 			}
 			if (step.waitFor != null) {
 				const matched = await withScenarioTimeout(

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -13,6 +13,16 @@ export type UsageDebugRequest = {
 	includeScreenSnapshots?: boolean;
 };
 
+export type UsageConfirmationRequest = {
+	type: "trust-directory";
+	targetId: string;
+	displayName: string;
+	path: string;
+	managed: boolean;
+};
+
+export type UsageConfirmation = (request: UsageConfirmationRequest) => Promise<boolean>;
+
 export type UsageExtractionContext = {
 	targetId: string;
 	displayName: string;
@@ -26,7 +36,18 @@ export type UsageExtractionContext = {
 	launch?: UsageLaunchDefinition;
 	signal: AbortSignal;
 	debug: UsageDebugRequest;
+	confirm?: UsageConfirmation;
 };
+
+export class UsageExtractionError extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+	) {
+		super(message);
+		this.name = "UsageExtractionError";
+	}
+}
 
 export type NormalizedUsageLimit = {
 	id: string;

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -77,6 +77,7 @@ export type NormalizedUsageTargetResult = {
 	command?: string;
 	limits: NormalizedUsageLimit[];
 	errors?: NormalizedUsageError[];
+	notes?: string[];
 	debug?: NormalizedUsageDebugArtifact[];
 };
 

--- a/tests/commands/usage.test.ts
+++ b/tests/commands/usage.test.ts
@@ -543,7 +543,7 @@ module.exports = {
 			displayName: "Mock Antigravity",
 			aliases: ["gemini"],
 			usage: {
-				windows: ["credits"],
+				windows: ["weekly"],
 				launch: { command: "agy" },
 				extract: async (ctx) => ({
 					targetId: ctx.targetId,
@@ -551,17 +551,17 @@ module.exports = {
 					command: ctx.command,
 					limits: [
 						{
-							id: ctx.targetId + ".ai_credits.credits",
+							id: ctx.targetId + ".gemini_models.weekly",
 							targetId: ctx.targetId,
 							agent: ctx.targetId,
-							scope: "ai_credits",
-							window: "credits",
-							label: "AI Credits",
-							percentUsed: null,
-							percentRemaining: null,
+							scope: "gemini_models",
+							window: "weekly",
+							label: "Gemini Models",
+							percentUsed: 28,
+							percentRemaining: 72,
 							resetAt: null,
-							resetText: null,
-							raw: "Remaining AI Credits: 1,234"
+							resetText: "Refreshes in 71h 49m",
+							raw: "72% remaining · Refreshes in 71h 49m"
 						}
 					]
 				})
@@ -579,26 +579,24 @@ module.exports = {
 			expect(envelope.targets[0].targetId).toBe("agy");
 			expect(envelope.targets[0].displayName).toBe("Mock Antigravity");
 			expect(envelope.targets[0].command).toBe(path.join(binDir, "agy"));
-			expect(envelope.targets[0].limits[0].raw).toBe("Remaining AI Credits: 1,234");
+			expect(envelope.targets[0].limits[0].raw).toBe("72% remaining · Refreshes in 71h 49m");
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
 
 	it("renders remainingText in the Left column for absolute balances", async () => {
 		await withTempRepo(async (root) => {
-			await createFakeCliBin(root, ["codex", "claude", "agy"]);
 			await writeConfig(
 				root,
-				usageConfig({
-					disableTargets: [],
-					extraTargets: `
+				`
+module.exports = {
+	disableTargets: ["codex", "claude", "gemini"],
+	targets: [
 		{
-			id: "agy",
-			displayName: "Mock Antigravity",
-			aliases: ["gemini"],
+			id: "balance-meter",
+			displayName: "Balance Meter",
 			usage: {
 				windows: ["credits"],
-				launch: { command: "agy" },
 				extract: async (ctx) => ({
 					targetId: ctx.targetId,
 					displayName: ctx.displayName,
@@ -621,17 +619,18 @@ module.exports = {
 					]
 				})
 			}
-		}`,
-				}),
+		}
+	]
+};
+`,
 			);
 
 			await withCwd(root, async () => {
-				await runCli(["node", "omniagent", "usage", "agy"]);
+				await runCli(["node", "omniagent", "usage", "balance-meter"]);
 			});
 
 			const output = joinOutput(logSpy.mock.calls);
-			const creditsRow = output.split("\n").find((line) => line.includes("AI Credits")) ?? "";
-			expect(creditsRow).toContain("1,234");
+			expect(output).toContain("1,234");
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
@@ -1835,6 +1834,36 @@ module.exports = {
 				message: "some rows could not be parsed",
 			});
 			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("promotes extractor-returned notes without failing", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["codex"]);
+			await writeConfig(
+				root,
+				usageConfig({
+					disableTargets: ["claude", "gemini"],
+					extractors: {
+						codex: `async (ctx) => ({
+							targetId: ctx.targetId,
+							displayName: ctx.displayName,
+							command: ctx.command,
+							limits: [],
+							notes: ["Mock Codex usage is not enabled for this account."]
+						})`,
+					},
+				}),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "usage", "codex"]);
+			});
+
+			const output = joinOutput(logSpy.mock.calls);
+			expect(output).toContain("Note: Mock Codex usage is not enabled for this account.");
+			expect(output).not.toContain("failed");
+			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/tests/commands/usage.test.ts
+++ b/tests/commands/usage.test.ts
@@ -3,6 +3,17 @@ import os from "node:os";
 import path from "node:path";
 import { runCli } from "../../src/cli/index.js";
 
+const readlineMock = vi.hoisted(() => ({
+	question: vi.fn(),
+	close: vi.fn(),
+	once: vi.fn(),
+	removeListener: vi.fn(),
+}));
+
+vi.mock("node:readline/promises", () => ({
+	createInterface: () => readlineMock,
+}));
+
 const joinOutput = (calls: Array<[unknown]>) => calls.map(([arg]) => String(arg)).join("\n");
 
 async function withTempRepo(fn: (root: string) => Promise<void>): Promise<void> {
@@ -44,6 +55,31 @@ async function withCwd(dir: string, fn: () => Promise<void>): Promise<void> {
 		await fn();
 	} finally {
 		cwdSpy.mockRestore();
+	}
+}
+
+async function withUsageTty<T>(
+	stdinIsTTY: boolean,
+	stderrIsTTY: boolean,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+	const stderrDescriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+	Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: stdinIsTTY });
+	Object.defineProperty(process.stderr, "isTTY", { configurable: true, value: stderrIsTTY });
+	try {
+		return await fn();
+	} finally {
+		if (stdinDescriptor == null) {
+			Reflect.deleteProperty(process.stdin, "isTTY");
+		} else {
+			Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+		}
+		if (stderrDescriptor == null) {
+			Reflect.deleteProperty(process.stderr, "isTTY");
+		} else {
+			Object.defineProperty(process.stderr, "isTTY", stderrDescriptor);
+		}
 	}
 }
 
@@ -182,12 +218,75 @@ module.exports = {
 `;
 }
 
+function confirmationUsageConfig(): string {
+	return `
+module.exports = {
+	disableTargets: ["codex", "claude"],
+	targets: [
+		{
+			id: "AGY",
+			displayName: "Mock Antigravity",
+			usage: {
+				windows: ["weekly"],
+				launch: { command: "agy" },
+				extract: async (ctx) => {
+					if (!ctx.confirm) {
+						const error = new Error("Directory trust confirmation is required.");
+						error.code = "trust_required";
+						throw error;
+					}
+					const approved = await ctx.confirm({
+						type: "trust-directory",
+						targetId: ctx.targetId,
+						displayName: ctx.displayName,
+						path: ctx.homeDir + "/managed-usage",
+						managed: true
+					});
+					if (!approved) {
+						const error = new Error("Directory trust was declined.");
+						error.code = "trust_denied";
+						throw error;
+					}
+					return {
+						targetId: ctx.targetId,
+						displayName: ctx.displayName,
+						command: ctx.command,
+						limits: [],
+						notes: ["Directory trust approved."]
+					};
+				}
+			}
+		}
+	]
+};
+`;
+}
+
+function inheritedAgyUsageConfig(): string {
+	return `
+module.exports = {
+	disableTargets: ["codex", "claude", "agy"],
+	targets: [
+		{
+			id: "company-agy",
+			displayName: "Company Antigravity",
+			inherits: "agy"
+		}
+	]
+};
+`;
+}
+
 describe.sequential("usage command", () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
 	let errorSpy: ReturnType<typeof vi.spyOn>;
 	let exitSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		readlineMock.question.mockReset();
+		readlineMock.close.mockReset();
+		readlineMock.once.mockReset();
+		readlineMock.removeListener.mockReset();
 		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
@@ -1837,6 +1936,171 @@ module.exports = {
 		});
 	});
 
+	it("prompts on an interactive terminal and forwards trust approval", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+			readlineMock.question.mockResolvedValueOnce("y");
+
+			await withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy"])),
+			);
+
+			const prompt = String(readlineMock.question.mock.calls[0]?.[0]);
+			expect(prompt).toContain("Mock Antigravity needs to trust this managed usage directory");
+			expect(prompt).toContain(path.join(root, "home", "managed-usage"));
+			expect(prompt).toContain("Allow this? [y/N]");
+			expect(joinOutput(logSpy.mock.calls)).toContain("Note: Directory trust approved.");
+			expect(readlineMock.close).toHaveBeenCalledOnce();
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("defaults an interactive trust confirmation to denied", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+			readlineMock.question.mockResolvedValueOnce("");
+
+			await withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy"])),
+			);
+
+			expect(joinOutput(logSpy.mock.calls)).toContain("Directory trust was declined.");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("provides confirmation to targets that inherit Antigravity usage", async () => {
+		await withTempRepo(async (root) => {
+			const binDir = await createFakeCliBin(root, ["agy"]);
+			await writeFile(
+				path.join(binDir, "agy"),
+				"#!/bin/sh\nprintf '\\033[2J\\033[HDo you trust the contents of this project?'\nIFS= read -r answer\n",
+				"utf8",
+			);
+			await writeConfig(root, inheritedAgyUsageConfig());
+			readlineMock.question.mockResolvedValueOnce("");
+
+			await withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "company-agy"])),
+			);
+
+			expect(readlineMock.question).toHaveBeenCalledOnce();
+			expect(joinOutput(logSpy.mock.calls)).toContain("Antigravity trust was declined");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("does not prompt when stdin is non-interactive", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+
+			await withUsageTty(false, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy"])),
+			);
+
+			expect(readlineMock.question).not.toHaveBeenCalled();
+			expect(joinOutput(logSpy.mock.calls)).toContain("Directory trust confirmation is required.");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("does not show an invisible prompt when stderr is redirected", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+
+			await withUsageTty(true, false, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy"])),
+			);
+
+			expect(readlineMock.question).not.toHaveBeenCalled();
+			expect(joinOutput(logSpy.mock.calls)).toContain("Directory trust confirmation is required.");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it.each([
+		"--json",
+		"--debug",
+	])("does not prompt for machine-readable output: %s", async (flag) => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+
+			await withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy", flag])),
+			);
+
+			const envelope = JSON.parse(joinOutput(logSpy.mock.calls));
+			expect(readlineMock.question).not.toHaveBeenCalled();
+			expect(envelope.errors[0]).toMatchObject({
+				targetId: "AGY",
+				code: "trust_required",
+			});
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	it("cancels usage when Ctrl-C is pressed at the trust prompt", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+			let interrupt: (() => void) | undefined;
+			readlineMock.once.mockImplementation((event, listener) => {
+				if (event === "SIGINT") {
+					interrupt = listener as () => void;
+				}
+				return readlineMock;
+			});
+			readlineMock.question.mockImplementation((_question, options) => {
+				const signal = (options as { signal: AbortSignal }).signal;
+				return new Promise<string>((_resolve, reject) => {
+					signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+				});
+			});
+
+			const command = withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy"])),
+			);
+			await vi.waitFor(() => expect(interrupt).toBeTypeOf("function"));
+			interrupt?.();
+			await command;
+
+			expect(errorSpy).toHaveBeenCalledWith("Usage cancelled.");
+			expect(exitSpy).toHaveBeenCalledWith(130);
+			expect(readlineMock.close).toHaveBeenCalledOnce();
+			expect(logSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("times out and closes a pending trust prompt", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["agy"]);
+			await writeConfig(root, confirmationUsageConfig());
+			let promptSignal: AbortSignal | undefined;
+			readlineMock.question.mockImplementation((_question, options) => {
+				promptSignal = (options as { signal: AbortSignal }).signal;
+				return new Promise<string>((_resolve, reject) => {
+					promptSignal?.addEventListener("abort", () => reject(promptSignal?.reason), {
+						once: true,
+					});
+				});
+			});
+
+			await withUsageTty(true, true, () =>
+				withCwd(root, () => runCli(["node", "omniagent", "usage", "agy", "--timeout=20ms"])),
+			);
+
+			expect(promptSignal?.aborted).toBe(true);
+			expect(readlineMock.close).toHaveBeenCalledOnce();
+			expect(joinOutput(logSpy.mock.calls)).toContain("Usage extraction timed out after 20ms.");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
 	it("promotes extractor-returned notes without failing", async () => {
 		await withTempRepo(async (root) => {
 			await createFakeCliBin(root, ["codex"]);
@@ -1863,6 +2127,37 @@ module.exports = {
 			const output = joinOutput(logSpy.mock.calls);
 			expect(output).toContain("Note: Mock Codex usage is not enabled for this account.");
 			expect(output).not.toContain("failed");
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("promotes extractor-returned notes to the JSON envelope", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["codex"]);
+			await writeConfig(
+				root,
+				usageConfig({
+					disableTargets: ["claude", "gemini"],
+					extractors: {
+						codex: `async (ctx) => ({
+							targetId: ctx.targetId,
+							displayName: ctx.displayName,
+							command: ctx.command,
+							limits: [],
+							notes: ["Mock Codex usage is not enabled for this account."]
+						})`,
+					},
+				}),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "usage", "codex", "--json"]);
+			});
+
+			const envelope = JSON.parse(joinOutput(logSpy.mock.calls));
+			expect(envelope.notes).toEqual(["Mock Codex usage is not enabled for this account."]);
+			expect(envelope.errors).toEqual([]);
+			expect(envelope.targets[0].notes).toBeUndefined();
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -2,6 +2,7 @@ import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { vi } from "vitest";
+import type { UsageConfirmation } from "../../../src/lib/usage/types.js";
 
 const ptyMock = vi.hoisted(() => ({
 	runPtyScenario: vi.fn(),
@@ -11,54 +12,28 @@ let tempDirs: string[] = [];
 
 type MockPtyStep = {
 	capture?: string;
-	write?: string;
+	write?:
+		| string
+		| ((snapshot: {
+				raw: string;
+				screen: string;
+		  }) => string | undefined | Promise<string | undefined>);
 	skipIf?: (snapshot: { raw: string; screen: string }) => boolean;
 	waitFor?: (snapshot: { raw: string; screen: string }) => boolean;
 	optional?: boolean;
+	waitForTimeoutMs?: number;
 };
 
 vi.mock("../../../src/lib/usage/pty.js", () => ({
 	enterKey: () => "\r",
 	escapeKey: () => "\x1b",
 	runPtyScenario: ptyMock.runPtyScenario,
-	typeTextSteps: (text: string, delayMs: number) =>
-		[...text].map((char) => ({ write: char, waitMs: delayMs })),
 }));
 
 describe("Antigravity usage extraction", () => {
 	beforeEach(() => {
 		ptyMock.runPtyScenario.mockReset();
-		ptyMock.runPtyScenario.mockResolvedValue({
-			command: "agy",
-			args: [],
-			exitCode: 0,
-			timedOut: false,
-			raw: "",
-			screen: "",
-			snapshots: {
-				usage: {
-					raw: "",
-					screen: `
-└ Models & Quota
-
-GEMINI MODELS
-  Models within this group: Gemini Flash, Gemini Pro
-
-  Weekly Limit
-    [████████████████████████████████████░░░░░░░░░░░░░░] 71.69%
-    72% remaining · Refreshes in 71h 49m
-
-CLAUDE AND GPT MODELS
-  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
-
-  Weekly Limit
-    [██████████████████████████████████████████████████] 99.94%
-    100% remaining · Refreshes in 71h 46m
-`,
-				},
-			},
-			debug: [],
-		});
+		ptyMock.runPtyScenario.mockResolvedValue(buildUsagePtyResult());
 	});
 
 	afterEach(async () => {
@@ -98,74 +73,110 @@ CLAUDE AND GPT MODELS
 		expect(result.limits[0]?.percentUsed).toBeCloseTo(28.31);
 	});
 
-	it("auto-accepts trust only for the managed usage directory", async () => {
+	it("forwards explicit approval to the managed usage directory trust prompt", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		const homeDir = await createTempDir("omniagent-agy-home-");
+		const fallbackDir = path.join(homeDir, ".omniagent", "state", "usage", "antigravity-cli");
+		const confirm = vi.fn().mockResolvedValue(true);
+		let forwardedKey: string | undefined;
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(steps);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			forwardedKey = await resolveStepWrite(trustForwardStep, trustSnapshot());
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			return buildUsagePtyResult();
+		});
 
-		await extractAgyUsage(
+		const result = await extractAgyUsage(
 			buildContext({
 				homeDir,
 				repoRoot: "/tmp/untrusted-repo",
+				confirm,
 			}),
 		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		const steps = options.steps as MockPtyStep[];
-		const trustAcceptStep = steps[1];
-		const readyAfterTrustStep = steps[2];
-		const slashStep = steps.find((step) => step.write === "/");
+		const readyAfterTrustStep = steps.find((step) => step.waitForTimeoutMs === 5_000);
 
-		expect(trustAcceptStep?.write).toBe("\r");
-		expect(
-			trustAcceptStep?.skipIf?.({
-				raw: "",
-				screen: "Do you trust the contents of this project?",
-			}),
-		).toBe(false);
-		expect(
-			trustAcceptStep?.skipIf?.({
-				raw: "",
-				screen: "? for shortcuts",
-			}),
-		).toBe(true);
-		expect(
-			readyAfterTrustStep?.waitFor?.({
-				raw: "Do you trust the contents of this project?",
-				screen: "? for shortcuts",
-			}),
-		).toBe(true);
-		expect(
-			slashStep?.skipIf?.({
-				raw: "Do you trust the contents of this project?",
-				screen: "? for shortcuts",
-			}),
-		).toBe(false);
-		expect(
-			slashStep?.skipIf?.({
-				raw: "",
-				screen: "Do you trust the contents of this project?",
-			}),
-		).toBe(true);
+		expect(options.cwd).toBe(fallbackDir);
+		expect(forwardedKey).toBe("\r");
+		expect(readyAfterTrustStep?.optional).toBe(true);
+		expect(confirm).toHaveBeenCalledWith({
+			type: "trust-directory",
+			targetId: "agy",
+			displayName: "Antigravity CLI",
+			path: fallbackDir,
+			managed: true,
+		});
+		expect(result.limits).toHaveLength(2);
 	});
 
-	it("does not auto-accept trust when falling back outside the managed usage directory", async () => {
+	it("requests explicit approval for the project fallback directory", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		const homeDir = await createTempDir("omniagent-agy-home-");
 		const repoRoot = path.join(homeDir, "repo");
+		const confirm = vi.fn().mockResolvedValue(true);
 		await mkdir(repoRoot, { recursive: true });
 		await writeFile(path.join(homeDir, ".omniagent"), "not a directory", "utf8");
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(
+				options.steps as MockPtyStep[],
+			);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			expect(await resolveStepWrite(trustForwardStep, trustSnapshot())).toBe("\r");
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			return buildUsagePtyResult();
+		});
 
 		await extractAgyUsage(
 			buildContext({
 				homeDir,
 				repoRoot,
+				confirm,
 			}),
 		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
-		const steps = options.steps as MockPtyStep[];
 		expect(options.cwd).toBe(repoRoot);
-		expect(steps[1]?.write).toBe("/");
+		expect(confirm).toHaveBeenCalledWith(
+			expect.objectContaining({ path: repoRoot, managed: false }),
+		);
+	});
+
+	it("does not forward a trust key if the prompt changes while confirmation is pending", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		let resolveConfirmation: ((approved: boolean) => void) | undefined;
+		const confirmation = new Promise<boolean>((resolve) => {
+			resolveConfirmation = resolve;
+		});
+		const confirm = vi.fn(() => confirmation);
+		let forwardedKey: string | undefined;
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(
+				options.steps as MockPtyStep[],
+			);
+			const decision = resolveStepWrite(trustDecisionStep, trustSnapshot());
+			await Promise.resolve();
+			resolveConfirmation?.(true);
+			expect(await decision).toBeUndefined();
+			forwardedKey = await resolveStepWrite(trustForwardStep, readySnapshot());
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			return buildUsagePtyResult();
+		});
+
+		const result = await extractAgyUsage(
+			buildContext({
+				homeDir,
+				repoRoot: "/tmp/untrusted-repo",
+				confirm,
+			}),
+		);
+
+		expect(forwardedKey).toBeUndefined();
+		expect(result.limits).toHaveLength(2);
 	});
 
 	it("falls back to an empty omniagent state directory when no trusted workspace exists", async () => {
@@ -205,9 +216,23 @@ CLAUDE AND GPT MODELS
 		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		const startupWait = options.steps[0];
+		const stabilizationWait = options.steps[1];
 		const usageWait = options.steps.find((step: { capture?: string }) => step.capture === "usage");
 
 		expect(usageWait.optional).toBe(true);
+		expect(
+			startupWait.waitFor({
+				raw: "Antigravity is not signed in.",
+				screen: "Antigravity is not signed in.",
+			}),
+		).toBe(true);
+		expect(
+			stabilizationWait.waitFor({
+				raw: "Antigravity is not signed in.",
+				screen: "Antigravity is not signed in.",
+			}),
+		).toBe(false);
 		expect(
 			usageWait.waitFor({
 				raw: "Antigravity is not signed in.",
@@ -216,10 +241,116 @@ CLAUDE AND GPT MODELS
 		).toBe(true);
 		expect(
 			usageWait.waitFor({
-				raw: "Signing in...",
+				raw: "Antigravity is not signed in.\nSigning in...",
+				screen: "Loading Models & Quota...",
+			}),
+		).toBe(false);
+		expect(
+			usageWait.waitFor({
+				raw: "Antigravity is not signed in.\nSigning in...",
 				screen: "Signing in...",
 			}),
 		).toBe(false);
+		expect(
+			stabilizationWait.waitFor({
+				raw: "Antigravity is not signed in.\nSigning in...",
+				screen: "? for shortcuts",
+			}),
+		).toBe(true);
+	});
+
+	it("does not type or dismiss the screen when the current state is signed out", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const signInSnapshot = {
+			raw: "Antigravity is not signed in.",
+			screen: "Antigravity is not signed in.",
+		};
+		const writes: Array<string | undefined> = [];
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [, , prepareUsageStep] = dynamicWriteSteps(steps);
+			await resolveStepWrite(prepareUsageStep, signInSnapshot);
+			for (const step of usageWriteSteps(steps)) {
+				writes.push(await resolveStepWrite(step, signInSnapshot));
+			}
+			return buildEmptyPtyResult(signInSnapshot);
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toThrow("Antigravity is not signed in");
+		expect(writes).toHaveLength(8);
+		expect(writes.every((write) => write == null)).toBe(true);
+	});
+
+	it("rechecks the live screen before Enter and Escape", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const blockedSnapshot = {
+			raw: "? for shortcuts\nDo you trust the contents of this project?",
+			screen: "? for shortcuts\nDo you trust the contents of this project?",
+		};
+		let commandEnter: string | undefined;
+		let cleanupEscape: string | undefined;
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [, , prepareUsageStep] = dynamicWriteSteps(steps);
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			const writes = usageWriteSteps(steps);
+			for (const step of writes.slice(0, 6)) {
+				expect(await resolveStepWrite(step, readySnapshot())).toBeTypeOf("string");
+			}
+			commandEnter = await resolveStepWrite(writes[6] as MockPtyStep, blockedSnapshot);
+			cleanupEscape = await resolveStepWrite(writes[7] as MockPtyStep, blockedSnapshot);
+			return buildEmptyPtyResult(blockedSnapshot);
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toMatchObject({ code: "trust_required" });
+		expect(commandEnter).toBeUndefined();
+		expect(cleanupEscape).toBeUndefined();
+	});
+
+	it("stops all remaining writes when authentication starts transitioning", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const signingInSnapshot = {
+			raw: "Signing in...",
+			screen: "Signing in...",
+		};
+		const writes: Array<string | undefined> = [];
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [, , prepareUsageStep] = dynamicWriteSteps(steps);
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			const usageWrites = usageWriteSteps(steps);
+			writes.push(await resolveStepWrite(usageWrites[0] as MockPtyStep, readySnapshot()));
+			writes.push(await resolveStepWrite(usageWrites[1] as MockPtyStep, signingInSnapshot));
+			for (const step of usageWrites.slice(2)) {
+				writes.push(await resolveStepWrite(step, readySnapshot()));
+			}
+			return buildEmptyPtyResult(signingInSnapshot);
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toThrow("Antigravity /usage output did not include");
+		expect(writes[0]).toBe("/");
+		expect(writes.slice(1).every((write) => write == null)).toBe(true);
 	});
 
 	it("captures parser-recognized usage rows without requiring the Models & Quota heading", async () => {
@@ -245,16 +376,17 @@ CLAUDE AND GPT MODELS
 
 	it("reports the specific sign-in error when Antigravity is not authenticated", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const staleUsage = "GEMINI MODELS\nWeekly Limit\n72% remaining · Refreshes in 71h 49m";
 		ptyMock.runPtyScenario.mockResolvedValueOnce({
 			command: "agy",
 			args: [],
 			exitCode: 0,
 			timedOut: false,
-			raw: "Antigravity is not signed in.",
+			raw: `${staleUsage}\nAntigravity is not signed in.`,
 			screen: "Antigravity is not signed in.",
 			snapshots: {
 				usage: {
-					raw: "Antigravity is not signed in.",
+					raw: `${staleUsage}\nAntigravity is not signed in.`,
 					screen: "Antigravity is not signed in.",
 				},
 			},
@@ -269,6 +401,34 @@ CLAUDE AND GPT MODELS
 				}),
 			),
 		).rejects.toThrow("Antigravity is not signed in. Run `agy` and complete the login.");
+	});
+
+	it("does not treat stale raw sign-in text as the current authentication state", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "Antigravity is not signed in.",
+			screen: "? for shortcuts",
+			snapshots: {
+				usage: {
+					raw: "Antigravity is not signed in.",
+					screen: "Loading Models & Quota...",
+				},
+			},
+			debug: [],
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toThrow("Antigravity /usage output did not include Models & Quota limit groups.");
 	});
 
 	it("returns disabled quota buckets as usage rows without percentages", async () => {
@@ -318,20 +478,21 @@ CLAUDE AND GPT MODELS
 		expect(result.limits[0]?.raw).toContain("Disabled");
 	});
 
-	it("reports the neutral launch directory if Antigravity still asks for trust", async () => {
+	it("returns trust_required when confirmation is unavailable", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		const homeDir = await createTempDir("omniagent-agy-home-");
 		const repoRoot = path.join(homeDir, "repo");
 		const fallbackDir = path.join(homeDir, ".omniagent", "state", "usage", "antigravity-cli");
-		ptyMock.runPtyScenario.mockResolvedValueOnce({
-			command: "agy",
-			args: [],
-			exitCode: 0,
-			timedOut: false,
-			raw: "Do you trust the contents of this project?",
-			screen: "Do you trust the contents of this project?",
-			snapshots: {},
-			debug: [],
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(steps);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			expect(await resolveStepWrite(trustForwardStep, trustSnapshot())).toBeUndefined();
+			await resolveStepWrite(prepareUsageStep, trustSnapshot());
+			expect(
+				await resolveStepWrite(usageWriteSteps(steps).at(-1) as MockPtyStep, trustSnapshot()),
+			).toBeUndefined();
+			return buildEmptyPtyResult(trustSnapshot());
 		});
 
 		await expect(
@@ -341,26 +502,26 @@ CLAUDE AND GPT MODELS
 					repoRoot,
 				}),
 			),
-		).rejects.toThrow(
-			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`agy\` in ${fallbackDir} once, accept the trust prompt, then re-run usage.`,
-		);
+		).rejects.toMatchObject({
+			code: "trust_required",
+			message: expect.stringContaining(fallbackDir),
+		});
 	});
 
-	it("reports project trust when the managed usage directory cannot be created", async () => {
+	it("forwards rejection as Escape and returns trust_denied", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		const homeDir = await createTempDir("omniagent-agy-home-");
 		const repoRoot = path.join(homeDir, "repo");
-		await mkdir(repoRoot, { recursive: true });
-		await writeFile(path.join(homeDir, ".omniagent"), "not a directory", "utf8");
-		ptyMock.runPtyScenario.mockResolvedValueOnce({
-			command: "agy",
-			args: [],
-			exitCode: 0,
-			timedOut: false,
-			raw: "Do you trust the contents of this project?",
-			screen: "Do you trust the contents of this project?",
-			snapshots: {},
-			debug: [],
+		const confirm = vi.fn().mockResolvedValue(false);
+		let forwardedKey: string | undefined;
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(
+				options.steps as MockPtyStep[],
+			);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			forwardedKey = await resolveStepWrite(trustForwardStep, trustSnapshot());
+			await resolveStepWrite(prepareUsageStep, { raw: trustSnapshot().raw, screen: "" });
+			return buildEmptyPtyResult({ raw: trustSnapshot().raw, screen: "" });
 		});
 
 		await expect(
@@ -368,13 +529,184 @@ CLAUDE AND GPT MODELS
 				buildContext({
 					homeDir,
 					repoRoot,
+					confirm,
 				}),
 			),
-		).rejects.toThrow(
-			`Antigravity has not trusted this project yet. Run \`agy\` in ${repoRoot} once, accept the trust prompt, then re-run usage.`,
-		);
+		).rejects.toMatchObject({ code: "trust_denied" });
+		expect(forwardedKey).toBe("\x1b");
+	});
+
+	it("returns a trust-specific failure when approval does not reach the ready screen", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const repoRoot = path.join(homeDir, "repo");
+		const confirm = vi.fn().mockResolvedValue(true);
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(steps);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			expect(await resolveStepWrite(trustForwardStep, trustSnapshot())).toBe("\r");
+			await resolveStepWrite(prepareUsageStep, trustSnapshot());
+			expect(
+				await resolveStepWrite(usageWriteSteps(steps).at(-1) as MockPtyStep, trustSnapshot()),
+			).toBeUndefined();
+			return buildEmptyPtyResult(trustSnapshot());
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir,
+					repoRoot,
+					confirm,
+				}),
+			),
+		).rejects.toMatchObject({ code: "trust_acceptance_failed" });
+	});
+
+	it("reports sign-in instead of failed trust after an approved prompt", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const confirm = vi.fn().mockResolvedValue(true);
+		const signInSnapshot = {
+			raw: "Do you trust the contents of this project?\nAntigravity is not signed in.",
+			screen: "Antigravity is not signed in.",
+		};
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(
+				options.steps as MockPtyStep[],
+			);
+			expect(await resolveStepWrite(trustDecisionStep, trustSnapshot())).toBeUndefined();
+			expect(await resolveStepWrite(trustForwardStep, trustSnapshot())).toBe("\r");
+			await resolveStepWrite(prepareUsageStep, signInSnapshot);
+			return buildEmptyPtyResult(signInSnapshot);
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir,
+					repoRoot: "/tmp/untrusted-repo",
+					confirm,
+				}),
+			),
+		).rejects.toThrow("Antigravity is not signed in. Run `agy` and complete the login.");
+	});
+
+	it("does not reinterpret a later auth transition as failed trust acceptance", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const confirm = vi.fn().mockResolvedValue(true);
+		const signingInSnapshot = {
+			raw: "Signing in...",
+			screen: "Signing in...",
+		};
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			const steps = options.steps as MockPtyStep[];
+			const [trustDecisionStep, trustForwardStep, prepareUsageStep] = dynamicWriteSteps(steps);
+			await resolveStepWrite(trustDecisionStep, trustSnapshot());
+			await resolveStepWrite(trustForwardStep, trustSnapshot());
+			await resolveStepWrite(prepareUsageStep, readySnapshot());
+			await resolveStepWrite(usageWriteSteps(steps)[0] as MockPtyStep, signingInSnapshot);
+			return buildEmptyPtyResult(signingInSnapshot);
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir,
+					repoRoot: "/tmp/untrusted-repo",
+					confirm,
+				}),
+			),
+		).rejects.toMatchObject({
+			message: "Antigravity /usage output did not include Models & Quota limit groups.",
+		});
 	});
 });
+
+function buildUsagePtyResult() {
+	return {
+		command: "agy",
+		args: [],
+		exitCode: 0,
+		timedOut: false,
+		raw: "",
+		screen: "",
+		snapshots: {
+			usage: {
+				raw: "",
+				screen: `
+└ Models & Quota
+
+GEMINI MODELS
+  Models within this group: Gemini Flash, Gemini Pro
+
+  Weekly Limit
+    [████████████████████████████████████░░░░░░░░░░░░░░] 71.69%
+    72% remaining · Refreshes in 71h 49m
+
+CLAUDE AND GPT MODELS
+  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
+
+  Weekly Limit
+    [██████████████████████████████████████████████████] 99.94%
+    100% remaining · Refreshes in 71h 46m
+`,
+			},
+		},
+		debug: [],
+	};
+}
+
+function buildEmptyPtyResult(snapshot: { raw: string; screen: string }) {
+	return {
+		command: "agy",
+		args: [],
+		exitCode: 0,
+		timedOut: false,
+		raw: snapshot.raw,
+		screen: snapshot.screen,
+		snapshots: { startup: snapshot },
+		debug: [],
+	};
+}
+
+function trustSnapshot(): { raw: string; screen: string } {
+	return {
+		raw: "Do you trust the contents of this project?",
+		screen: "Do you trust the contents of this project?",
+	};
+}
+
+function readySnapshot(): { raw: string; screen: string } {
+	return { raw: "? for shortcuts", screen: "? for shortcuts" };
+}
+
+function dynamicWriteSteps(steps: MockPtyStep[]): [MockPtyStep, MockPtyStep, MockPtyStep] {
+	const dynamicSteps = steps.filter((step) => typeof step.write === "function");
+	const trustDecisionStep = dynamicSteps[0];
+	const trustForwardStep = dynamicSteps[1];
+	const prepareUsageStep = dynamicSteps[2];
+	if (trustDecisionStep == null || trustForwardStep == null || prepareUsageStep == null) {
+		throw new Error("Expected trust decision, forwarding, and usage preparation steps.");
+	}
+	return [trustDecisionStep, trustForwardStep, prepareUsageStep];
+}
+
+function usageWriteSteps(steps: MockPtyStep[]): MockPtyStep[] {
+	return steps.filter((step) => typeof step.write === "function").slice(3);
+}
+
+async function resolveStepWrite(
+	step: MockPtyStep,
+	snapshot: { raw: string; screen: string },
+): Promise<string | undefined> {
+	if (typeof step.write !== "function") {
+		throw new Error("Expected a dynamic PTY write step.");
+	}
+	return step.write(snapshot);
+}
 
 async function createTempDir(prefix: string): Promise<string> {
 	const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
@@ -388,7 +720,7 @@ async function writeAgySettings(homeDir: string, settings: unknown): Promise<voi
 	await writeFile(path.join(settingsDir, "settings.json"), JSON.stringify(settings), "utf8");
 }
 
-function buildContext(options: { homeDir: string; repoRoot: string }) {
+function buildContext(options: { homeDir: string; repoRoot: string; confirm?: UsageConfirmation }) {
 	return {
 		targetId: "agy",
 		displayName: "Antigravity CLI",
@@ -404,6 +736,7 @@ function buildContext(options: { homeDir: string; repoRoot: string }) {
 			timeoutMs: 70_000,
 		},
 		signal: new AbortController().signal,
+		confirm: options.confirm,
 		debug: {
 			enabled: false,
 		},

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -58,13 +58,14 @@ CLAUDE AND GPT MODELS
 		tempDirs = [];
 	});
 
-	it("runs the usage probe from an existing Antigravity trusted workspace", async () => {
+	it("uses the neutral omniagent state directory instead of unrelated trusted workspaces", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		const homeDir = await createTempDir("omniagent-agy-home-");
 		const trustedWorkspace = path.join(homeDir, "trusted-workspace");
+		const fallbackDir = path.join(homeDir, ".omniagent", "state", "usage", "antigravity-cli");
 		await mkdir(trustedWorkspace, { recursive: true });
 		await writeAgySettings(homeDir, {
-			trustedWorkspaces: [path.join(homeDir, "stale-workspace"), trustedWorkspace],
+			trustedWorkspaces: [trustedWorkspace],
 		});
 
 		const result = await extractAgyUsage(
@@ -75,8 +76,9 @@ CLAUDE AND GPT MODELS
 		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
-		expect(options.cwd).toBe(trustedWorkspace);
+		expect(options.cwd).toBe(fallbackDir);
 		expect(options.cwd).not.toBe(homeDir);
+		expect(options.cwd).not.toBe(trustedWorkspace);
 		expect(options.cwd).not.toBe("/tmp/untrusted-repo");
 		expect(result.limits).toHaveLength(2);
 		expect(result.limits[0]).toMatchObject({
@@ -134,6 +136,12 @@ CLAUDE AND GPT MODELS
 				screen: "Antigravity is not signed in.",
 			}),
 		).toBe(true);
+		expect(
+			usageWait.waitFor({
+				raw: "Signing in...",
+				screen: "Signing in...",
+			}),
+		).toBe(false);
 	});
 
 	it("captures parser-recognized usage rows without requiring the Models & Quota heading", async () => {

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { vi } from "vitest";
@@ -88,19 +88,25 @@ CLAUDE AND GPT MODELS
 		expect(result.limits[0]?.percentUsed).toBeCloseTo(28.31);
 	});
 
-	it("falls back to home when Antigravity has no trusted workspace setting", async () => {
+	it("falls back to an empty omniagent state directory when no trusted workspace exists", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const repoRoot = path.join(homeDir, "repo");
+		await mkdir(repoRoot, { recursive: true });
+		const fallbackDir = path.join(homeDir, ".omniagent", "state", "usage", "antigravity-cli");
 
 		const result = await extractAgyUsage(
 			buildContext({
-				homeDir: "/Users/tester",
-				repoRoot: "/tmp/untrusted-repo",
+				homeDir,
+				repoRoot,
 			}),
 		);
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
-		expect(options.cwd).toBe("/Users/tester");
-		expect(options.cwd).not.toBe("/tmp/untrusted-repo");
+		expect(options.cwd).toBe(fallbackDir);
+		expect(options.cwd).not.toBe(homeDir);
+		expect(options.cwd).not.toBe(repoRoot);
+		await expect(access(fallbackDir)).resolves.toBeUndefined();
 		expect(result.limits[0]).toMatchObject({
 			scope: "gemini_models",
 			window: "weekly",
@@ -126,6 +132,27 @@ CLAUDE AND GPT MODELS
 			usageWait.waitFor({
 				raw: "Antigravity is not signed in.",
 				screen: "Antigravity is not signed in.",
+			}),
+		).toBe(true);
+	});
+
+	it("captures parser-recognized usage rows without requiring the Models & Quota heading", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+
+		await extractAgyUsage(
+			buildContext({
+				homeDir: "/Users/tester",
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		const usageWait = options.steps.find((step: { capture?: string }) => step.capture === "usage");
+
+		expect(
+			usageWait.waitFor({
+				raw: "GEMINI MODELS\r\nWeekly Limit\r\n72% remaining · Refreshes in 71h 49m\r\n",
+				screen: "",
 			}),
 		).toBe(true);
 	});
@@ -207,6 +234,9 @@ CLAUDE AND GPT MODELS
 
 	it("reports the neutral launch directory if Antigravity still asks for trust", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const repoRoot = path.join(homeDir, "repo");
+		const fallbackDir = path.join(homeDir, ".omniagent", "state", "usage", "antigravity-cli");
 		ptyMock.runPtyScenario.mockResolvedValueOnce({
 			command: "agy",
 			args: [],
@@ -221,12 +251,12 @@ CLAUDE AND GPT MODELS
 		await expect(
 			extractAgyUsage(
 				buildContext({
-					homeDir: "/Users/tester",
-					repoRoot: "/tmp/untrusted-repo",
+					homeDir,
+					repoRoot,
 				}),
 			),
 		).rejects.toThrow(
-			"Antigravity has not trusted the usage launch directory yet. Run `agy` in /Users/tester once, accept the trust prompt, then re-run usage.",
+			`Antigravity has not trusted the usage launch directory yet. Run \`agy\` in ${fallbackDir} once, accept the trust prompt, then re-run usage.`,
 		);
 	});
 });

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -9,6 +9,14 @@ const ptyMock = vi.hoisted(() => ({
 
 let tempDirs: string[] = [];
 
+type MockPtyStep = {
+	capture?: string;
+	write?: string;
+	skipIf?: (snapshot: { raw: string; screen: string }) => boolean;
+	waitFor?: (snapshot: { raw: string; screen: string }) => boolean;
+	optional?: boolean;
+};
+
 vi.mock("../../../src/lib/usage/pty.js", () => ({
 	enterKey: () => "\r",
 	escapeKey: () => "\x1b",
@@ -88,6 +96,76 @@ CLAUDE AND GPT MODELS
 			percentRemaining: 71.69,
 		});
 		expect(result.limits[0]?.percentUsed).toBeCloseTo(28.31);
+	});
+
+	it("auto-accepts trust only for the managed usage directory", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+
+		await extractAgyUsage(
+			buildContext({
+				homeDir,
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		const steps = options.steps as MockPtyStep[];
+		const trustAcceptStep = steps[1];
+		const readyAfterTrustStep = steps[2];
+		const slashStep = steps.find((step) => step.write === "/");
+
+		expect(trustAcceptStep?.write).toBe("\r");
+		expect(
+			trustAcceptStep?.skipIf?.({
+				raw: "",
+				screen: "Do you trust the contents of this project?",
+			}),
+		).toBe(false);
+		expect(
+			trustAcceptStep?.skipIf?.({
+				raw: "",
+				screen: "? for shortcuts",
+			}),
+		).toBe(true);
+		expect(
+			readyAfterTrustStep?.waitFor?.({
+				raw: "Do you trust the contents of this project?",
+				screen: "? for shortcuts",
+			}),
+		).toBe(true);
+		expect(
+			slashStep?.skipIf?.({
+				raw: "Do you trust the contents of this project?",
+				screen: "? for shortcuts",
+			}),
+		).toBe(false);
+		expect(
+			slashStep?.skipIf?.({
+				raw: "",
+				screen: "Do you trust the contents of this project?",
+			}),
+		).toBe(true);
+	});
+
+	it("does not auto-accept trust when falling back outside the managed usage directory", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const repoRoot = path.join(homeDir, "repo");
+		await mkdir(repoRoot, { recursive: true });
+		await writeFile(path.join(homeDir, ".omniagent"), "not a directory", "utf8");
+
+		await extractAgyUsage(
+			buildContext({
+				homeDir,
+				repoRoot,
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		const steps = options.steps as MockPtyStep[];
+		expect(options.cwd).toBe(repoRoot);
+		expect(steps[1]?.write).toBe("/");
 	});
 
 	it("falls back to an empty omniagent state directory when no trusted workspace exists", async () => {
@@ -264,7 +342,7 @@ CLAUDE AND GPT MODELS
 				}),
 			),
 		).rejects.toThrow(
-			`Antigravity has not trusted the usage launch directory yet. Run \`agy\` in ${fallbackDir} once, accept the trust prompt, then re-run usage.`,
+			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`agy\` in ${fallbackDir} once, accept the trust prompt, then re-run usage.`,
 		);
 	});
 });

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -345,6 +345,35 @@ CLAUDE AND GPT MODELS
 			`Antigravity did not accept the managed usage launch directory trust prompt automatically. Run \`agy\` in ${fallbackDir} once, accept the trust prompt, then re-run usage.`,
 		);
 	});
+
+	it("reports project trust when the managed usage directory cannot be created", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const repoRoot = path.join(homeDir, "repo");
+		await mkdir(repoRoot, { recursive: true });
+		await writeFile(path.join(homeDir, ".omniagent"), "not a directory", "utf8");
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "Do you trust the contents of this project?",
+			screen: "Do you trust the contents of this project?",
+			snapshots: {},
+			debug: [],
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir,
+					repoRoot,
+				}),
+			),
+		).rejects.toThrow(
+			`Antigravity has not trusted this project yet. Run \`agy\` in ${repoRoot} once, accept the trust prompt, then re-run usage.`,
+		);
+	});
 });
 
 async function createTempDir(prefix: string): Promise<string> {

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -1,0 +1,169 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { vi } from "vitest";
+
+const ptyMock = vi.hoisted(() => ({
+	runPtyScenario: vi.fn(),
+}));
+
+let tempDirs: string[] = [];
+
+vi.mock("../../../src/lib/usage/pty.js", () => ({
+	enterKey: () => "\r",
+	escapeKey: () => "\x1b",
+	runPtyScenario: ptyMock.runPtyScenario,
+	typeTextSteps: (text: string, delayMs: number) =>
+		[...text].map((char) => ({ write: char, waitMs: delayMs })),
+}));
+
+describe("Antigravity usage extraction", () => {
+	beforeEach(() => {
+		ptyMock.runPtyScenario.mockReset();
+		ptyMock.runPtyScenario.mockResolvedValue({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "",
+			screen: "",
+			snapshots: {
+				usage: {
+					raw: "",
+					screen: `
+└ Models & Quota
+
+GEMINI MODELS
+  Models within this group: Gemini Flash, Gemini Pro
+
+  Weekly Limit
+    [████████████████████████████████████░░░░░░░░░░░░░░] 71.69%
+    72% remaining · Refreshes in 71h 49m
+
+CLAUDE AND GPT MODELS
+  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
+
+  Weekly Limit
+    [██████████████████████████████████████████████████] 99.94%
+    100% remaining · Refreshes in 71h 46m
+`,
+				},
+			},
+			debug: [],
+		});
+	});
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+		tempDirs = [];
+	});
+
+	it("runs the usage probe from an existing Antigravity trusted workspace", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		const homeDir = await createTempDir("omniagent-agy-home-");
+		const trustedWorkspace = path.join(homeDir, "trusted-workspace");
+		await mkdir(trustedWorkspace, { recursive: true });
+		await writeAgySettings(homeDir, {
+			trustedWorkspaces: [path.join(homeDir, "stale-workspace"), trustedWorkspace],
+		});
+
+		const result = await extractAgyUsage(
+			buildContext({
+				homeDir,
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		expect(options.cwd).toBe(trustedWorkspace);
+		expect(options.cwd).not.toBe(homeDir);
+		expect(options.cwd).not.toBe("/tmp/untrusted-repo");
+		expect(result.limits).toHaveLength(2);
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			window: "weekly",
+			label: "Gemini Models",
+			percentRemaining: 71.69,
+		});
+		expect(result.limits[0]?.percentUsed).toBeCloseTo(28.31);
+	});
+
+	it("falls back to home when Antigravity has no trusted workspace setting", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+
+		const result = await extractAgyUsage(
+			buildContext({
+				homeDir: "/Users/tester",
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		expect(options.cwd).toBe("/Users/tester");
+		expect(options.cwd).not.toBe("/tmp/untrusted-repo");
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			window: "weekly",
+			percentRemaining: 71.69,
+		});
+	});
+
+	it("reports the neutral launch directory if Antigravity still asks for trust", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "Do you trust the contents of this project?",
+			screen: "Do you trust the contents of this project?",
+			snapshots: {},
+			debug: [],
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toThrow(
+			"Antigravity has not trusted the usage launch directory yet. Run `agy` in /Users/tester once, accept the trust prompt, then re-run usage.",
+		);
+	});
+});
+
+async function createTempDir(prefix: string): Promise<string> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function writeAgySettings(homeDir: string, settings: unknown): Promise<void> {
+	const settingsDir = path.join(homeDir, ".gemini", "antigravity-cli");
+	await mkdir(settingsDir, { recursive: true });
+	await writeFile(path.join(settingsDir, "settings.json"), JSON.stringify(settings), "utf8");
+}
+
+function buildContext(options: { homeDir: string; repoRoot: string }) {
+	return {
+		targetId: "agy",
+		displayName: "Antigravity CLI",
+		command: "agy",
+		window: "weekly",
+		windows: ["weekly"],
+		now: new Date("2026-05-18T12:00:00.000Z"),
+		repoRoot: options.repoRoot,
+		agentsDir: `${options.repoRoot}/agents`,
+		homeDir: options.homeDir,
+		launch: {
+			command: "agy",
+			timeoutMs: 70_000,
+		},
+		signal: new AbortController().signal,
+		debug: {
+			enabled: false,
+		},
+	};
+}

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -369,6 +369,8 @@ describe("Antigravity usage extraction", () => {
 		try {
 			expect(usageWait.waitFor(snapshot)).toBe(false);
 			nowSpy.mockReturnValue(2_000);
+			expect(usageWait.waitFor(snapshot)).toBe(false);
+			nowSpy.mockReturnValue(3_000);
 			expect(usageWait.waitFor(snapshot)).toBe(true);
 		} finally {
 			nowSpy.mockRestore();

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -108,6 +108,103 @@ CLAUDE AND GPT MODELS
 		});
 	});
 
+	it("captures known sign-in failures instead of timing out waiting for usage rows", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+
+		await extractAgyUsage(
+			buildContext({
+				homeDir: "/Users/tester",
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
+		const usageWait = options.steps.find((step: { capture?: string }) => step.capture === "usage");
+
+		expect(usageWait.optional).toBe(true);
+		expect(
+			usageWait.waitFor({
+				raw: "Antigravity is not signed in.",
+				screen: "Antigravity is not signed in.",
+			}),
+		).toBe(true);
+	});
+
+	it("reports the specific sign-in error when Antigravity is not authenticated", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "Antigravity is not signed in.",
+			screen: "Antigravity is not signed in.",
+			snapshots: {
+				usage: {
+					raw: "Antigravity is not signed in.",
+					screen: "Antigravity is not signed in.",
+				},
+			},
+			debug: [],
+		});
+
+		await expect(
+			extractAgyUsage(
+				buildContext({
+					homeDir: "/Users/tester",
+					repoRoot: "/tmp/untrusted-repo",
+				}),
+			),
+		).rejects.toThrow("Antigravity is not signed in. Run `agy` and complete the login.");
+	});
+
+	it("returns disabled quota buckets as usage rows without percentages", async () => {
+		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
+		ptyMock.runPtyScenario.mockResolvedValueOnce({
+			command: "agy",
+			args: [],
+			exitCode: 0,
+			timedOut: false,
+			raw: "",
+			screen: "",
+			snapshots: {
+				usage: {
+					raw: "",
+					screen: `
+└ Models & Quota
+
+CLAUDE AND GPT MODELS
+  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
+
+  Weekly Limit
+    Disabled
+`,
+				},
+			},
+			debug: [],
+		});
+
+		const result = await extractAgyUsage(
+			buildContext({
+				homeDir: "/Users/tester",
+				repoRoot: "/tmp/untrusted-repo",
+			}),
+		);
+
+		expect(result.limits).toHaveLength(1);
+		expect(result.limits[0]).toMatchObject({
+			scope: "claude_and_gpt_models",
+			window: "weekly",
+			label: "Claude And GPT Models",
+			percentUsed: null,
+			percentRemaining: null,
+			remainingText: "Disabled",
+			resetAt: null,
+			resetText: null,
+		});
+		expect(result.limits[0]?.raw).toContain("Disabled");
+	});
+
 	it("reports the neutral launch directory if Antigravity still asks for trust", async () => {
 		const { extractAgyUsage } = await import("../../../src/lib/usage/agy.js");
 		ptyMock.runPtyScenario.mockResolvedValueOnce({

--- a/tests/lib/usage/agy-extract.test.ts
+++ b/tests/lib/usage/agy-extract.test.ts
@@ -98,7 +98,9 @@ describe("Antigravity usage extraction", () => {
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		const steps = options.steps as MockPtyStep[];
-		const readyAfterTrustStep = steps.find((step) => step.waitForTimeoutMs === 5_000);
+		const readyAfterTrustStep = steps.find(
+			(step) => step.waitForTimeoutMs === 25_000 && step.capture == null,
+		);
 
 		expect(options.cwd).toBe(fallbackDir);
 		expect(forwardedKey).toBe("\r");
@@ -217,18 +219,11 @@ describe("Antigravity usage extraction", () => {
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		const startupWait = options.steps[0];
-		const stabilizationWait = options.steps[1];
 		const usageWait = options.steps.find((step: { capture?: string }) => step.capture === "usage");
 
 		expect(usageWait.optional).toBe(true);
 		expect(
 			startupWait.waitFor({
-				raw: "Antigravity is not signed in.",
-				screen: "Antigravity is not signed in.",
-			}),
-		).toBe(true);
-		expect(
-			stabilizationWait.waitFor({
 				raw: "Antigravity is not signed in.",
 				screen: "Antigravity is not signed in.",
 			}),
@@ -252,7 +247,7 @@ describe("Antigravity usage extraction", () => {
 			}),
 		).toBe(false);
 		expect(
-			stabilizationWait.waitFor({
+			startupWait.waitFor({
 				raw: "Antigravity is not signed in.\nSigning in...",
 				screen: "? for shortcuts",
 			}),
@@ -365,13 +360,19 @@ describe("Antigravity usage extraction", () => {
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		const usageWait = options.steps.find((step: { capture?: string }) => step.capture === "usage");
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const snapshot = {
+			raw: "GEMINI MODELS\r\nWeekly Limit\r\n72% remaining · Refreshes in 71h 49m\r\n",
+			screen: "",
+		};
 
-		expect(
-			usageWait.waitFor({
-				raw: "GEMINI MODELS\r\nWeekly Limit\r\n72% remaining · Refreshes in 71h 49m\r\n",
-				screen: "",
-			}),
-		).toBe(true);
+		try {
+			expect(usageWait.waitFor(snapshot)).toBe(false);
+			nowSpy.mockReturnValue(2_000);
+			expect(usageWait.waitFor(snapshot)).toBe(true);
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	it("reports the specific sign-in error when Antigravity is not authenticated", async () => {

--- a/tests/lib/usage/agy-pty-integration.test.ts
+++ b/tests/lib/usage/agy-pty-integration.test.ts
@@ -6,7 +6,8 @@ import type { UsageConfirmation, UsageExtractionContext } from "../../../src/lib
 
 const FAKE_AGY_SCRIPT = String.raw`
 const mode = process.argv[1];
-const trustMode = mode === "trust" || mode === "delayed-trust";
+const trustMode =
+	mode === "trust" || mode === "delayed-trust" || mode === "trust-login-selection";
 const loginSelectionMode = mode === "login-selection";
 let state = trustMode ? "trust" : "sign-in";
 let input = "";
@@ -18,6 +19,17 @@ function render(content) {
 function renderReady() {
 	state = "ready";
 	render("Antigravity\r\n? for shortcuts");
+}
+
+function renderLoginSelection() {
+	state = "login-selection";
+	render([
+		"Welcome to the Antigravity CLI. You are currently not signed in.",
+		"",
+		"Select login method:",
+		"> 1. Google OAuth",
+		"  2. Use a Google Cloud project",
+	].join("\r\n"));
 }
 
 function renderUsage(includeClaude = false) {
@@ -47,13 +59,7 @@ function renderUsage(includeClaude = false) {
 if (state === "trust") {
 	render("Do you trust the contents of this project?");
 } else if (loginSelectionMode) {
-	render([
-		"Welcome to the Antigravity CLI. You are currently not signed in.",
-		"",
-		"Select login method:",
-		"> 1. Google OAuth",
-		"  2. Use a Google Cloud project",
-	].join("\r\n"));
+	renderLoginSelection();
 } else {
 	render("Antigravity is not signed in.");
 	setTimeout(renderReady, mode === "delayed-auth" ? 2500 : 75);
@@ -73,6 +79,10 @@ process.stdin.on("data", (chunk) => {
 		}
 		if (state === "trust") {
 			input = "";
+			if (mode === "trust-login-selection") {
+				renderLoginSelection();
+				continue;
+			}
 			state = "loading";
 			render("Loading trusted project...");
 			setTimeout(renderReady, mode === "delayed-trust" ? 5250 : 0);
@@ -85,7 +95,7 @@ process.stdin.on("data", (chunk) => {
 			setTimeout(() => {
 				renderUsage(false);
 				if (mode === "incremental-usage") {
-					setTimeout(() => renderUsage(true), 700);
+					setTimeout(() => renderUsage(true), 1300);
 				}
 			}, 800);
 		}
@@ -149,6 +159,17 @@ describe("Antigravity usage PTY integration", () => {
 		);
 	});
 
+	it("reports login selection immediately after trust approval", async () => {
+		const confirm = vi.fn<UsageConfirmation>().mockResolvedValue(true);
+
+		await expect(
+			extractAgyUsage(buildContext(tempDir, "trust-login-selection", confirm)),
+		).rejects.toThrow(
+			`Antigravity is not signed in. Run \`${process.execPath}\` and complete the login.`,
+		);
+		expect(confirm).toHaveBeenCalledOnce();
+	}, 10_000);
+
 	it("waits for readiness after trust beyond the old five-second deadline", async () => {
 		const confirm = vi.fn<UsageConfirmation>().mockResolvedValue(true);
 		const result = await extractAgyUsage(buildContext(tempDir, "delayed-trust", confirm));
@@ -175,6 +196,7 @@ function buildContext(
 	mode:
 		| "trust"
 		| "delayed-trust"
+		| "trust-login-selection"
 		| "stale-auth"
 		| "delayed-auth"
 		| "login-selection"
@@ -195,7 +217,7 @@ function buildContext(
 		launch: {
 			command: process.execPath,
 			args: ["-e", FAKE_AGY_SCRIPT, mode],
-			timeoutMs: mode === "login-selection" ? 3_000 : 12_000,
+			timeoutMs: mode === "login-selection" || mode === "trust-login-selection" ? 3_000 : 12_000,
 		},
 		signal: new AbortController().signal,
 		confirm,

--- a/tests/lib/usage/agy-pty-integration.test.ts
+++ b/tests/lib/usage/agy-pty-integration.test.ts
@@ -6,7 +6,8 @@ import type { UsageConfirmation, UsageExtractionContext } from "../../../src/lib
 
 const FAKE_AGY_SCRIPT = String.raw`
 const mode = process.argv[1];
-let state = mode === "trust" ? "trust" : "sign-in";
+const trustMode = mode === "trust" || mode === "delayed-trust";
+let state = trustMode ? "trust" : "sign-in";
 let input = "";
 
 function render(content) {
@@ -18,9 +19,9 @@ function renderReady() {
 	render("Antigravity\r\n? for shortcuts");
 }
 
-function renderUsage() {
+function renderUsage(includeClaude = false) {
 	state = "usage";
-	render([
+	const lines = [
 		"└ Models & Quota",
 		"",
 		"GEMINI MODELS",
@@ -28,14 +29,25 @@ function renderUsage() {
 		"",
 		"  Weekly Limit",
 		"    72% remaining · Refreshes in 71h 49m",
-	].join("\r\n"));
+	];
+	if (includeClaude) {
+		lines.push(
+			"",
+			"CLAUDE AND GPT MODELS",
+			"  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
+			"",
+			"  Weekly Limit",
+			"    55% remaining · Refreshes in 40h 10m",
+		);
+	}
+	render(lines.join("\r\n"));
 }
 
 if (state === "trust") {
 	render("Do you trust the contents of this project?");
 } else {
 	render("Antigravity is not signed in.");
-	setTimeout(renderReady, 75);
+	setTimeout(renderReady, mode === "delayed-auth" ? 2500 : 75);
 }
 
 process.stdin.setEncoding("utf8");
@@ -52,14 +64,21 @@ process.stdin.on("data", (chunk) => {
 		}
 		if (state === "trust") {
 			input = "";
-			renderReady();
+			state = "loading";
+			render("Loading trusted project...");
+			setTimeout(renderReady, mode === "delayed-trust" ? 5250 : 0);
 			continue;
 		}
 		if (state === "ready" && input === "/usage") {
 			input = "";
 			state = "loading";
 			render("Loading Models & Quota...");
-			setTimeout(renderUsage, 800);
+			setTimeout(() => {
+				renderUsage(false);
+				if (mode === "incremental-usage") {
+					setTimeout(() => renderUsage(true), 700);
+				}
+			}, 800);
 		}
 	}
 });
@@ -105,11 +124,40 @@ describe("Antigravity usage PTY integration", () => {
 			percentRemaining: 72,
 		});
 	}, 10_000);
+
+	it("waits through automatic authentication that exceeds the old stabilization window", async () => {
+		const result = await extractAgyUsage(buildContext(tempDir, "delayed-auth"));
+
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			percentRemaining: 72,
+		});
+	}, 15_000);
+
+	it("waits for readiness after trust beyond the old five-second deadline", async () => {
+		const confirm = vi.fn<UsageConfirmation>().mockResolvedValue(true);
+		const result = await extractAgyUsage(buildContext(tempDir, "delayed-trust", confirm));
+
+		expect(confirm).toHaveBeenCalledOnce();
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			percentRemaining: 72,
+		});
+	}, 15_000);
+
+	it("waits for an incrementally rendered quota panel to stabilize", async () => {
+		const result = await extractAgyUsage(buildContext(tempDir, "incremental-usage"));
+
+		expect(result.limits.map((limit) => limit.scope)).toEqual([
+			"gemini_models",
+			"claude_and_gpt_models",
+		]);
+	}, 15_000);
 });
 
 function buildContext(
 	homeDir: string,
-	mode: "trust" | "stale-auth",
+	mode: "trust" | "delayed-trust" | "stale-auth" | "delayed-auth" | "incremental-usage",
 	confirm?: UsageConfirmation,
 ): UsageExtractionContext {
 	const repoRoot = path.join(homeDir, "repo");
@@ -126,7 +174,7 @@ function buildContext(
 		launch: {
 			command: process.execPath,
 			args: ["-e", FAKE_AGY_SCRIPT, mode],
-			timeoutMs: 8_000,
+			timeoutMs: 12_000,
 		},
 		signal: new AbortController().signal,
 		confirm,

--- a/tests/lib/usage/agy-pty-integration.test.ts
+++ b/tests/lib/usage/agy-pty-integration.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { extractAgyUsage } from "../../../src/lib/usage/agy.js";
+import type { UsageConfirmation, UsageExtractionContext } from "../../../src/lib/usage/types.js";
+
+const FAKE_AGY_SCRIPT = String.raw`
+const mode = process.argv[1];
+let state = mode === "trust" ? "trust" : "sign-in";
+let input = "";
+
+function render(content) {
+	process.stdout.write("\x1b[2J\x1b[H" + content);
+}
+
+function renderReady() {
+	state = "ready";
+	render("Antigravity\r\n? for shortcuts");
+}
+
+function renderUsage() {
+	state = "usage";
+	render([
+		"└ Models & Quota",
+		"",
+		"GEMINI MODELS",
+		"  Models within this group: Gemini Flash, Gemini Pro",
+		"",
+		"  Weekly Limit",
+		"    72% remaining · Refreshes in 71h 49m",
+	].join("\r\n"));
+}
+
+if (state === "trust") {
+	render("Do you trust the contents of this project?");
+} else {
+	render("Antigravity is not signed in.");
+	setTimeout(renderReady, 75);
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.setRawMode?.(true);
+process.stdin.resume();
+process.stdin.on("data", (chunk) => {
+	for (const character of chunk) {
+		if (character === "\x1b") {
+			process.exit(0);
+		}
+		if (character !== "\r" && character !== "\n") {
+			input += character;
+			continue;
+		}
+		if (state === "trust") {
+			input = "";
+			renderReady();
+			continue;
+		}
+		if (state === "ready" && input === "/usage") {
+			input = "";
+			state = "loading";
+			render("Loading Models & Quota...");
+			setTimeout(renderUsage, 800);
+		}
+	}
+});
+`;
+
+describe("Antigravity usage PTY integration", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(path.join(os.tmpdir(), "omniagent-agy-pty-"));
+		await mkdir(path.join(tempDir, "repo"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("forwards approval, waits for ready, and enters /usage through the real PTY runner", async () => {
+		const managedPath = path.join(tempDir, ".omniagent", "state", "usage", "antigravity-cli");
+		const confirm = vi.fn<UsageConfirmation>().mockResolvedValue(true);
+
+		const result = await extractAgyUsage(buildContext(tempDir, "trust", confirm));
+
+		expect(confirm).toHaveBeenCalledWith({
+			type: "trust-directory",
+			targetId: "agy",
+			displayName: "Antigravity CLI",
+			path: managedPath,
+			managed: true,
+		});
+		expect(result.limits).toHaveLength(1);
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			percentRemaining: 72,
+		});
+	}, 10_000);
+
+	it("ignores stale raw sign-in output once the current screen is ready", async () => {
+		const result = await extractAgyUsage(buildContext(tempDir, "stale-auth"));
+
+		expect(result.limits[0]).toMatchObject({
+			scope: "gemini_models",
+			percentRemaining: 72,
+		});
+	}, 10_000);
+});
+
+function buildContext(
+	homeDir: string,
+	mode: "trust" | "stale-auth",
+	confirm?: UsageConfirmation,
+): UsageExtractionContext {
+	const repoRoot = path.join(homeDir, "repo");
+	return {
+		targetId: "agy",
+		displayName: "Antigravity CLI",
+		command: process.execPath,
+		window: "weekly",
+		windows: ["weekly"],
+		now: new Date("2026-05-18T12:00:00.000Z"),
+		repoRoot,
+		agentsDir: path.join(repoRoot, "agents"),
+		homeDir,
+		launch: {
+			command: process.execPath,
+			args: ["-e", FAKE_AGY_SCRIPT, mode],
+			timeoutMs: 8_000,
+		},
+		signal: new AbortController().signal,
+		confirm,
+		debug: {
+			enabled: false,
+		},
+	};
+}

--- a/tests/lib/usage/agy-pty-integration.test.ts
+++ b/tests/lib/usage/agy-pty-integration.test.ts
@@ -7,6 +7,7 @@ import type { UsageConfirmation, UsageExtractionContext } from "../../../src/lib
 const FAKE_AGY_SCRIPT = String.raw`
 const mode = process.argv[1];
 const trustMode = mode === "trust" || mode === "delayed-trust";
+const loginSelectionMode = mode === "login-selection";
 let state = trustMode ? "trust" : "sign-in";
 let input = "";
 
@@ -45,6 +46,14 @@ function renderUsage(includeClaude = false) {
 
 if (state === "trust") {
 	render("Do you trust the contents of this project?");
+} else if (loginSelectionMode) {
+	render([
+		"Welcome to the Antigravity CLI. You are currently not signed in.",
+		"",
+		"Select login method:",
+		"> 1. Google OAuth",
+		"  2. Use a Google Cloud project",
+	].join("\r\n"));
 } else {
 	render("Antigravity is not signed in.");
 	setTimeout(renderReady, mode === "delayed-auth" ? 2500 : 75);
@@ -134,6 +143,12 @@ describe("Antigravity usage PTY integration", () => {
 		});
 	}, 15_000);
 
+	it("reports the definitive login-selection screen without waiting for startup timeout", async () => {
+		await expect(extractAgyUsage(buildContext(tempDir, "login-selection"))).rejects.toThrow(
+			`Antigravity is not signed in. Run \`${process.execPath}\` and complete the login.`,
+		);
+	});
+
 	it("waits for readiness after trust beyond the old five-second deadline", async () => {
 		const confirm = vi.fn<UsageConfirmation>().mockResolvedValue(true);
 		const result = await extractAgyUsage(buildContext(tempDir, "delayed-trust", confirm));
@@ -157,7 +172,13 @@ describe("Antigravity usage PTY integration", () => {
 
 function buildContext(
 	homeDir: string,
-	mode: "trust" | "delayed-trust" | "stale-auth" | "delayed-auth" | "incremental-usage",
+	mode:
+		| "trust"
+		| "delayed-trust"
+		| "stale-auth"
+		| "delayed-auth"
+		| "login-selection"
+		| "incremental-usage",
 	confirm?: UsageConfirmation,
 ): UsageExtractionContext {
 	const repoRoot = path.join(homeDir, "repo");
@@ -174,7 +195,7 @@ function buildContext(
 		launch: {
 			command: process.execPath,
 			args: ["-e", FAKE_AGY_SCRIPT, mode],
-			timeoutMs: 12_000,
+			timeoutMs: mode === "login-selection" ? 3_000 : 12_000,
 		},
 		signal: new AbortController().signal,
 		confirm,

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -1,4 +1,4 @@
-import { parseAgyCredits } from "../../../src/lib/usage/agy.js";
+import { parseAgyUsage } from "../../../src/lib/usage/agy.js";
 import {
 	buildClaudeApiUsageResult,
 	buildClaudeUsageLimits,
@@ -577,64 +577,58 @@ Current week (Sonnet only)
 	});
 });
 
-describe("Antigravity credits parser", () => {
-	it("parses remaining credits and the plan label from the credits panel", () => {
+describe("Antigravity usage parser", () => {
+	it("parses weekly model quota groups from the Models & Quota panel", () => {
 		const screen = `
-Antigravity CLI 1.0.16
-user@example.com (Antigravity Starter Quota)
-Antigravity CLI  credits
-Model AI Credits
-Remaining AI Credits: 1,234
-Actions
-> Get More AI Credits
-See Activity
+└ Models & Quota
+
+  Account: user@example.com
+
+GEMINI MODELS
+  Models within this group: Gemini Flash, Gemini Pro
+
+  Weekly Limit
+    [████████████████████████████████████░░░░░░░░░░░░░░] 71.69%
+    72% remaining · Refreshes in 71h 49m
+
+
+CLAUDE AND GPT MODELS
+  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
+
+  Weekly Limit
+    [██████████████████████████████████████████████████] 99.94%
+    100% remaining · Refreshes in 71h 46m
 `;
 
-		const parsed = parseAgyCredits(screen);
-		expect(parsed.remaining).toBe("1,234");
-		expect(parsed.notEnabled).toBe(false);
-		expect(parsed.plan).toBe("Antigravity Starter Quota");
-		expect(parsed.rawLine).toBe("Remaining AI Credits: 1,234");
+		const parsed = parseAgyUsage(screen);
+		expect(parsed).toHaveLength(2);
+		expect(parsed[0]).toMatchObject({
+			heading: "GEMINI MODELS",
+			models: "Gemini Flash, Gemini Pro",
+			limitLabel: "Weekly Limit",
+			percentRemaining: 71.69,
+			resetText: "Refreshes in 71h 49m",
+		});
+		expect(parsed[1]).toMatchObject({
+			heading: "CLAUDE AND GPT MODELS",
+			models: "Claude Opus, Claude Sonnet, GPT-OSS",
+			percentRemaining: 99.94,
+			resetText: "Refreshes in 71h 46m",
+		});
 	});
 
-	it("detects the credits-not-enabled variant", () => {
-		const screen = `
-Antigravity CLI  credits
-Model AI Credits
-Remaining AI Credits: AI Credits not enabled (enable in /settings)
-Actions
-`;
-
-		const parsed = parseAgyCredits(screen);
-		expect(parsed.remaining).toBeNull();
-		expect(parsed.notEnabled).toBe(true);
-		expect(parsed.rawLine).toBe(
-			"Remaining AI Credits: AI Credits not enabled (enable in /settings)",
-		);
+	it("falls back to cleaned raw output when the screen has no quota panel", () => {
+		const raw =
+			"\u001b[32mGEMINI MODELS\u001b[0m\r\nWeekly Limit\r\n72% remaining · Refreshes in 71h 49m\r\n";
+		const parsed = parseAgyUsage("", cleanControlOutput(raw));
+		expect(parsed[0]).toMatchObject({
+			heading: "GEMINI MODELS",
+			percentRemaining: 72,
+			resetText: "Refreshes in 71h 49m",
+		});
 	});
 
-	it("parses a standalone plan line rendered apart from the account email", () => {
-		const screen = `
-user@example.com
-(Antigravity Starter Quota)
-Remaining AI Credits: 88
-`;
-
-		const parsed = parseAgyCredits(screen);
-		expect(parsed.remaining).toBe("88");
-		expect(parsed.plan).toBe("Antigravity Starter Quota");
-	});
-
-	it("falls back to cleaned raw output when the screen has no credits panel", () => {
-		const raw = "\u001b[32mRemaining AI Credits: 42\u001b[0m\r\n";
-		const parsed = parseAgyCredits("", cleanControlOutput(raw));
-		expect(parsed.remaining).toBe("42");
-	});
-
-	it("returns empty values when no credits information is present", () => {
-		const parsed = parseAgyCredits("just a prompt screen", "");
-		expect(parsed.remaining).toBeNull();
-		expect(parsed.notEnabled).toBe(false);
-		expect(parsed.plan).toBeNull();
+	it("returns no groups when no quota information is present", () => {
+		expect(parseAgyUsage("just a prompt screen", "")).toEqual([]);
 	});
 });

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -628,6 +628,39 @@ CLAUDE AND GPT MODELS
 		});
 	});
 
+	it("parses disabled quota buckets from the Models & Quota panel", () => {
+		const screen = `
+└ Models & Quota
+
+GEMINI MODELS
+  Models within this group: Gemini Flash, Gemini Pro
+
+  Weekly Limit
+    72% remaining · Refreshes in 71h 49m
+
+CLAUDE AND GPT MODELS
+  Models within this group: Claude Opus, Claude Sonnet, GPT-OSS
+
+  Weekly Limit
+    Disabled
+`;
+
+		const parsed = parseAgyUsage(screen);
+		expect(parsed).toHaveLength(2);
+		expect(parsed[0]).toMatchObject({
+			heading: "GEMINI MODELS",
+			percentRemaining: 72,
+			disabled: false,
+		});
+		expect(parsed[1]).toMatchObject({
+			heading: "CLAUDE AND GPT MODELS",
+			limitLabel: "Weekly Limit",
+			percentRemaining: null,
+			resetText: null,
+			disabled: true,
+		});
+	});
+
 	it("returns no groups when no quota information is present", () => {
 		expect(parseAgyUsage("just a prompt screen", "")).toEqual([]);
 	});

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -628,6 +628,34 @@ CLAUDE AND GPT MODELS
 		});
 	});
 
+	it("merges complete raw groups with the currently visible screen groups", () => {
+		const raw = `
+GEMINI MODELS
+  Weekly Limit
+    72% remaining · Refreshes in 71h 49m
+
+CLAUDE AND GPT MODELS
+  Weekly Limit
+    50% remaining · Refreshes in 40h 10m
+`;
+		const screen = `
+CLAUDE AND GPT MODELS
+  Weekly Limit
+    55% remaining · Refreshes in 39h 55m
+`;
+
+		const parsed = parseAgyUsage(screen, raw);
+
+		expect(parsed.map((group) => group.heading)).toEqual([
+			"GEMINI MODELS",
+			"CLAUDE AND GPT MODELS",
+		]);
+		expect(parsed[1]).toMatchObject({
+			percentRemaining: 55,
+			resetText: "Refreshes in 39h 55m",
+		});
+	});
+
 	it("parses disabled quota buckets from the Models & Quota panel", () => {
 		const screen = `
 └ Models & Quota

--- a/tests/lib/usage/pty.test.ts
+++ b/tests/lib/usage/pty.test.ts
@@ -30,6 +30,13 @@ const ptyMock = vi.hoisted(() => {
 				}
 			}, 5);
 		}
+		if (args.some((arg) => arg.includes("exit-early"))) {
+			setTimeout(() => {
+				for (const handler of exitHandlers) {
+					handler({ exitCode: 0 });
+				}
+			}, 10);
+		}
 
 		return child;
 	});
@@ -80,6 +87,125 @@ describe("PTY usage utility", () => {
 
 		expect(result.raw).toContain("ready");
 		expect(result.snapshots.ready.raw).toContain("ready");
+	});
+
+	it("awaits an asynchronous write resolver and writes its returned key", async () => {
+		const { runPtyScenario } = await import("../../../src/lib/usage/pty.js");
+		let markStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		let resolveWrite: ((value: string | undefined) => void) | undefined;
+		const write = new Promise<string | undefined>((resolve) => {
+			resolveWrite = resolve;
+		});
+
+		const resultPromise = runPtyScenario({
+			command: "node",
+			args: ["-e", "ready"],
+			timeoutMs: 1_000,
+			steps: [
+				{ waitFor: ({ raw }) => raw.includes("ready") },
+				{
+					waitMs: 20,
+					write: async ({ screen }) => {
+						expect(screen).toContain("ready");
+						markStarted?.();
+						return write;
+					},
+				},
+			],
+		});
+
+		await started;
+		const child = ptyMock.spawn.mock.results.at(-1)?.value;
+		expect(child?.write).not.toHaveBeenCalled();
+		resolveWrite?.("\r");
+		await resultPromise;
+		expect(child?.write).toHaveBeenCalledWith("\r");
+	});
+
+	it("aborts while an asynchronous write resolver is pending", async () => {
+		const { runPtyScenario } = await import("../../../src/lib/usage/pty.js");
+		const controller = new AbortController();
+		let markStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+
+		const resultPromise = runPtyScenario({
+			command: "node",
+			args: ["-e", "ready"],
+			timeoutMs: 1_000,
+			signal: controller.signal,
+			steps: [
+				{
+					waitFor: ({ screen }) => screen.includes("ready"),
+					write: () => {
+						markStarted?.();
+						return new Promise<string | undefined>(() => {});
+					},
+				},
+			],
+		});
+
+		await started;
+		controller.abort(new Error("confirmation cancelled"));
+		await expect(resultPromise).rejects.toMatchObject({
+			name: "PtyScenarioError",
+			timedOut: true,
+			message: "confirmation cancelled",
+		});
+		expect(ptyMock.spawn.mock.results.at(-1)?.value.kill).toHaveBeenCalled();
+	});
+
+	it("enforces its timeout when a non-aborting external signal is present", async () => {
+		const { runPtyScenario } = await import("../../../src/lib/usage/pty.js");
+		const controller = new AbortController();
+
+		const result = runPtyScenario({
+			command: "node",
+			args: ["-e", "ready"],
+			timeoutMs: 20,
+			signal: controller.signal,
+			steps: [
+				{
+					waitFor: ({ screen }) => screen.includes("ready"),
+					write: () => new Promise<string | undefined>(() => {}),
+				},
+			],
+		});
+
+		await expect(result).rejects.toMatchObject({
+			name: "PtyScenarioError",
+			timedOut: true,
+			message: "PTY scenario timed out after 20ms.",
+		});
+		expect(controller.signal.aborted).toBe(false);
+		expect(ptyMock.spawn.mock.results.at(-1)?.value.kill).toHaveBeenCalled();
+	});
+
+	it("marks a pending resolver timeout after the child exits as timed out", async () => {
+		const { runPtyScenario } = await import("../../../src/lib/usage/pty.js");
+
+		const result = runPtyScenario({
+			command: "node",
+			args: ["-e", "ready exit-early"],
+			timeoutMs: 80,
+			steps: [
+				{
+					waitFor: ({ screen }) => screen.includes("ready"),
+					write: () => new Promise<string | undefined>(() => {}),
+				},
+			],
+		});
+
+		await expect(result).rejects.toMatchObject({
+			name: "PtyScenarioError",
+			timedOut: true,
+			message: "PTY scenario timed out after 80ms.",
+		});
+		expect(ptyMock.spawn.mock.results.at(-1)?.value.kill).not.toHaveBeenCalled();
 	});
 
 	it("throws when required output does not arrive", async () => {


### PR DESCRIPTION
## Summary

- Launch the Antigravity usage probe from an existing trusted Antigravity workspace instead of the caller's current directory.
- Drive `agy /usage` and parse the Models & Quota weekly model-group rows.
- Update Antigravity usage metadata, docs, and focused parser/extractor coverage.

## Root Cause

The Antigravity usage implementation launched agy from the current repo and used `/credits`. That tied `omniagent usage` to the caller's workspace trust state and read the wrong usage panel. Antigravity's actual usage data is shown in `/usage` under Models & Quota.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test`
- Manual check from `~/Downloads`: `node dist/cli.js usage agy --timeout=45` returned weekly Gemini and Claude/GPT quota rows.
