### PR TITLE
Fix weekly-only usage extraction

### DIFF
--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -14,7 +14,6 @@ import {
 	typeTextSteps,
 } from "./pty.js";
 import type {
-	NormalizedUsageError,
 	NormalizedUsageLimit,
 	UsageExtractionContext,
 	UsageExtractionResult,
@@ -73,8 +72,18 @@ async function extractCodexUsageFromTui(
 		signal: context.signal,
 		debug: context.debug,
 		steps: [
-			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000 },
+			{ waitFor: isCodexPromptReadyOrStartupPrompt, waitForTimeoutMs: 10_000 },
+			// Numeric migration choices submit immediately, so do not append Enter.
+			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
+			{ waitFor: isCodexPromptReadyOrTrustPrompt, waitForTimeoutMs: 10_000, optional: true },
 			{ write: enterKey(), skipIf: isCodexPromptReady },
+			// Trust onboarding can precede the model-migration dialog.
+			{
+				waitFor: isCodexPromptReadyOrMigrationPrompt,
+				waitForTimeoutMs: 10_000,
+				optional: true,
+			},
+			{ write: dismissCodexModelMigrationPrompt, skipIf: isCodexPromptReady },
 			{ waitFor: isCodexPromptReady, waitForTimeoutMs: 10_000 },
 			...typeTextSteps("/status", 20),
 			{ write: enterKey() },
@@ -181,15 +190,14 @@ export function buildCodexApiUsageResult(
 			scope: "main",
 			rateLimit: usage.rate_limit,
 			now: context.now,
-			requireBothWindows: true,
 		}),
 		...buildCodexApiAdditionalUsageLimits(usage.additional_rate_limits, context),
 	];
 
-	const hasMainHourly = limits.some((limit) => limit.scope === "main" && limit.window === "hourly");
-	const hasMainWeekly = limits.some((limit) => limit.scope === "main" && limit.window === "weekly");
-	if (!hasMainHourly || !hasMainWeekly) {
-		throw new Error("Codex usage API response did not include complete main rate-limit windows.");
+	if (!limits.some((limit) => limit.scope === "main")) {
+		throw new Error(
+			"Codex usage API response did not include any recognized main rate-limit windows.",
+		);
 	}
 
 	return {
@@ -305,7 +313,6 @@ function buildCodexApiAdditionalUsageLimits(
 			rateLimit: entry.rate_limit,
 			now: context.now,
 			labelPrefix: scope === "spark" ? undefined : limitName || meteredFeature || scope,
-			requireBothWindows: false,
 		});
 	});
 }
