### PR TITLE
Fix Codex usage extraction for weekly-only limits

### DIFF
--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -507,7 +507,7 @@ function dismissCodexModelMigrationPrompt(snapshot: {
 	screen: string;
 }): string | undefined {
 	const selection = codexKeepModelSelection(snapshot);
-	return selection == null ? undefined : `${selection}${enterKey()}`;
+	return selection ?? undefined;
 }
 
 function hasCodexStatusLimits(snapshot: { raw: string; screen: string }): boolean {
@@ -610,10 +610,15 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 			if (isCodexSparkLimitLabel(label)) {
 				// Inline rows like "GPT-5.3-Codex-Spark Weekly limit: 100% left" carry their own
 				// value; bare labels like "GPT-5.3-Codex-Spark limit:" open a Spark section instead.
-				section = "spark";
-				key = sparkLimitKey(label);
-				if (key && inlineValue) {
-					setValue(values, key, inlineValue);
+				const sparkKey = sparkLimitKey(label);
+				if (sparkKey) {
+					key = sparkKey;
+					if (inlineValue) {
+						setValue(values, key, inlineValue);
+					}
+				} else {
+					section = "spark";
+					key = "";
 				}
 				continue;
 			}
@@ -649,7 +654,7 @@ function assertAnyRequiredCodexLimit(parsed: ParsedCodexStatus): void {
 	if (parsed.main5hLimit || parsed.mainWeeklyLimit) {
 		return;
 	}
-	throw new Error("Codex usage output did not include the required 5h and weekly limit rows.");
+	throw new Error("Codex usage output did not include any main rate-limit rows.");
 }
 
 function isCodexSparkLimitLabel(label: string): boolean {

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -77,6 +77,9 @@ async function extractCodexUsageFromTui(
 			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
 			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000, optional: true },
 			{ write: enterKey(), skipIf: isCodexPromptReady },
+			// Trust onboarding can also precede the model-deprecation dialog.
+			{ waitFor: isCodexPromptReadyOrMigrationPrompt, waitForTimeoutMs: 10_000, optional: true },
+			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
 			{ waitFor: isCodexPromptReady, waitForTimeoutMs: 10_000 },
 			...typeTextSteps("/status", 20),
 			{ write: enterKey() },
@@ -487,9 +490,15 @@ function isCodexModelMigrationPrompt(snapshot: { raw: string; screen: string }):
 	return codexKeepModelSelection(snapshot) != null;
 }
 
-function codexKeepModelSelection(snapshot: { raw: string; screen: string }): string | null {
-	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
-	const match = /(\d+)\.\s*Use existing model/i.exec(cleanedOutput);
+function isCodexPromptReadyOrMigrationPrompt(snapshot: { raw: string; screen: string }): boolean {
+	return isCodexPromptReady(snapshot) || isCodexModelMigrationPrompt(snapshot);
+}
+
+// The migration dialog must be detected on the live screen only: raw output still contains the
+// dialog after it is dismissed, and re-sending the selection would type into the composer.
+function codexKeepModelSelection(snapshot: { screen: string }): string | null {
+	const cleanedScreen = cleanControlOutput(snapshot.screen);
+	const match = /(\d+)\.\s*Use existing model/i.exec(cleanedScreen);
 	return match?.[1] ?? null;
 }
 

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -513,8 +513,8 @@ function dismissCodexModelMigrationPrompt(snapshot: {
 function hasCodexStatusLimits(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
 	const parsed = parseCodexStatus(cleanedOutput);
-	// Codex currently reports only a weekly main limit; any main row means the status is complete.
-	return Boolean(parsed.main5hLimit || parsed.mainWeeklyLimit);
+	// Codex currently reports only a weekly main limit; one parseable main row is complete.
+	return hasParseableCodexMainLimit(parsed);
 }
 
 function hasCodexStatusResponse(snapshot: { raw: string; screen: string }): boolean {
@@ -651,10 +651,17 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 }
 
 function assertAnyRequiredCodexLimit(parsed: ParsedCodexStatus): void {
-	if (parsed.main5hLimit || parsed.mainWeeklyLimit) {
+	if (hasParseableCodexMainLimit(parsed)) {
 		return;
 	}
-	throw new Error("Codex usage output did not include any main rate-limit rows.");
+	throw new Error("Codex usage output did not include any parseable main rate-limit rows.");
+}
+
+function hasParseableCodexMainLimit(parsed: ParsedCodexStatus): boolean {
+	return (
+		parsePercentRemaining(parsed.main5hLimit) != null ||
+		parsePercentRemaining(parsed.mainWeeklyLimit) != null
+	);
 }
 
 function isCodexSparkLimitLabel(label: string): boolean {

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
 	cleanControlOutput,
@@ -62,47 +63,60 @@ async function extractCodexUsageFromTui(
 	context: UsageExtractionContext,
 ): Promise<UsageExtractionResult> {
 	const command = context.command ?? context.launch?.command ?? "codex";
-	const ptyResult = await runPtyScenario({
-		command,
-		args: context.launch?.args ?? ["--no-alt-screen"],
-		cwd: context.homeDir,
-		cols: 100,
-		rows: 40,
-		timeoutMs: context.launch?.timeoutMs ?? 60_000,
-		signal: context.signal,
-		debug: context.debug,
-		steps: [
-			{ waitFor: isCodexPromptReadyOrStartupPrompt, waitForTimeoutMs: 10_000 },
-			// Keep the configured model when Codex opens with a model-deprecation dialog.
-			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
-			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000, optional: true },
-			{ write: enterKey(), skipIf: isCodexPromptReady },
-			// Trust onboarding can also precede the model-deprecation dialog.
-			{ waitFor: isCodexPromptReadyOrMigrationPrompt, waitForTimeoutMs: 10_000, optional: true },
-			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
-			{ waitFor: isCodexPromptReady, waitForTimeoutMs: 10_000 },
-			...typeTextSteps("/status", 20),
-			{ write: enterKey() },
-			{
-				waitFor: hasCodexStatusResponse,
-				waitForTimeoutMs: 15_000,
-				capture: "status",
-				captureWaitMs: 500,
+	const probeCodexHome = await createIsolatedCodexProbeHome(context.homeDir);
+	let ptyResult: PtyScenarioResult;
+	try {
+		ptyResult = await runPtyScenario({
+			command,
+			args: context.launch?.args ?? ["--no-alt-screen"],
+			cwd: context.homeDir,
+			env: {
+				CODEX_HOME: probeCodexHome,
 			},
-			{ waitMs: 5_000, skipIf: hasCodexStatusLimits },
-			{ write: `${CLEAR_LINE}/status${enterKey()}`, skipIf: hasCodexStatusLimits },
-			{
-				waitFor: hasCodexStatusLimits,
-				waitForTimeoutMs: 15_000,
-				skipIf: hasCodexStatusLimits,
-				optional: true,
-				capture: "statusRetry",
-				captureWaitMs: 500,
-			},
-			{ write: `${CLEAR_LINE}/exit${enterKey()}` },
-			{ waitMs: 500 },
-		],
-	});
+			cols: 100,
+			rows: 40,
+			timeoutMs: context.launch?.timeoutMs ?? 60_000,
+			signal: context.signal,
+			debug: context.debug,
+			steps: [
+				{ waitFor: isCodexPromptReadyOrStartupPrompt, waitForTimeoutMs: 10_000 },
+				// Keep the configured model when Codex opens with a model-deprecation dialog.
+				{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
+				{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000, optional: true },
+				{ write: enterKey(), skipIf: isCodexPromptReady },
+				// Trust onboarding can also precede the model-deprecation dialog.
+				{
+					waitFor: isCodexPromptReadyOrMigrationPrompt,
+					waitForTimeoutMs: 10_000,
+					optional: true,
+				},
+				{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
+				{ waitFor: isCodexPromptReady, waitForTimeoutMs: 10_000 },
+				...typeTextSteps("/status", 20),
+				{ write: enterKey() },
+				{
+					waitFor: hasCodexStatusResponse,
+					waitForTimeoutMs: 15_000,
+					capture: "status",
+					captureWaitMs: 500,
+				},
+				{ waitMs: 5_000, skipIf: hasCodexStatusLimits },
+				{ write: `${CLEAR_LINE}/status${enterKey()}`, skipIf: hasCodexStatusLimits },
+				{
+					waitFor: hasCodexStatusLimits,
+					waitForTimeoutMs: 15_000,
+					skipIf: hasCodexStatusLimits,
+					optional: true,
+					capture: "statusRetry",
+					captureWaitMs: 500,
+				},
+				{ write: `${CLEAR_LINE}/exit${enterKey()}` },
+				{ waitMs: 500 },
+			],
+		});
+	} finally {
+		await rm(probeCodexHome, { recursive: true, force: true });
+	}
 
 	const parsed = selectCodexStatus(ptyResult);
 	const result = buildCodexUsageResult(parsed, {
@@ -116,6 +130,38 @@ async function extractCodexUsageFromTui(
 		...result,
 		debug: ptyResult.debug.length > 0 ? ptyResult.debug : undefined,
 	};
+}
+
+async function createIsolatedCodexProbeHome(homeDir: string): Promise<string> {
+	const probeCodexHome = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-probe-"));
+	try {
+		await Promise.all([
+			copyCodexProbeFile(path.join(homeDir, ...CODEX_AUTH_PATH), probeCodexHome, "auth.json"),
+			copyCodexProbeFile(
+				path.join(homeDir, ...CODEX_INSTALLATION_ID_PATH),
+				probeCodexHome,
+				"installation_id",
+			),
+		]);
+		return probeCodexHome;
+	} catch (error) {
+		await rm(probeCodexHome, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+async function copyCodexProbeFile(
+	sourcePath: string,
+	probeCodexHome: string,
+	filename: string,
+): Promise<void> {
+	let contents: Buffer;
+	try {
+		contents = await readFile(sourcePath);
+	} catch {
+		return;
+	}
+	await writeFile(path.join(probeCodexHome, filename), contents, { mode: 0o600 });
 }
 
 async function extractCodexUsageFromApi(
@@ -324,15 +370,11 @@ function buildCodexApiRateLimitUsageLimits(options: {
 		return [];
 	}
 
-	const windows = [
-		["primary", options.rateLimit.primary_window],
-		["secondary", options.rateLimit.secondary_window],
-	] as const;
-	return windows.flatMap(([kind, window]) => {
+	const windows = [options.rateLimit.primary_window, options.rateLimit.secondary_window];
+	return windows.flatMap((window) => {
 		const limit = makeCodexApiUsageLimit({
 			targetId: options.targetId,
 			scope: options.scope,
-			windowKind: kind,
 			window,
 			now: options.now,
 			labelPrefix: options.labelPrefix,
@@ -344,7 +386,6 @@ function buildCodexApiRateLimitUsageLimits(options: {
 function makeCodexApiUsageLimit(options: {
 	targetId: string;
 	scope: string;
-	windowKind: "primary" | "secondary";
 	window: CodexApiRateLimitWindow | undefined;
 	now: Date;
 	labelPrefix?: string;
@@ -358,8 +399,11 @@ function makeCodexApiUsageLimit(options: {
 		return null;
 	}
 
+	const window = codexApiWindowName(options.window);
+	if (window == null) {
+		return null;
+	}
 	const resetAt = parseApiEpochSeconds(options.window.reset_at);
-	const window = codexApiWindowName(options.window, options.windowKind);
 	const percentUsedClamped = clampPercent(percentUsed);
 	const percentRemaining = 100 - percentUsedClamped;
 	const resetText = resetAt == null ? null : `resets ${resetAt}`;
@@ -396,10 +440,7 @@ function codexAdditionalLimitScope(limitName: string, meteredFeature: string): s
 	return normalized || "additional";
 }
 
-function codexApiWindowName(
-	window: CodexApiRateLimitWindow,
-	kind: "primary" | "secondary",
-): "5h" | "weekly" | string {
+function codexApiWindowName(window: CodexApiRateLimitWindow): "5h" | "weekly" | null {
 	const seconds = parseApiNumber(window.limit_window_seconds);
 	if (seconds === 18_000) {
 		return "5h";
@@ -407,7 +448,7 @@ function codexApiWindowName(
 	if (seconds === 604_800) {
 		return "weekly";
 	}
-	return kind === "primary" ? "5h" : "weekly";
+	return null;
 }
 
 function formatWindowLabel(window: string): string {
@@ -513,8 +554,9 @@ function dismissCodexModelMigrationPrompt(snapshot: {
 function hasCodexStatusLimits(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
 	const parsed = parseCodexStatus(cleanedOutput);
-	// Codex currently reports only a weekly main limit; one parseable main row is complete.
-	return hasParseableCodexMainLimit(parsed);
+	// Codex currently reports only a weekly main limit; absent rows are fine, but any row that has
+	// started rendering must include a parseable percentage before the probe exits.
+	return hasOnlyParseableCodexMainLimits(parsed);
 }
 
 function hasCodexStatusResponse(snapshot: { raw: string; screen: string }): boolean {
@@ -552,12 +594,15 @@ export function buildCodexUsageLimits(
 		}
 
 		const percentRemaining = parsePercentRemaining(raw);
+		if (percentRemaining == null) {
+			return [];
+		}
 		return [
 			makeUsageLimit({
 				targetId: context.targetId,
 				scope,
 				window,
-				percentUsed: percentRemaining == null ? null : 100 - percentRemaining,
+				percentUsed: 100 - percentRemaining,
 				percentRemaining,
 				resetText: parseResetText(raw),
 				raw,
@@ -662,6 +707,13 @@ function hasParseableCodexMainLimit(parsed: ParsedCodexStatus): boolean {
 		parsePercentRemaining(parsed.main5hLimit) != null ||
 		parsePercentRemaining(parsed.mainWeeklyLimit) != null
 	);
+}
+
+function hasOnlyParseableCodexMainLimits(parsed: ParsedCodexStatus): boolean {
+	const mainLimits = [parsed.main5hLimit, parsed.mainWeeklyLimit]
+		.map((limit) => limit.trim())
+		.filter(Boolean);
+	return mainLimits.length > 0 && mainLimits.every((limit) => parsePercentRemaining(limit) != null);
 }
 
 function isCodexSparkLimitLabel(label: string): boolean {

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -14,7 +14,6 @@ import {
 	typeTextSteps,
 } from "./pty.js";
 import type {
-	NormalizedUsageError,
 	NormalizedUsageLimit,
 	UsageExtractionContext,
 	UsageExtractionResult,
@@ -73,7 +72,10 @@ async function extractCodexUsageFromTui(
 		signal: context.signal,
 		debug: context.debug,
 		steps: [
-			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000 },
+			{ waitFor: isCodexPromptReadyOrStartupPrompt, waitForTimeoutMs: 10_000 },
+			// Keep the configured model when Codex opens with a model-deprecation dialog.
+			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
+			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000, optional: true },
 			{ write: enterKey(), skipIf: isCodexPromptReady },
 			{ waitFor: isCodexPromptReady, waitForTimeoutMs: 10_000 },
 			...typeTextSteps("/status", 20),
@@ -181,15 +183,14 @@ export function buildCodexApiUsageResult(
 			scope: "main",
 			rateLimit: usage.rate_limit,
 			now: context.now,
-			requireBothWindows: true,
 		}),
 		...buildCodexApiAdditionalUsageLimits(usage.additional_rate_limits, context),
 	];
 
-	const hasMainHourly = limits.some((limit) => limit.scope === "main" && limit.window === "hourly");
-	const hasMainWeekly = limits.some((limit) => limit.scope === "main" && limit.window === "weekly");
-	if (!hasMainHourly || !hasMainWeekly) {
-		throw new Error("Codex usage API response did not include complete main rate-limit windows.");
+	// Codex currently reports only a weekly main window; accept whichever windows it returns.
+	const hasMainLimit = limits.some((limit) => limit.scope === "main");
+	if (!hasMainLimit) {
+		throw new Error("Codex usage API response did not include any main rate-limit windows.");
 	}
 
 	return {
@@ -305,7 +306,6 @@ function buildCodexApiAdditionalUsageLimits(
 			rateLimit: entry.rate_limit,
 			now: context.now,
 			labelPrefix: scope === "spark" ? undefined : limitName || meteredFeature || scope,
-			requireBothWindows: false,
 		});
 	});
 }
@@ -316,7 +316,6 @@ function buildCodexApiRateLimitUsageLimits(options: {
 	rateLimit: CodexApiRateLimit | undefined;
 	now: Date;
 	labelPrefix?: string;
-	requireBothWindows: boolean;
 }): NormalizedUsageLimit[] {
 	if (!isRecord(options.rateLimit)) {
 		return [];
@@ -326,7 +325,7 @@ function buildCodexApiRateLimitUsageLimits(options: {
 		["primary", options.rateLimit.primary_window],
 		["secondary", options.rateLimit.secondary_window],
 	] as const;
-	const limits = windows.flatMap(([kind, window]) => {
+	return windows.flatMap(([kind, window]) => {
 		const limit = makeCodexApiUsageLimit({
 			targetId: options.targetId,
 			scope: options.scope,
@@ -337,11 +336,6 @@ function buildCodexApiRateLimitUsageLimits(options: {
 		});
 		return limit == null ? [] : [limit];
 	});
-
-	if (options.requireBothWindows && limits.length !== 2) {
-		return [];
-	}
-	return limits;
 }
 
 function makeCodexApiUsageLimit(options: {
@@ -480,15 +474,38 @@ function isCodexPromptReadyOrTrustPrompt(snapshot: { raw: string; screen: string
 	return isCodexPromptReady(snapshot) || isCodexTrustPrompt(snapshot);
 }
 
+function isCodexPromptReadyOrStartupPrompt(snapshot: { raw: string; screen: string }): boolean {
+	return isCodexPromptReadyOrTrustPrompt(snapshot) || isCodexModelMigrationPrompt(snapshot);
+}
+
 function isCodexTrustPrompt(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
 	return /do you trust the contents of this directory/i.test(cleanedOutput);
 }
 
+function isCodexModelMigrationPrompt(snapshot: { raw: string; screen: string }): boolean {
+	return codexKeepModelSelection(snapshot) != null;
+}
+
+function codexKeepModelSelection(snapshot: { raw: string; screen: string }): string | null {
+	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
+	const match = /(\d+)\.\s*Use existing model/i.exec(cleanedOutput);
+	return match?.[1] ?? null;
+}
+
+function dismissCodexModelMigrationPrompt(snapshot: {
+	raw: string;
+	screen: string;
+}): string | undefined {
+	const selection = codexKeepModelSelection(snapshot);
+	return selection == null ? undefined : `${selection}${enterKey()}`;
+}
+
 function hasCodexStatusLimits(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
 	const parsed = parseCodexStatus(cleanedOutput);
-	return Boolean(parsed.main5hLimit && parsed.mainWeeklyLimit);
+	// Codex currently reports only a weekly main limit; any main row means the status is complete.
+	return Boolean(parsed.main5hLimit || parsed.mainWeeklyLimit);
 }
 
 function hasCodexStatusResponse(snapshot: { raw: string; screen: string }): boolean {
@@ -507,13 +524,11 @@ export function buildCodexUsageResult(
 	},
 ): UsageExtractionResult {
 	assertAnyRequiredCodexLimit(parsed);
-	const errors = buildCodexUsageErrors(parsed, context);
 	return {
 		targetId: context.targetId,
 		displayName: context.displayName,
 		command: context.command,
 		limits: buildCodexUsageLimits(parsed, context),
-		errors: errors.length > 0 ? errors : undefined,
 	};
 }
 
@@ -584,8 +599,13 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 			const inlineValue = labelMatch[2].trim();
 
 			if (isCodexSparkLimitLabel(label)) {
+				// Inline rows like "GPT-5.3-Codex-Spark Weekly limit: 100% left" carry their own
+				// value; bare labels like "GPT-5.3-Codex-Spark limit:" open a Spark section instead.
 				section = "spark";
-				key = "";
+				key = sparkLimitKey(label);
+				if (key && inlineValue) {
+					setValue(values, key, inlineValue);
+				}
 				continue;
 			}
 
@@ -623,32 +643,18 @@ function assertAnyRequiredCodexLimit(parsed: ParsedCodexStatus): void {
 	throw new Error("Codex usage output did not include the required 5h and weekly limit rows.");
 }
 
-function buildCodexUsageErrors(
-	parsed: ParsedCodexStatus,
-	context: Pick<UsageExtractionContext, "targetId" | "displayName">,
-): NormalizedUsageError[] {
-	const missing: string[] = [];
-	if (!parsed.main5hLimit) {
-		missing.push("5h");
-	}
-	if (!parsed.mainWeeklyLimit) {
-		missing.push("weekly");
-	}
-	if (missing.length === 0) {
-		return [];
-	}
-	return [
-		{
-			targetId: context.targetId,
-			displayName: context.displayName,
-			code: "partial_parse",
-			message: `Codex usage output did not include the ${missing.join(" and ")} limit row.`,
-		},
-	];
-}
-
 function isCodexSparkLimitLabel(label: string): boolean {
 	return /\bspark\b/i.test(label) && /\blimit\b/i.test(label);
+}
+
+function sparkLimitKey(label: string): keyof ParsedCodexStatus | "" {
+	if (/\b5h limit$/i.test(label)) {
+		return "spark5hLimit";
+	}
+	if (/\bweekly limit$/i.test(label)) {
+		return "sparkWeeklyLimit";
+	}
+	return "";
 }
 
 function labelToCodexKey(label: string, section: "main" | "spark"): keyof ParsedCodexStatus | "" {

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -149,12 +149,22 @@ Weekly limit: 41% left
 		]);
 
 		const steps = options.steps;
-		expect(
-			steps[0].waitFor({ raw: "", screen: "Do you trust the contents of this directory?" }),
-		).toBe(true);
-		expect(steps[1]).toMatchObject({ write: "\r" });
-		expect(steps[1].skipIf({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
-		expect(steps[2].waitFor({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
+		const trustPrompt = { raw: "", screen: "Do you trust the contents of this directory?" };
+		const migrationPrompt = {
+			raw: "",
+			screen: "GPT-5.4 Mini will be deprecated soon\n› 1. Try new model\n  2. Use existing model",
+		};
+		const readyPrompt = { raw: "", screen: "gpt-5.5 Context 0% used > " };
+		expect(steps[0].waitFor(trustPrompt)).toBe(true);
+		expect(steps[0].waitFor(migrationPrompt)).toBe(true);
+		expect(steps[1].write(migrationPrompt)).toBe("2\r");
+		expect(steps[1].write(trustPrompt)).toBeUndefined();
+		expect(steps[1].skipIf(readyPrompt)).toBe(true);
+		expect(steps[2].waitFor(trustPrompt)).toBe(true);
+		expect(steps[2].optional).toBe(true);
+		expect(steps[3]).toMatchObject({ write: "\r" });
+		expect(steps[3].skipIf(readyPrompt)).toBe(true);
+		expect(steps[4].waitFor(readyPrompt)).toBe(true);
 	});
 
 	async function createCodexHome(): Promise<string> {

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -154,6 +154,7 @@ Weekly limit: 41% left
 			raw: "",
 			screen: "GPT-5.4 Mini will be deprecated soon\n› 1. Try new model\n  2. Use existing model",
 		};
+		const dismissedMigrationPrompt = { raw: migrationPrompt.screen, screen: "" };
 		const readyPrompt = { raw: "", screen: "gpt-5.5 Context 0% used > " };
 		expect(steps[0].waitFor(trustPrompt)).toBe(true);
 		expect(steps[0].waitFor(migrationPrompt)).toBe(true);
@@ -164,7 +165,15 @@ Weekly limit: 41% left
 		expect(steps[2].optional).toBe(true);
 		expect(steps[3]).toMatchObject({ write: "\r" });
 		expect(steps[3].skipIf(readyPrompt)).toBe(true);
+		expect(steps[4].waitFor(migrationPrompt)).toBe(true);
 		expect(steps[4].waitFor(readyPrompt)).toBe(true);
+		expect(steps[4].optional).toBe(true);
+		expect(steps[5].write(migrationPrompt)).toBe("2\r");
+		// A dialog that only lingers in raw output was already dismissed; typing again would
+		// submit the selection to the composer.
+		expect(steps[5].write(dismissedMigrationPrompt)).toBeUndefined();
+		expect(steps[5].skipIf(readyPrompt)).toBe(true);
+		expect(steps[6].waitFor(readyPrompt)).toBe(true);
 	});
 
 	async function createCodexHome(): Promise<string> {

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -158,7 +158,7 @@ Weekly limit: 41% left
 		const readyPrompt = { raw: "", screen: "gpt-5.5 Context 0% used > " };
 		expect(steps[0].waitFor(trustPrompt)).toBe(true);
 		expect(steps[0].waitFor(migrationPrompt)).toBe(true);
-		expect(steps[1].write(migrationPrompt)).toBe("2\r");
+		expect(steps[1].write(migrationPrompt)).toBe("2");
 		expect(steps[1].write(trustPrompt)).toBeUndefined();
 		expect(steps[1].skipIf(readyPrompt)).toBe(true);
 		expect(steps[2].waitFor(trustPrompt)).toBe(true);
@@ -168,7 +168,7 @@ Weekly limit: 41% left
 		expect(steps[4].waitFor(migrationPrompt)).toBe(true);
 		expect(steps[4].waitFor(readyPrompt)).toBe(true);
 		expect(steps[4].optional).toBe(true);
-		expect(steps[5].write(migrationPrompt)).toBe("2\r");
+		expect(steps[5].write(migrationPrompt)).toBe("2");
 		// A dialog that only lingers in raw output was already dismissed; typing again would
 		// submit the selection to the composer.
 		expect(steps[5].write(dismissedMigrationPrompt)).toBeUndefined();

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { vi } from "vitest";
@@ -19,25 +19,7 @@ describe("Codex usage extraction", () => {
 
 	beforeEach(() => {
 		ptyMock.runPtyScenario.mockReset();
-		ptyMock.runPtyScenario.mockResolvedValue({
-			command: "codex",
-			args: ["--no-alt-screen"],
-			exitCode: 0,
-			timedOut: false,
-			raw: "",
-			screen: "",
-			snapshots: {
-				status: {
-					raw: "",
-					screen: `
-Model: gpt-5.1-codex
-5h limit: 85% left
-Weekly limit: 41% left
-`,
-				},
-			},
-			debug: [],
-		});
+		ptyMock.runPtyScenario.mockResolvedValue(buildPtyResult());
 	});
 
 	afterEach(async () => {
@@ -130,6 +112,42 @@ Weekly limit: 41% left
 		]);
 	});
 
+	it("isolates fallback TUI state from the user's Codex configuration", async () => {
+		const { extractCodexUsage } = await import("../../../src/lib/usage/codex.js");
+		const homeDir = await createCodexHome();
+		const configPath = path.join(homeDir, ".codex", "config.toml");
+		const configContents = 'model = "gpt-5.4-mini"\n';
+		await writeFile(configPath, configContents);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				status: 200,
+				json: async () => ({}),
+			}),
+		);
+
+		let probeCodexHome = "";
+		ptyMock.runPtyScenario.mockImplementationOnce(async (options) => {
+			probeCodexHome = options.env?.CODEX_HOME ?? "";
+			expect(probeCodexHome).not.toBe(path.join(homeDir, ".codex"));
+			expect(await readFile(path.join(probeCodexHome, "auth.json"), "utf8")).toContain(
+				"test-access-token",
+			);
+			expect(await readFile(path.join(probeCodexHome, "installation_id"), "utf8")).toBe(
+				"test-installation-id",
+			);
+			await expect(
+				readFile(path.join(probeCodexHome, "config.toml"), "utf8"),
+			).rejects.toMatchObject({ code: "ENOENT" });
+			return buildPtyResult();
+		});
+
+		await extractCodexUsage(buildContext({ homeDir, now: new Date("2026-05-18T12:00:00.000Z") }));
+
+		expect(await readFile(configPath, "utf8")).toBe(configContents);
+		await expect(access(probeCodexHome)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
 	it("runs the built-in probe from home and continues past the Codex trust gate", async () => {
 		const { extractCodexUsage } = await import("../../../src/lib/usage/codex.js");
 
@@ -174,6 +192,18 @@ Weekly limit: 41% left
 		expect(steps[5].write(dismissedMigrationPrompt)).toBeUndefined();
 		expect(steps[5].skipIf(readyPrompt)).toBe(true);
 		expect(steps[6].waitFor(readyPrompt)).toBe(true);
+
+		const statusSettleStep = steps.find((step: { waitMs?: number }) => step.waitMs === 5_000);
+		const weeklyOnlyStatus = {
+			raw: "",
+			screen: "Model: gpt-5.4-mini\nWeekly limit: 60% left",
+		};
+		const mixedIncrementalStatus = {
+			raw: "",
+			screen: "Model: gpt-5.4-mini\n5h limit: [██\nWeekly limit: 60% left",
+		};
+		expect(statusSettleStep.skipIf(weeklyOnlyStatus)).toBe(true);
+		expect(statusSettleStep.skipIf(mixedIncrementalStatus)).toBe(false);
 	});
 
 	async function createCodexHome(): Promise<string> {
@@ -216,3 +246,25 @@ Weekly limit: 41% left
 		};
 	}
 });
+
+function buildPtyResult() {
+	return {
+		command: "codex",
+		args: ["--no-alt-screen"],
+		exitCode: 0,
+		timedOut: false,
+		raw: "",
+		screen: "",
+		snapshots: {
+			status: {
+				raw: "",
+				screen: `
+Model: gpt-5.1-codex
+5h limit: 85% left
+Weekly limit: 41% left
+`,
+			},
+		},
+		debug: [],
+	};
+}

--- a/tests/lib/usage/codex-pty-integration.test.ts
+++ b/tests/lib/usage/codex-pty-integration.test.ts
@@ -16,6 +16,7 @@ const states = {
 	"migration-trust": ["migration", "trust"],
 	migration: ["migration"],
 	trust: ["trust"],
+	incremental: [],
 }[mode];
 let state = states.shift() ?? "ready";
 let input = "";
@@ -90,6 +91,15 @@ process.stdin.on("data", (chunk) => {
 			continue;
 		}
 		if (state === "ready" && entered === "/status") {
+			if (mode === "incremental") {
+				render("Model: gpt-5.4-mini\r\nWeekly limit: [██");
+				setTimeout(() => {
+					render(
+						"Model: gpt-5.4-mini\r\nWeekly limit: [███░] 93% left (resets 13:03 on 28 Jul)",
+					);
+				}, 1_000);
+				continue;
+			}
 			render(
 				[
 					"╭────────────────────╮",
@@ -156,11 +166,17 @@ describe("Codex usage PTY integration", () => {
 			"spark:weekly",
 		]);
 	}, 15_000);
+
+	it("waits for an incrementally rendered main limit to include its percentage", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "incremental"));
+
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([93]);
+	}, 15_000);
 });
 
 function buildContext(
 	homeDir: string,
-	mode: "trust-migration" | "migration-trust" | "migration" | "trust",
+	mode: "trust-migration" | "migration-trust" | "migration" | "trust" | "incremental",
 ): UsageExtractionContext {
 	// homeDir has no .codex/auth.json, so extraction falls back to the TUI probe.
 	return {

--- a/tests/lib/usage/codex-pty-integration.test.ts
+++ b/tests/lib/usage/codex-pty-integration.test.ts
@@ -6,8 +6,9 @@ import type { UsageExtractionContext } from "../../../src/lib/usage/types.js";
 
 // Simulates the Codex TUI startup flow: an optional trust prompt and an optional
 // model-deprecation dialog in either order, followed by the composer prompt and a
-// weekly-only /status response. Selecting anything but "Use existing model" on the
-// deprecation dialog dead-ends so tests fail if the probe switches the model.
+// weekly-only /status response. The deprecation dialog handles numeric options immediately,
+// matching Codex; selecting anything but "Use existing model" or sending trailing input in the
+// same write dead-ends so tests fail if the probe switches the model or leaks an extra key.
 const FAKE_CODEX_SCRIPT = String.raw`
 const mode = process.argv[1];
 const states = {
@@ -53,7 +54,24 @@ process.stdin.setEncoding("utf8");
 process.stdin.setRawMode?.(true);
 process.stdin.resume();
 process.stdin.on("data", (chunk) => {
+	let migrationSelectionHandled = false;
 	for (const character of chunk) {
+		if (migrationSelectionHandled) {
+			render("Unexpected trailing input after model selection.");
+			state = "switched";
+			continue;
+		}
+		if (state === "migration") {
+			if (character === "2") {
+				input = "";
+				advance();
+				migrationSelectionHandled = true;
+			} else {
+				render("Switching to GPT-5.6 Luna...");
+				state = "switched";
+			}
+			continue;
+		}
 		if (character === "\x15") {
 			input = "";
 			continue;
@@ -69,15 +87,6 @@ process.stdin.on("data", (chunk) => {
 		}
 		if (state === "trust") {
 			advance();
-			continue;
-		}
-		if (state === "migration") {
-			if (entered === "2") {
-				advance();
-			} else if (entered !== "") {
-				render("Switching to GPT-5.6 Luna...");
-				state = "switched";
-			}
 			continue;
 		}
 		if (state === "ready" && entered === "/status") {

--- a/tests/lib/usage/codex-pty-integration.test.ts
+++ b/tests/lib/usage/codex-pty-integration.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { extractCodexUsage } from "../../../src/lib/usage/codex.js";
+import type { UsageExtractionContext } from "../../../src/lib/usage/types.js";
+
+// Simulates the Codex TUI startup flow: an optional trust prompt and an optional
+// model-deprecation dialog in either order, followed by the composer prompt and a
+// weekly-only /status response. Selecting anything but "Use existing model" on the
+// deprecation dialog dead-ends so tests fail if the probe switches the model.
+const FAKE_CODEX_SCRIPT = String.raw`
+const mode = process.argv[1];
+const states = {
+	"trust-migration": ["trust", "migration"],
+	"migration-trust": ["migration", "trust"],
+	migration: ["migration"],
+	trust: ["trust"],
+}[mode];
+let state = states.shift() ?? "ready";
+let input = "";
+
+function render(content) {
+	process.stdout.write("\x1b[2J\x1b[H" + content);
+}
+
+function renderState() {
+	if (state === "trust") {
+		render("Do you trust the contents of this directory?\r\n> 1. Yes, continue\r\n  2. No, exit");
+	} else if (state === "migration") {
+		render(
+			[
+				"GPT-5.4 Mini will be deprecated soon",
+				"",
+				"Codex now uses GPT-5.6 Luna in place of GPT-5.4 Mini.",
+				"",
+				"› 1. Try new model",
+				"  2. Use existing model",
+			].join("\r\n"),
+		);
+	} else if (state === "ready") {
+		render("› Summarize recent commits\r\n\r\n  gpt-5.4-mini · Context 0% used");
+	}
+}
+
+function advance() {
+	state = states.shift() ?? "ready";
+	renderState();
+}
+
+renderState();
+
+process.stdin.setEncoding("utf8");
+process.stdin.setRawMode?.(true);
+process.stdin.resume();
+process.stdin.on("data", (chunk) => {
+	for (const character of chunk) {
+		if (character === "\x15") {
+			input = "";
+			continue;
+		}
+		if (character !== "\r" && character !== "\n") {
+			input += character;
+			continue;
+		}
+		const entered = input;
+		input = "";
+		if (entered === "/exit") {
+			process.exit(0);
+		}
+		if (state === "trust") {
+			advance();
+			continue;
+		}
+		if (state === "migration") {
+			if (entered === "2") {
+				advance();
+			} else if (entered !== "") {
+				render("Switching to GPT-5.6 Luna...");
+				state = "switched";
+			}
+			continue;
+		}
+		if (state === "ready" && entered === "/status") {
+			render(
+				[
+					"╭────────────────────╮",
+					"│  >_ OpenAI Codex (v0.144.6)",
+					"│",
+					"│  Model:            gpt-5.4-mini (reasoning low)",
+					"│  Directory:        ~",
+					"│  Account:          user@example.com (Pro)",
+					"│",
+					"│  Weekly limit:     [███░] 93% left (resets 13:03 on 28 Jul)",
+					"│  GPT-5.3-Codex-Spark Weekly limit: [████] 100% left (resets 16:38 on 28 Jul)",
+					"╰────────────────────╯",
+					"",
+					"› Summarize recent commits",
+					"",
+					"  gpt-5.4-mini · Context 0% used",
+				].join("\r\n"),
+			);
+		}
+	}
+});
+`;
+
+describe("Codex usage PTY integration", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-pty-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("dismisses a model-deprecation dialog shown after trust onboarding", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "trust-migration"));
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+	}, 15_000);
+
+	it("dismisses a model-deprecation dialog shown before trust onboarding", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "migration-trust"));
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+	}, 15_000);
+
+	it("dismisses a model-deprecation dialog when no trust prompt appears", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "migration"));
+
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([93, 100]);
+	}, 15_000);
+
+	it("continues past the trust prompt when no deprecation dialog appears", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "trust"));
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+	}, 15_000);
+});
+
+function buildContext(
+	homeDir: string,
+	mode: "trust-migration" | "migration-trust" | "migration" | "trust",
+): UsageExtractionContext {
+	// homeDir has no .codex/auth.json, so extraction falls back to the TUI probe.
+	return {
+		targetId: "codex",
+		displayName: "OpenAI Codex",
+		command: process.execPath,
+		window: "hourly",
+		windows: ["hourly", "weekly"],
+		now: new Date("2026-07-21T12:00:00.000Z"),
+		repoRoot: homeDir,
+		agentsDir: path.join(homeDir, "agents"),
+		homeDir,
+		launch: {
+			command: process.execPath,
+			args: ["-e", FAKE_CODEX_SCRIPT, mode],
+			timeoutMs: 12_000,
+		},
+		signal: new AbortController().signal,
+		debug: {
+			enabled: false,
+		},
+	};
+}

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -304,6 +304,23 @@ describe("Codex usage parser", () => {
 		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([95, 100]);
 	});
 
+	it("does not treat inline Spark rows as section headings", () => {
+		const parsed = parseCodexStatus(`
+╭──────────────────────────╮
+│ Model: gpt-5.4-mini      │
+│ GPT-5.3-Codex-Spark Weekly limit: 100% left
+│ 5h limit: 85% left
+│ Weekly limit: 42% left
+╰──────────────────────────╯
+`);
+
+		expect(parsed).toMatchObject({
+			main5hLimit: "85% left",
+			mainWeeklyLimit: "42% left",
+			sparkWeeklyLimit: "100% left",
+		});
+	});
+
 	it("parses Spark limit headings without pinning the Codex model version", () => {
 		const parsed = parseCodexStatus(`
 ╭──────────────────────────╮
@@ -492,7 +509,7 @@ gpt-5.5 xhigh · Context 0% used
 					now: new Date("2026-05-18T12:00:00.000Z"),
 				},
 			),
-		).toThrow("Codex usage output did not include the required 5h and weekly limit rows.");
+		).toThrow("Codex usage output did not include any main rate-limit rows.");
 	});
 
 	it("treats Codex time-only resets as local CLI times", () => {

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -158,15 +158,56 @@ describe("Codex usage parser", () => {
 		expect(result.limits[1]?.resetAt).toBe("2026-05-25T12:00:00.000Z");
 	});
 
-	it("requires complete main Codex API rate-limit windows", () => {
+	it("builds weekly-only Codex usage limits when the API omits the 5h window", () => {
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const result = buildCodexApiUsageResult(
+			{
+				rate_limit: {
+					primary_window: {
+						used_percent: 5,
+						limit_window_seconds: 604_800,
+						reset_at: now.getTime() / 1000 + 7 * 24 * 60 * 60,
+					},
+					secondary_window: null,
+				},
+				additional_rate_limits: [
+					{
+						limit_name: "GPT-5.3-Codex-Spark",
+						metered_feature: "codex_bengalfox",
+						rate_limit: {
+							primary_window: {
+								used_percent: 0,
+								limit_window_seconds: 604_800,
+								reset_at: now.getTime() / 1000 + 6 * 24 * 60 * 60,
+							},
+							secondary_window: null,
+						},
+					},
+				],
+			},
+			{
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				command: "codex",
+				now,
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([95, 100]);
+		expect(result.limits[0]?.resetAt).toBe("2026-05-25T12:00:00.000Z");
+	});
+
+	it("requires at least one main Codex API rate-limit window", () => {
 		expect(() =>
 			buildCodexApiUsageResult(
 				{
 					rate_limit: {
-						primary_window: {
-							used_percent: 6,
-							limit_window_seconds: 18_000,
-						},
+						primary_window: null,
+						secondary_window: null,
 					},
 				},
 				{
@@ -175,7 +216,7 @@ describe("Codex usage parser", () => {
 					now: new Date("2026-05-18T12:00:00.000Z"),
 				},
 			),
-		).toThrow("Codex usage API response did not include complete main rate-limit windows.");
+		).toThrow("Codex usage API response did not include any main rate-limit windows.");
 	});
 
 	it("extracts Codex ChatGPT backend auth from auth.json", () => {
@@ -219,6 +260,48 @@ describe("Codex usage parser", () => {
 			spark5hLimit: "90% left",
 			sparkWeeklyLimit: "60% left (resets May 25)",
 		});
+	});
+
+	it("parses weekly-only status output with inline Spark limit rows", () => {
+		const parsed = parseCodexStatus(`
+╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.144.6)                                                                    │
+│                                                                                                │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date                                  │
+│ information on rate limits and credits                                                         │
+│                                                                                                │
+│  Model:                              gpt-5.4-mini (reasoning low, summaries auto)              │
+│  Directory:                          ~                                                         │
+│  Permissions:                        Workspace (untrusted)                                     │
+│  Agents.md:                          <none>                                                    │
+│  Account:                            user@example.com (Pro)                                    │
+│  Collaboration mode:                 Default                                                   │
+│                                                                                                │
+│  Weekly limit:                       [███████████████████░] 95% left (resets 13:03 on 28 Jul)  │
+│  GPT-5.3-Codex-Spark Weekly limit:   [████████████████████] 100% left (resets 16:38 on 28 Jul) │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+`);
+
+		expect(parsed).toMatchObject({
+			model: "gpt-5.4-mini (reasoning low, summaries auto)",
+			account: "user@example.com (Pro)",
+			main5hLimit: "",
+			mainWeeklyLimit: "[███████████████████░] 95% left (resets 13:03 on 28 Jul)",
+			spark5hLimit: "",
+			sparkWeeklyLimit: "[████████████████████] 100% left (resets 16:38 on 28 Jul)",
+		});
+
+		const result = buildCodexUsageResult(parsed, {
+			targetId: "codex",
+			displayName: "OpenAI Codex",
+			now: new Date("2026-07-21T12:00:00.000Z"),
+		});
+		expect(result.errors).toBeUndefined();
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([95, 100]);
 	});
 
 	it("parses Spark limit headings without pinning the Codex model version", () => {
@@ -335,7 +418,7 @@ gpt-5.5 xhigh · Context 0% used
 		expect(limits.map((limit) => limit.percentRemaining)).toEqual([85, 60]);
 	});
 
-	it("returns partial Codex limits with an error when one required main row is missing", () => {
+	it("returns 5h-only Codex limits without errors when the weekly row is missing", () => {
 		const result = buildCodexUsageResult(
 			{
 				model: "",
@@ -358,17 +441,10 @@ gpt-5.5 xhigh · Context 0% used
 		);
 
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:hourly"]);
-		expect(result.errors).toEqual([
-			{
-				targetId: "codex",
-				displayName: "OpenAI Codex",
-				code: "partial_parse",
-				message: "Codex usage output did not include the weekly limit row.",
-			},
-		]);
+		expect(result.errors).toBeUndefined();
 	});
 
-	it("returns partial Codex weekly limits when the 5h row is missing", () => {
+	it("returns weekly-only Codex limits without errors when the 5h row is missing", () => {
 		const result = buildCodexUsageResult(
 			{
 				model: "",
@@ -391,9 +467,7 @@ gpt-5.5 xhigh · Context 0% used
 		);
 
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:weekly"]);
-		expect(result.errors?.[0]?.message).toBe(
-			"Codex usage output did not include the 5h limit row.",
-		);
+		expect(result.errors).toBeUndefined();
 	});
 
 	it("throws when Codex output has no required main limit rows", () => {

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -487,7 +487,7 @@ gpt-5.5 xhigh · Context 0% used
 		expect(result.errors).toBeUndefined();
 	});
 
-	it("throws when Codex output has no required main limit rows", () => {
+	it("throws when Codex output has no parseable main limit rows", () => {
 		expect(() =>
 			buildCodexUsageResult(
 				{
@@ -509,7 +509,32 @@ gpt-5.5 xhigh · Context 0% used
 					now: new Date("2026-05-18T12:00:00.000Z"),
 				},
 			),
-		).toThrow("Codex usage output did not include any main rate-limit rows.");
+		).toThrow("Codex usage output did not include any parseable main rate-limit rows.");
+	});
+
+	it("rejects an incrementally rendered main limit without a percentage", () => {
+		expect(() =>
+			buildCodexUsageResult(
+				{
+					model: "",
+					directory: "",
+					permissions: "",
+					agentsMd: "",
+					account: "",
+					collaborationMode: "",
+					session: "",
+					main5hLimit: "",
+					mainWeeklyLimit: "[██",
+					spark5hLimit: "",
+					sparkWeeklyLimit: "",
+				},
+				{
+					targetId: "codex",
+					displayName: "OpenAI Codex",
+					now: new Date("2026-05-18T12:00:00.000Z"),
+				},
+			),
+		).toThrow("Codex usage output did not include any parseable main rate-limit rows.");
 	});
 
 	it("treats Codex time-only resets as local CLI times", () => {

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -219,6 +219,26 @@ describe("Codex usage parser", () => {
 		).toThrow("Codex usage API response did not include any main rate-limit windows.");
 	});
 
+	it("rejects Codex API windows with unknown durations", () => {
+		expect(() =>
+			buildCodexApiUsageResult(
+				{
+					rate_limit: {
+						primary_window: {
+							used_percent: 5,
+						},
+						secondary_window: null,
+					},
+				},
+				{
+					targetId: "codex",
+					displayName: "OpenAI Codex",
+					now: new Date("2026-05-18T12:00:00.000Z"),
+				},
+			),
+		).toThrow("Codex usage API response did not include any main rate-limit windows.");
+	});
+
 	it("extracts Codex ChatGPT backend auth from auth.json", () => {
 		expect(
 			extractCodexBackendAuth(
@@ -433,6 +453,32 @@ gpt-5.5 xhigh · Context 0% used
 			"spark:weekly",
 		]);
 		expect(limits.map((limit) => limit.percentRemaining)).toEqual([85, 60]);
+	});
+
+	it("omits incomplete rows when another main limit is parseable", () => {
+		const result = buildCodexUsageResult(
+			{
+				model: "",
+				directory: "",
+				permissions: "",
+				agentsMd: "",
+				account: "",
+				collaborationMode: "",
+				session: "",
+				main5hLimit: "[██",
+				mainWeeklyLimit: "60% left",
+				spark5hLimit: "",
+				sparkWeeklyLimit: "[███",
+			},
+			{
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				now: new Date("2026-05-18T12:00:00.000Z"),
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:weekly"]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([60]);
 	});
 
 	it("returns 5h-only Codex limits without errors when the weekly row is missing", () => {


### PR DESCRIPTION
## Problem

`omniagent usage codex` regressed to a hard failure ("Timed out waiting for expected TUI output.") after upstream Codex changes. Both extraction paths broke:

1. **Usage API path** — `chatgpt.com/backend-api/wham/usage` now returns only a weekly main window (`secondary_window: null`, `limit_window_seconds: 604800`). `buildCodexApiUsageResult` required both a 5h and weekly main window, so it threw and fell back to the TUI.
2. **TUI fallback** — Codex 0.144.6 can open with a model-deprecation dialog ("GPT-5.4 Mini will be deprecated soon… 1. Try new model / 2. Use existing model") that the PTY scenario didn't know how to dismiss, so the probe timed out. Even past the dialog, `/status` no longer prints a `5h limit:` row, and the Spark limit moved from a section heading to an inline row (`GPT-5.3-Codex-Spark Weekly limit: …`) that the parser mistook for a section header and dropped.

## Fix

Codex's usage output is in flux and the 5h window will likely return, so 5h parsing is kept intact everywhere — the extractors just no longer *require* it:

- The API extractor accepts whichever main windows the response includes and only fails when there are none (which still triggers the TUI fallback).
- The TUI probe dismisses the model-deprecation dialog by picking **"Use existing model"** (keyed off the option's number) so the probe never switches the user's configured model.
- `parseCodexStatus` handles inline Spark limit rows while still supporting the older Spark section-heading format.
- A single main limit row now counts as a complete `/status` response, so the probe stops burning ~20s waiting and re-sending `/status` for a 5h row that doesn't exist, and missing-window `partial_parse` errors (which forced exit code 1 on every run) are no longer emitted.

## Verification

- `npm run check`, `npm run typecheck`, and `npm test` (688 tests) pass.
- Ran `omniagent usage codex` against codex-cli 0.144.6 with a live ChatGPT-plan login: the API path returns main + Spark weekly limits, exit 0.
- Forced the TUI fallback (home dir without `.codex/auth.json`): the probe dismissed the deprecation dialog, kept the existing model, and parsed the weekly-only `/status` output including the inline Spark row.