@@ -316,38 +323,27 @@ function buildCodexApiRateLimitUsageLimits(options: {
 	rateLimit: CodexApiRateLimit | undefined;
 	now: Date;
 	labelPrefix?: string;
-	requireBothWindows: boolean;
 }): NormalizedUsageLimit[] {
 	if (!isRecord(options.rateLimit)) {
 		return [];
 	}
 
-	const windows = [
-		["primary", options.rateLimit.primary_window],
-		["secondary", options.rateLimit.secondary_window],
-	] as const;
-	const limits = windows.flatMap(([kind, window]) => {
+	const windows = [options.rateLimit.primary_window, options.rateLimit.secondary_window];
+	return windows.flatMap((window) => {
 		const limit = makeCodexApiUsageLimit({
 			targetId: options.targetId,
 			scope: options.scope,
-			windowKind: kind,
 			window,
 			now: options.now,
 			labelPrefix: options.labelPrefix,
 		});
 		return limit == null ? [] : [limit];
 	});
-
-	if (options.requireBothWindows && limits.length !== 2) {
-		return [];
-	}
-	return limits;
 }
 
 function makeCodexApiUsageLimit(options: {
 	targetId: string;
 	scope: string;
-	windowKind: "primary" | "secondary";
 	window: CodexApiRateLimitWindow | undefined;
 	now: Date;
 	labelPrefix?: string;
@@ -361,8 +357,11 @@ function makeCodexApiUsageLimit(options: {
 		return null;
 	}
 
+	const window = codexApiWindowName(options.window);
+	if (window == null) {
+		return null;
+	}
 	const resetAt = parseApiEpochSeconds(options.window.reset_at);
-	const window = codexApiWindowName(options.window, options.windowKind);
 	const percentUsedClamped = clampPercent(percentUsed);
 	const percentRemaining = 100 - percentUsedClamped;
 	const resetText = resetAt == null ? null : `resets ${resetAt}`;
@@ -399,10 +398,7 @@ function codexAdditionalLimitScope(limitName: string, meteredFeature: string): s
 	return normalized || "additional";
 }
 
-function codexApiWindowName(
-	window: CodexApiRateLimitWindow,
-	kind: "primary" | "secondary",
-): "5h" | "weekly" | string {
+function codexApiWindowName(window: CodexApiRateLimitWindow): "5h" | "weekly" | null {
 	const seconds = parseApiNumber(window.limit_window_seconds);
 	if (seconds === 18_000) {
 		return "5h";
@@ -410,7 +406,7 @@ function codexApiWindowName(
 	if (seconds === 604_800) {
 		return "weekly";
 	}
-	return kind === "primary" ? "5h" : "weekly";
+	return null;
 }
 
 function formatWindowLabel(window: string): string {
@@ -459,9 +455,9 @@ function selectCodexStatus(result: PtyScenarioResult): ParsedCodexStatus {
 		if (snapshot == null) {
 			continue;
 		}
-		for (const content of [`${snapshot.screen}\n${snapshot.raw}`, snapshot.screen, snapshot.raw]) {
+		for (const content of [snapshot.screen, `${snapshot.screen}\n${snapshot.raw}`, snapshot.raw]) {
 			const parsed = parseCodexStatus(cleanControlOutput(content));
-			if (parsed.main5hLimit || parsed.mainWeeklyLimit) {
+			if (isCompleteCodexStatus(parsed)) {
 				return parsed;
 			}
 		}
@@ -480,15 +476,37 @@ function isCodexPromptReadyOrTrustPrompt(snapshot: { raw: string; screen: string
 	return isCodexPromptReady(snapshot) || isCodexTrustPrompt(snapshot);
 }
 
+function isCodexPromptReadyOrStartupPrompt(snapshot: { raw: string; screen: string }): boolean {
+	return isCodexPromptReadyOrTrustPrompt(snapshot) || isCodexModelMigrationPrompt(snapshot);
+}
+
 function isCodexTrustPrompt(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
 	return /do you trust the contents of this directory/i.test(cleanedOutput);
 }
 
+function isCodexModelMigrationPrompt(snapshot: { screen: string }): boolean {
+	return codexKeepModelSelection(snapshot) != null;
+}
+
+function isCodexPromptReadyOrMigrationPrompt(snapshot: { raw: string; screen: string }): boolean {
+	return isCodexPromptReady(snapshot) || isCodexModelMigrationPrompt(snapshot);
+}
+
+// Raw output retains dismissed dialogs, so migration detection must use the live screen only.
+function codexKeepModelSelection(snapshot: { screen: string }): string | null {
+	const cleanedScreen = cleanControlOutput(snapshot.screen);
+	const match = /(\d+)\.\s*Use existing model/i.exec(cleanedScreen);
+	return match?.[1] ?? null;
+}
+
+function dismissCodexModelMigrationPrompt(snapshot: { screen: string }): string | undefined {
+	return codexKeepModelSelection(snapshot) ?? undefined;
+}
+
 function hasCodexStatusLimits(snapshot: { raw: string; screen: string }): boolean {
 	const cleanedOutput = cleanControlOutput(`${snapshot.screen}\n${snapshot.raw}`);
-	const parsed = parseCodexStatus(cleanedOutput);
-	return Boolean(parsed.main5hLimit && parsed.mainWeeklyLimit);
+	return isCompleteCodexStatus(parseCodexStatus(cleanedOutput));
 }
 
 function hasCodexStatusResponse(snapshot: { raw: string; screen: string }): boolean {
@@ -506,14 +524,12 @@ export function buildCodexUsageResult(
 		command?: string;
 	},
 ): UsageExtractionResult {
-	assertAnyRequiredCodexLimit(parsed);
-	const errors = buildCodexUsageErrors(parsed, context);
+	assertCompleteCodexStatus(parsed);
 	return {
 		targetId: context.targetId,
 		displayName: context.displayName,
 		command: context.command,
 		limits: buildCodexUsageLimits(parsed, context),
-		errors: errors.length > 0 ? errors : undefined,
 	};
 }
 
@@ -528,12 +544,15 @@ export function buildCodexUsageLimits(
 		}
 
 		const percentRemaining = parsePercentRemaining(raw);
+		if (percentRemaining == null) {
+			return [];
+		}
 		return [
 			makeUsageLimit({
 				targetId: context.targetId,
 				scope,
 				window,
-				percentUsed: percentRemaining == null ? null : 100 - percentRemaining,
+				percentUsed: 100 - percentRemaining,
 				percentRemaining,
 				resetText: parseResetText(raw),
 				raw,
@@ -584,8 +603,16 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 			const inlineValue = labelMatch[2].trim();
 
 			if (isCodexSparkLimitLabel(label)) {
-				section = "spark";
-				key = "";
+				const sparkKey = sparkLimitKey(label);
+				if (sparkKey) {
+					key = sparkKey;
+					if (inlineValue) {
+						setValue(values, key, inlineValue);
+					}
+				} else {
+					section = "spark";
+					key = "";
+				}
 				continue;
 			}
 
@@ -616,39 +643,44 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 	};
 }
 
-function assertAnyRequiredCodexLimit(parsed: ParsedCodexStatus): void {
-	if (parsed.main5hLimit || parsed.mainWeeklyLimit) {
-		return;
+function assertCompleteCodexStatus(parsed: ParsedCodexStatus): void {
+	if (!hasParseableCodexMainLimit(parsed)) {
+		throw new Error("Codex usage output did not include any parseable main rate-limit rows.");
 	}
-	throw new Error("Codex usage output did not include the required 5h and weekly limit rows.");
+
+	if (!hasOnlyParseableCodexLimits(parsed)) {
+		throw new Error("Codex usage output included an incomplete rate-limit row.");
+	}
 }
 
-function buildCodexUsageErrors(
-	parsed: ParsedCodexStatus,
-	context: Pick<UsageExtractionContext, "targetId" | "displayName">,
-): NormalizedUsageError[] {
-	const missing: string[] = [];
-	if (!parsed.main5hLimit) {
-		missing.push("5h");
-	}
-	if (!parsed.mainWeeklyLimit) {
-		missing.push("weekly");
-	}
-	if (missing.length === 0) {
-		return [];
-	}
-	return [
-		{
-			targetId: context.targetId,
-			displayName: context.displayName,
-			code: "partial_parse",
-			message: `Codex usage output did not include the ${missing.join(" and ")} limit row.`,
-		},
-	];
+function isCompleteCodexStatus(parsed: ParsedCodexStatus): boolean {
+	return hasParseableCodexMainLimit(parsed) && hasOnlyParseableCodexLimits(parsed);
+}
+
+function hasParseableCodexMainLimit(parsed: ParsedCodexStatus): boolean {
+	return (
+		parsePercentRemaining(parsed.main5hLimit) != null ||
+		parsePercentRemaining(parsed.mainWeeklyLimit) != null
+	);
+}
+
+function hasOnlyParseableCodexLimits(parsed: ParsedCodexStatus): boolean {
+	const limits = CODEX_WINDOWS.map(([, , key]) => parsed[key].trim()).filter(Boolean);
+	return limits.every((limit) => parsePercentRemaining(limit) != null);
 }
 
 function isCodexSparkLimitLabel(label: string): boolean {
 	return /\bspark\b/i.test(label) && /\blimit\b/i.test(label);
+}
+
+function sparkLimitKey(label: string): keyof ParsedCodexStatus | "" {
+	if (/\b5h limit$/i.test(label)) {
+		return "spark5hLimit";
+	}
+	if (/\bweekly limit$/i.test(label)) {
+		return "sparkWeeklyLimit";
+	}
+	return "";
 }
 
 function labelToCodexKey(label: string, section: "main" | "spark"): keyof ParsedCodexStatus | "" {

--- a/src/lib/usage/codex.ts
+++ b/src/lib/usage/codex.ts
@@ -606,9 +606,7 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 				const sparkKey = sparkLimitKey(label);
 				if (sparkKey) {
 					key = sparkKey;
-					if (inlineValue) {
-						setValue(values, key, inlineValue);
-					}
+					setCodexLabeledValue(values, key, label, inlineValue);
 				} else {
 					section = "spark";
 					key = "";
@@ -617,8 +615,8 @@ export function parseCodexStatus(cleanedOutput: string): ParsedCodexStatus {
 			}
 
 			key = labelToCodexKey(label, section);
-			if (key && inlineValue) {
-				setValue(values, key, inlineValue);
+			if (key) {
+				setCodexLabeledValue(values, key, label, inlineValue);
 			}
 			continue;
 		}
@@ -696,6 +694,19 @@ function labelToCodexKey(label: string, section: "main" | "spark"): keyof Parsed
 		return section === "spark" ? "sparkWeeklyLimit" : "mainWeeklyLimit";
 	}
 	return "";
+}
+
+function setCodexLabeledValue(
+	values: Partial<ParsedCodexStatus>,
+	key: keyof ParsedCodexStatus,
+	label: string,
+	inlineValue: string,
+): void {
+	if (inlineValue) {
+		setValue(values, key, inlineValue);
+	} else if (CODEX_WINDOWS.some(([, , limitKey]) => limitKey === key)) {
+		setValue(values, key, `${label}:`);
+	}
 }
 
 function setValue(

--- a/tests/lib/usage/codex-extract.test.ts
+++ b/tests/lib/usage/codex-extract.test.ts
@@ -56,14 +56,10 @@ Weekly limit: 41% left
 				rate_limit: {
 					primary_window: {
 						used_percent: 6,
-						limit_window_seconds: 18_000,
-						reset_at: now.getTime() / 1000 + 30 * 60,
-					},
-					secondary_window: {
-						used_percent: 25,
 						limit_window_seconds: 604_800,
 						reset_at: now.getTime() / 1000 + 7 * 24 * 60 * 60,
 					},
+					secondary_window: null,
 				},
 				additional_rate_limits: [
 					{
@@ -72,12 +68,9 @@ Weekly limit: 41% left
 						rate_limit: {
 							primary_window: {
 								used_percent: 0,
-								limit_window_seconds: 18_000,
-							},
-							secondary_window: {
-								used_percent: 1,
 								limit_window_seconds: 604_800,
 							},
+							secondary_window: null,
 						},
 					},
 				],
@@ -100,12 +93,10 @@ Weekly limit: 41% left
 			}),
 		);
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
-			"main:hourly",
 			"main:weekly",
-			"spark:hourly",
 			"spark:weekly",
 		]);
-		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([6, 25, 0, 1]);
+		expect(result.limits.map((limit) => limit.percentUsed)).toEqual([6, 0]);
 	});
 
 	it("falls back to the TUI probe when the Codex API usage shape is unavailable", async () => {
@@ -143,6 +134,7 @@ Weekly limit: 41% left
 
 		const options = ptyMock.runPtyScenario.mock.calls[0]?.[0];
 		expect(options.cwd).toBe("/Users/tester");
+		expect(options.env).toBeUndefined();
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
 			"main:hourly",
 			"main:weekly",
@@ -152,9 +144,15 @@ Weekly limit: 41% left
 		expect(
 			steps[0].waitFor({ raw: "", screen: "Do you trust the contents of this directory?" }),
 		).toBe(true);
-		expect(steps[1]).toMatchObject({ write: "\r" });
-		expect(steps[1].skipIf({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
-		expect(steps[2].waitFor({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
+		expect(
+			steps[1].write({
+				raw: "",
+				screen: "GPT-5.4 Mini will be deprecated soon\n  2. Use existing model",
+			}),
+		).toBe("2");
+		expect(steps[3]).toMatchObject({ write: "\r" });
+		expect(steps[3].skipIf({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
+		expect(steps[6].waitFor({ raw: "", screen: "gpt-5.5 Context 0% used > " })).toBe(true);
 	});
 
 	async function createCodexHome(): Promise<string> {

--- a/tests/lib/usage/codex-pty-integration.test.ts
+++ b/tests/lib/usage/codex-pty-integration.test.ts
@@ -1,0 +1,274 @@
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { extractCodexUsage } from "../../../src/lib/usage/codex.js";
+import type { UsageExtractionContext } from "../../../src/lib/usage/types.js";
+
+type FakeCodexMode =
+	| "trust-migration"
+	| "migration-trust"
+	| "migration"
+	| "trust"
+	| "incremental-main"
+	| "incremental-spark"
+	| "refresh"
+	| "environment";
+
+// Simulates the Codex startup states and current weekly-only /status output. Numeric migration
+// options submit immediately; any trailing input after the selection deliberately dead-ends.
+const FAKE_CODEX_SCRIPT = String.raw`
+const fs = require("node:fs");
+const path = require("node:path");
+const mode = process.argv[1];
+const expectedCodexHome = process.argv[2];
+const states = {
+	"trust-migration": ["trust", "migration"],
+	"migration-trust": ["migration", "trust"],
+	migration: ["migration"],
+	trust: ["trust"],
+	"incremental-main": [],
+	"incremental-spark": [],
+	refresh: [],
+	environment: [],
+}[mode];
+let state = states.shift() ?? "ready";
+let input = "";
+let statusRequests = 0;
+
+if (mode === "environment") {
+	if (process.env.CODEX_HOME !== expectedCodexHome) {
+		process.stderr.write("CODEX_HOME was replaced.");
+		process.exit(2);
+	}
+	fs.writeFileSync(path.join(expectedCodexHome, "credential-refresh-marker"), "persisted");
+}
+
+function render(content) {
+	process.stdout.write("\x1b[2J\x1b[H" + content);
+}
+
+function renderState() {
+	if (state === "trust") {
+		render("Do you trust the contents of this directory?\r\n> 1. Yes, continue\r\n  2. No, exit");
+	} else if (state === "migration") {
+		render(
+			[
+				"GPT-5.4 Mini will be deprecated soon",
+				"",
+				"Codex now uses GPT-5.6 Luna in place of GPT-5.4 Mini.",
+				"",
+				"› 1. Try new model",
+				"  2. Use existing model",
+			].join("\r\n"),
+		);
+	} else if (state === "ready") {
+		render("› Summarize recent commits\r\n\r\n  gpt-5.4-mini · Context 0% used");
+	}
+}
+
+function renderCompleteStatus(includeSpark = true) {
+	const lines = [
+		"╭────────────────────╮",
+		"│  >_ OpenAI Codex (v0.144.6)",
+		"│",
+		"│  Model:            gpt-5.4-mini (reasoning low)",
+		"│  Directory:        ~",
+		"│  Account:          user@example.com (Pro)",
+		"│",
+		"│  Weekly limit:     [███░] 93% left (resets 13:03 on 28 Jul)",
+	];
+	if (includeSpark) {
+		lines.push(
+			"│  GPT-5.3-Codex-Spark Weekly limit: [████] 100% left (resets 16:38 on 28 Jul)",
+		);
+	}
+	lines.push(
+		"╰────────────────────╯",
+		"",
+		"› Summarize recent commits",
+		"",
+		"  gpt-5.4-mini · Context 0% used",
+	);
+	render(lines.join("\r\n"));
+}
+
+function advance() {
+	state = states.shift() ?? "ready";
+	renderState();
+}
+
+renderState();
+
+process.stdin.setEncoding("utf8");
+process.stdin.setRawMode?.(true);
+process.stdin.resume();
+process.stdin.on("data", (chunk) => {
+	let migrationSelectionHandled = false;
+	for (const character of chunk) {
+		if (migrationSelectionHandled) {
+			render("Unexpected trailing input after model selection.");
+			state = "failed";
+			continue;
+		}
+		if (state === "migration") {
+			if (character === "2") {
+				input = "";
+				advance();
+				migrationSelectionHandled = true;
+			} else {
+				render("Switching to GPT-5.6 Luna...");
+				state = "failed";
+			}
+			continue;
+		}
+		if (character === "\x15") {
+			input = "";
+			continue;
+		}
+		if (character !== "\r" && character !== "\n") {
+			input += character;
+			continue;
+		}
+
+		const entered = input;
+		input = "";
+		if (entered === "/exit") {
+			process.exit(0);
+		}
+		if (state === "trust") {
+			advance();
+			continue;
+		}
+		if (state !== "ready" || entered !== "/status") {
+			continue;
+		}
+
+		statusRequests += 1;
+		if (mode === "refresh" && statusRequests === 1) {
+			render("Model: gpt-5.4-mini\r\nLimits: refresh requested; run /status again shortly.");
+			continue;
+		}
+		if (mode === "incremental-main") {
+			render("Model: gpt-5.4-mini\r\nWeekly limit: [██");
+			setTimeout(() => renderCompleteStatus(false), 1_000);
+			continue;
+		}
+		if (mode === "incremental-spark") {
+			render(
+				"Model: gpt-5.4-mini\r\nWeekly limit: 93% left\r\n" +
+					"GPT-5.3-Codex-Spark Weekly limit: [██",
+			);
+			setTimeout(() => renderCompleteStatus(true), 1_000);
+			continue;
+		}
+		renderCompleteStatus(true);
+	}
+});
+`;
+
+describe("Codex usage PTY integration", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-pty-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it.each([
+		["after trust onboarding", "trust-migration"],
+		["before trust onboarding", "migration-trust"],
+		["without trust onboarding", "migration"],
+		["when only trust onboarding appears", "trust"],
+	] as const)(
+		"handles the model-migration dialog %s",
+		async (_description, mode) => {
+			const result = await extractCodexUsage(buildContext(tempDir, mode));
+
+			expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+				"main:weekly",
+				"spark:weekly",
+			]);
+		},
+		15_000,
+	);
+
+	it("waits for an incrementally rendered main limit", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "incremental-main"));
+
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([93]);
+	}, 15_000);
+
+	it("waits for an incrementally rendered Spark limit", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "incremental-spark"));
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([93, 100]);
+	}, 15_000);
+
+	it("retries status after Codex reports that a refresh was requested", async () => {
+		const result = await extractCodexUsage(buildContext(tempDir, "refresh"));
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+	}, 15_000);
+
+	it("preserves the active CODEX_HOME for fallback credential updates", async () => {
+		const activeCodexHome = path.join(tempDir, "active-codex-home");
+		await mkdir(activeCodexHome, { recursive: true });
+		const originalCodexHome = process.env.CODEX_HOME;
+		process.env.CODEX_HOME = activeCodexHome;
+		try {
+			const result = await extractCodexUsage(buildContext(tempDir, "environment", activeCodexHome));
+
+			expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+				"main:weekly",
+				"spark:weekly",
+			]);
+			expect(await readFile(path.join(activeCodexHome, "credential-refresh-marker"), "utf8")).toBe(
+				"persisted",
+			);
+		} finally {
+			if (originalCodexHome == null) {
+				delete process.env.CODEX_HOME;
+			} else {
+				process.env.CODEX_HOME = originalCodexHome;
+			}
+		}
+	}, 15_000);
+});
+
+function buildContext(
+	homeDir: string,
+	mode: FakeCodexMode,
+	expectedCodexHome = "",
+): UsageExtractionContext {
+	// homeDir has no .codex/auth.json, so extraction falls back to the TUI probe.
+	return {
+		targetId: "codex",
+		displayName: "OpenAI Codex",
+		command: process.execPath,
+		window: "hourly",
+		windows: ["hourly", "weekly"],
+		now: new Date("2026-07-21T12:00:00.000Z"),
+		repoRoot: homeDir,
+		agentsDir: path.join(homeDir, "agents"),
+		homeDir,
+		launch: {
+			command: process.execPath,
+			args: ["--input-type=commonjs", "-e", FAKE_CODEX_SCRIPT, mode, expectedCodexHome],
+			timeoutMs: 12_000,
+		},
+		signal: new AbortController().signal,
+		debug: {
+			enabled: false,
+		},
+	};
+}

--- a/tests/lib/usage/codex-pty-integration.test.ts
+++ b/tests/lib/usage/codex-pty-integration.test.ts
@@ -156,7 +156,7 @@ process.stdin.on("data", (chunk) => {
 		if (mode === "incremental-spark") {
 			render(
 				"Model: gpt-5.4-mini\r\nWeekly limit: 93% left\r\n" +
-					"GPT-5.3-Codex-Spark Weekly limit: [██",
+					"GPT-5.3-Codex-Spark Weekly limit:",
 			);
 			setTimeout(() => renderCompleteStatus(true), 1_000);
 			continue;

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -158,15 +158,80 @@ describe("Codex usage parser", () => {
 		expect(result.limits[1]?.resetAt).toBe("2026-05-25T12:00:00.000Z");
 	});
 
-	it("requires complete main Codex API rate-limit windows", () => {
+	it("builds weekly-only Codex usage limits when the API omits the 5h window", () => {
+		const now = new Date("2026-05-18T12:00:00.000Z");
+		const result = buildCodexApiUsageResult(
+			{
+				rate_limit: {
+					primary_window: {
+						used_percent: 5,
+						limit_window_seconds: 604_800,
+						reset_at: now.getTime() / 1000 + 7 * 24 * 60 * 60,
+					},
+					secondary_window: null,
+				},
+				additional_rate_limits: [
+					{
+						limit_name: "GPT-5.3-Codex-Spark",
+						metered_feature: "codex_bengalfox",
+						rate_limit: {
+							primary_window: {
+								used_percent: 0,
+								limit_window_seconds: 604_800,
+								reset_at: now.getTime() / 1000 + 6 * 24 * 60 * 60,
+							},
+							secondary_window: null,
+						},
+					},
+				],
+			},
+			{
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				command: "codex",
+				now,
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+		expect(result.limits.map((limit) => limit.percentRemaining)).toEqual([95, 100]);
+		expect(result.limits[0]?.resetAt).toBe("2026-05-25T12:00:00.000Z");
+	});
+
+	it("accepts a recognized 5h main API window without a weekly window", () => {
+		const result = buildCodexApiUsageResult(
+			{
+				rate_limit: {
+					primary_window: {
+						used_percent: 6,
+						limit_window_seconds: 18_000,
+					},
+					secondary_window: null,
+				},
+			},
+			{
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				now: new Date("2026-05-18T12:00:00.000Z"),
+			},
+		);
+
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:hourly"]);
+	});
+
+	it("rejects Codex API payloads without a recognized main window", () => {
 		expect(() =>
 			buildCodexApiUsageResult(
 				{
 					rate_limit: {
 						primary_window: {
 							used_percent: 6,
-							limit_window_seconds: 18_000,
+							limit_window_seconds: 3_600,
 						},
+						secondary_window: null,
 					},
 				},
 				{
@@ -175,7 +240,7 @@ describe("Codex usage parser", () => {
 					now: new Date("2026-05-18T12:00:00.000Z"),
 				},
 			),
-		).toThrow("Codex usage API response did not include complete main rate-limit windows.");
+		).toThrow("Codex usage API response did not include any recognized main rate-limit windows.");
 	});
 
 	it("extracts Codex ChatGPT backend auth from auth.json", () => {
@@ -218,6 +283,56 @@ describe("Codex usage parser", () => {
 			mainWeeklyLimit: "41% left (resets May 25 at 9am)",
 			spark5hLimit: "90% left",
 			sparkWeeklyLimit: "60% left (resets May 25)",
+		});
+	});
+
+	it("parses weekly-only status output with an inline Spark row", () => {
+		const parsed = parseCodexStatus(`
+╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.144.6)                                                                    │
+│                                                                                                │
+│  Model:                              gpt-5.4-mini (reasoning low, summaries auto)              │
+│  Directory:                          ~                                                         │
+│  Account:                            user@example.com (Pro)                                    │
+│                                                                                                │
+│  Weekly limit:                       [███████████████████░] 95% left (resets 13:03 on 28 Jul)  │
+│  GPT-5.3-Codex-Spark Weekly limit:   [████████████████████] 100% left (resets 16:38 on 28 Jul) │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+`);
+
+		expect(parsed).toMatchObject({
+			main5hLimit: "",
+			mainWeeklyLimit: "[███████████████████░] 95% left (resets 13:03 on 28 Jul)",
+			spark5hLimit: "",
+			sparkWeeklyLimit: "[████████████████████] 100% left (resets 16:38 on 28 Jul)",
+		});
+
+		const result = buildCodexUsageResult(parsed, {
+			targetId: "codex",
+			displayName: "OpenAI Codex",
+			now: new Date("2026-07-21T12:00:00.000Z"),
+		});
+		expect(result.errors).toBeUndefined();
+		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual([
+			"main:weekly",
+			"spark:weekly",
+		]);
+	});
+
+	it("does not treat an inline Spark row as a section heading", () => {
+		const parsed = parseCodexStatus(`
+╭──────────────────────────╮
+│ Model: gpt-5.4-mini      │
+│ GPT-5.3-Codex-Spark Weekly limit: 100% left
+│ 5h limit: 85% left
+│ Weekly limit: 42% left
+╰──────────────────────────╯
+`);
+
+		expect(parsed).toMatchObject({
+			main5hLimit: "85% left",
+			mainWeeklyLimit: "42% left",
+			sparkWeeklyLimit: "100% left",
 		});
 	});
 
@@ -335,7 +450,7 @@ gpt-5.5 xhigh · Context 0% used
 		expect(limits.map((limit) => limit.percentRemaining)).toEqual([85, 60]);
 	});
 
-	it("returns partial Codex limits with an error when one required main row is missing", () => {
+	it("returns a 5h-only Codex result without a missing-window error", () => {
 		const result = buildCodexUsageResult(
 			{
 				model: "",
@@ -358,17 +473,10 @@ gpt-5.5 xhigh · Context 0% used
 		);
 
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:hourly"]);
-		expect(result.errors).toEqual([
-			{
-				targetId: "codex",
-				displayName: "OpenAI Codex",
-				code: "partial_parse",
-				message: "Codex usage output did not include the weekly limit row.",
-			},
-		]);
+		expect(result.errors).toBeUndefined();
 	});
 
-	it("returns partial Codex weekly limits when the 5h row is missing", () => {
+	it("returns a weekly-only Codex result without a missing-window error", () => {
 		const result = buildCodexUsageResult(
 			{
 				model: "",
@@ -391,12 +499,10 @@ gpt-5.5 xhigh · Context 0% used
 		);
 
 		expect(result.limits.map((limit) => `${limit.scope}:${limit.window}`)).toEqual(["main:weekly"]);
-		expect(result.errors?.[0]?.message).toBe(
-			"Codex usage output did not include the 5h limit row.",
-		);
+		expect(result.errors).toBeUndefined();
 	});
 
-	it("throws when Codex output has no required main limit rows", () => {
+	it("throws when Codex output has no parseable main limit rows", () => {
 		expect(() =>
 			buildCodexUsageResult(
 				{
@@ -418,7 +524,32 @@ gpt-5.5 xhigh · Context 0% used
 					now: new Date("2026-05-18T12:00:00.000Z"),
 				},
 			),
-		).toThrow("Codex usage output did not include the required 5h and weekly limit rows.");
+		).toThrow("Codex usage output did not include any parseable main rate-limit rows.");
+	});
+
+	it("throws when a displayed Codex limit row remains incomplete", () => {
+		expect(() =>
+			buildCodexUsageResult(
+				{
+					model: "",
+					directory: "",
+					permissions: "",
+					agentsMd: "",
+					account: "",
+					collaborationMode: "",
+					session: "",
+					main5hLimit: "",
+					mainWeeklyLimit: "60% left",
+					spark5hLimit: "",
+					sparkWeeklyLimit: "[██",
+				},
+				{
+					targetId: "codex",
+					displayName: "OpenAI Codex",
+					now: new Date("2026-05-18T12:00:00.000Z"),
+				},
+			),
+		).toThrow("Codex usage output included an incomplete rate-limit row.");
 	});
 
 	it("treats Codex time-only resets as local CLI times", () => {

--- a/tests/lib/usage/parsers.test.ts
+++ b/tests/lib/usage/parsers.test.ts
@@ -552,6 +552,23 @@ gpt-5.5 xhigh · Context 0% used
 		).toThrow("Codex usage output included an incomplete rate-limit row.");
 	});
 
+	it("preserves a displayed Codex limit label while its value is still empty", () => {
+		const parsed = parseCodexStatus(`
+Model: gpt-5.4-mini
+Weekly limit: 93% left
+GPT-5.3-Codex-Spark Weekly limit:
+`);
+
+		expect(parsed.sparkWeeklyLimit).toBe("GPT-5.3-Codex-Spark Weekly limit:");
+		expect(() =>
+			buildCodexUsageResult(parsed, {
+				targetId: "codex",
+				displayName: "OpenAI Codex",
+				now: new Date("2026-05-18T12:00:00.000Z"),
+			}),
+		).toThrow("Codex usage output included an incomplete rate-limit row.");
+	});
+
 	it("treats Codex time-only resets as local CLI times", () => {
 		const originalTimeZone = process.env.TZ;
 		process.env.TZ = "America/New_York";


### PR DESCRIPTION
## Summary

- accept independently reported 5-hour or weekly Codex API windows using their exact durations
- parse weekly-only TUI output, including inline Spark limits
- handle trust onboarding and model-migration dialogs in either order without sending trailing input after numeric selections
- keep the active `CODEX_HOME` during TUI fallback so refreshed credentials persist
- wait for every displayed main and Spark rate-limit row to contain a parseable percentage before accepting a snapshot

## Root cause

The extractor assumed that Codex always returned both its 5-hour and weekly main windows.
Current API and TUI responses can report only the weekly window. The fallback startup flow
also did not account for model migration appearing on either side of trust onboarding.
Earlier isolation of the fallback in a temporary `CODEX_HOME` would have discarded credential
refreshes and ignored a configured Codex home.

## Impact

Weekly-only usage responses now produce usable limits instead of falling back or returning
partial-parse errors. TUI fallback tolerates the current startup dialogs and incremental
rendering while preserving the user's active credential location.

## Validation

- `npm run check`
- `npm run typecheck`
- `npm test` — 699 tests passed
- `npm run build`
- `git diff --check`

The added PTY integration coverage exercises trust/migration ordering, migration-only and
trust-only startup, incremental main and Spark rows, refresh retry behavior, and `CODEX_HOME`
preservation.
