### PR TITLE
Add search command for reusing past agent prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,4 +65,5 @@ TypeScript 5.x, Node.js 18+: Enforced by Biome (formatting and linting)
 - Keep ignore and publish rules aligned with tool-specific directories so package publishes stay
   clean.
 - CLI shim E2E docs: `docs/cli-shim-e2e.md`.
+- Specs directories are opt-in; never flag a missing one in code review.
 <!-- MANUAL ADDITIONS END -->

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ omniagent usage --agentsDir ./my-custom-agents
 omniagent usage codex --json
 omniagent usage codex --debug
 
+# Search your past agent conversations and reuse a prompt
+# (opens a picker: arrows to move, type to filter, enter to copy)
+omniagent search merge conflict
+omniagent search "merge conflict"
+omniagent search --project . migration
+omniagent search --role agent exploration
+omniagent search --only codex --since 7d deploy
+
+# Non-interactive, for scripts and agents
+omniagent search merge conflict --copy      # copy the newest match
+omniagent search merge conflict --print 2   # write one result's text to stdout
+omniagent search merge conflict --full --no-interactive
+omniagent search --limit 50 --json refactor
+
 # Shim mode (no subcommand)
 omniagent --agent codex
 omniagent -p "Summarize this repo" --agent codex --output json

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Use the pages below when you need deeper behavior or advanced configuration.
 - Local overrides: [`docs/local-overrides.md`](local-overrides.md)
 - Sync profiles: [`docs/profiles.md`](profiles.md)
 - Templating and dynamic scripts: [`docs/templating.md`](templating.md)
-- Command reference, including `sync`, `usage`, and shim flags: [`docs/reference.md`](reference.md)
+- Command reference, including `sync`, `usage`, `search`, and shim flags: [`docs/reference.md`](reference.md)
 - Troubleshooting: [`docs/troubleshooting.md`](troubleshooting.md)
 
 Contributor/development docs live in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -111,6 +111,109 @@ extract: async (context) => ({
 });
 ```
 
+## Searchable history (`history`)
+
+A target that declares a `history` block becomes searchable by `omniagent search`. Everything
+agent-specific lives here — where transcripts are, what a message looks like, how to get back into
+a session — so adding a new agent never requires changing the search engine.
+
+```ts
+export default {
+  targets: [
+    {
+      id: "demo",
+      displayName: "Demo Agent",
+      history: {
+        // Roles this agent can actually produce. Declared rather than inferred, so asking for a
+        // role it does not record prints a note instead of silently returning nothing.
+        roles: ["user", "assistant"],
+
+        // Enumerate candidate transcripts. Owns all discovery and pruning. Keep it cheap:
+        // readdir/stat, plus at most a small header probe.
+        listFiles: async function* (scope, context) {
+          yield {
+            path: "/absolute/path/to/session.jsonl",
+            projectPath: "/repo/the-session-ran-in",
+            sessionId: "session-id",
+            modifiedAt: new Date().toISOString(),
+            sizeBytes: null,
+          };
+        },
+
+        // One raw line in, one record out, or null to discard. Runs in the hot loop, so it must
+        // be synchronous. This is where every format quirk belongs.
+        normalize: (line, file, index, context) => {
+          const record = JSON.parse(line);
+          if (record.kind !== "prompt") return null;
+          return {
+            agentId: context.targetId,
+            role: "user",
+            timestamp: record.at,
+            text: record.text,
+            sessionId: file.sessionId,
+            cwd: file.projectPath,
+            sourcePath: file.path,
+            recordIndex: index,
+          };
+        },
+
+        // Set `cwd` when the resume verb is directory-scoped; the renderer then emits a `cd`
+        // prefix automatically. Return null for a session that cannot be resumed.
+        resume: (record) => ({
+          command: "demo-cli",
+          args: ["--session", record.sessionId],
+          cwd: null,
+        }),
+      },
+    },
+  ],
+};
+```
+
+### Agents whose history is not line-oriented
+
+`normalize` exists because the engine owns the file loop, which lets it skip the vast majority of
+lines without parsing them. If an agent stores history as a single JSON document, a database, or
+one file per message, declare a custom scan instead and yield records directly. This forgoes the
+fast path but requires no engine change:
+
+```ts
+history: {
+  roles: ["user"],
+  listFiles: async function* () { /* ... */ },
+  scan: {
+    kind: "custom",
+    read: async function* (file, context) {
+      for (const row of JSON.parse(await readFile(file.path, "utf8"))) {
+        yield {
+          agentId: context.targetId,
+          role: "user",
+          timestamp: row.at,
+          text: row.text,
+          sessionId: file.sessionId,
+          cwd: file.projectPath,
+          sourcePath: file.path,
+          recordIndex: row.index,
+        };
+      }
+    },
+  },
+}
+```
+
+### Rules
+
+- `roles` must be a non-empty subset of `user`, `assistant`, `agent`.
+- `listFiles` is required.
+- Define exactly one reader: `normalize` for the line-oriented fast path, or `scan.read` for a
+  custom store. Defining both is rejected; defining neither yields no records.
+- `resume` is optional.
+- `text` must be cleaned and non-empty. Returning `null` from `normalize` is how you discard
+  everything that is not a real message — tool output, harness wrappers, duplicate encodings.
+- `scope` passed to `listFiles` is only a hint. The engine re-applies every project and date
+  filter to each surviving record, so pruning too little is slow but never wrong; pruning too much
+  silently loses results.
+
 ## Structured output (`cli.flags.structuredOutput`)
 
 Custom targets whose CLI supports schema-constrained responses can declare a

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -210,6 +210,10 @@ history: {
 - Define exactly one reader: `normalize` for the line-oriented fast path, or `scan.read` for a
   custom store. Defining both is rejected; defining neither yields no records.
 - `resume` is optional.
+- Every emitted record is runtime-validated: `agentId`, `sessionId`, and `sourcePath` are strings;
+  `role` is `user`, `assistant`, or `agent`; `timestamp` and `cwd` are strings or `null`;
+  `gitBranch` is optional, a string, or `null`; and `recordIndex` is a non-negative integer.
+  Malformed records are skipped and counted in search statistics.
 - `text` must be cleaned and non-empty. Returning `null` from `normalize` is how you discard
   everything that is not a real message — tool output, harness wrappers, duplicate encodings.
 - `scope` passed to `listFiles` is only a hint. The engine re-applies every project and date

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -205,6 +205,8 @@ history: {
 
 - `roles` must be a non-empty subset of `user`, `assistant`, `agent`.
 - `listFiles` is required.
+- `prefilter(line, query)` is optional and must never reject a line whose normalized record could
+  match; omit it unless the raw encoding makes that guarantee possible.
 - Define exactly one reader: `normalize` for the line-oriented fast path, or `scan.read` for a
   custom store. Defining both is rejected; defining neither yields no records.
 - `resume` is optional.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -111,6 +111,91 @@ Failure basics:
 - If no installed active usage-capable agents are found in all-target mode, omniagent prints an
   actionable note and exits successfully.
 
+## Search
+
+```bash
+npx omniagent@latest search merge conflict
+npx omniagent@latest search "merge conflict"
+npx omniagent@latest search merge conflict --copy
+npx omniagent@latest search merge conflict --copy 3
+npx omniagent@latest search merge conflict --print 2
+npx omniagent@latest search merge conflict --full --no-interactive
+npx omniagent@latest search --project . migration
+npx omniagent@latest search --project bt-monorepo rls
+npx omniagent@latest search --role assistant flaky test
+npx omniagent@latest search --role agent exploration
+npx omniagent@latest search --only codex --since 7d deploy
+npx omniagent@latest search --skip codex refactor
+npx omniagent@latest search --regex "TODO\(\w+\)"
+npx omniagent@latest search --limit 50 --json refactor
+```
+
+Searches the conversation transcripts agent CLIs already write to disk so you can find a prompt
+you wrote before and reuse it. The primary path is copying a past message to the clipboard.
+Nothing is launched, nothing is written, and no network request is made — unlike `usage`, no agent
+CLI needs to be installed for its past sessions to be searchable.
+
+### Picking a result
+
+By default, results open in an interactive picker: a list on top, the full text of the highlighted
+match below.
+
+| Key | Action |
+| --- | --- |
+| `↑` / `↓`, `ctrl-p` / `ctrl-n` | Move between results |
+| any character | Filter the results further, in memory, with no re-scan |
+| `enter` | Copy the highlighted message to the clipboard and exit |
+| `ctrl-r` | Copy that session's resume command instead |
+| `esc` | Clear the filter; exit when the filter is already empty |
+| `ctrl-c` | Exit without copying |
+
+Result numbers stay fixed to the unfiltered list, so a number seen while filtering is the same
+number `--copy` and `--print` accept.
+
+### Non-interactive use
+
+The picker is skipped automatically outside a TTY and whenever `--json`, `--copy`, or `--print` is
+passed, so scripts and agents never hit a prompt. `--no-interactive` forces the plain listing.
+
+- `--copy [n]` copies a result and prints a confirmation to stderr. With no number it copies the
+  newest match. If no clipboard helper is available the text is written to stdout instead of being
+  lost, and the command exits 1.
+- `--print [n]` writes only that result's complete message text to stdout — no header, no excerpt,
+  no resume line — so `omniagent search deploy --print | pbcopy` works and an agent gets clean
+  input.
+- `--full` prints every match's complete text instead of a one-line excerpt.
+- `--json` carries full text in `matches[].text` with newlines preserved, so
+  `omniagent search deploy --json | jq -r '.matches[0].text'` round-trips a prompt verbatim.
+- Put the query before `--copy` / `--print`. `search --copy merge conflict` would otherwise consume
+  a search term as the index; that case is rejected with a message naming the fix.
+
+- Command surface: `search [query..]` with `--role`, `--project`, `--only`, `--skip`, `--since`,
+  `--until`, `--limit`, `--case-sensitive`, `--regex`, `--full`, `--copy`, `--print`,
+  `--no-interactive`, `--agentsDir`, and `--json`.
+- Query behavior: matching is case-insensitive by default. Each argument is a separate term and
+  all terms must match, so `search merge conflict` also finds "conflict during the merge". Quote a
+  phrase to match it exactly: `search "merge conflict"`.
+- Role behavior: `--role user` (the default) returns only what you typed. `assistant` returns
+  agent replies, `agent` returns subagent transcripts, and `all` spans everything. Agents declare
+  which roles they record; requesting one an agent cannot produce prints a note rather than
+  silently returning nothing.
+- Scope behavior: every project is searched by default. `--project` accepts either a path or a
+  name fragment — a value that looks like a path (`.`, `./x`, `~/x`, `/x`) is resolved and scoped
+  to the repository containing it, so `--project .` means "this repository"; anything else matches
+  the project path as a case-insensitive substring.
+- Target behavior: `--only` and `--skip` accept comma-separated target ids or aliases and are
+  mutually exclusive. Only agents that declare a `history` capability are searchable.
+- Result order is newest first. `--limit` defaults to 20 and applies after ordering; pass
+  `--limit 0` for no limit.
+- Each hit in the plain listing is numbered and prints a resume command, prefixed with `cd` when
+  the session belongs to another directory, so it can be pasted as-is.
+- Notes and warnings go to stderr in both modes, keeping stdout a clean, pipeable result list.
+- Zero matches is a successful result and exits 0. Invalid flag values exit 2. An invalid agents
+  directory, invalid target configuration, or an agent named in `--only` with no history to search
+  exits 1. Interrupting a search exits 130.
+- Transcripts can contain secrets you pasted into a session. Human output shows only a window
+  around the match, but `--json` includes full message text.
+
 ## Shim
 
 ```bash

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -186,7 +186,7 @@ passed, so scripts and agents never hit a prompt. `--no-interactive` forces the 
 - Target behavior: `--only` and `--skip` accept comma-separated target ids or aliases and are
   mutually exclusive. Only agents that declare a `history` capability are searchable.
 - Result order is newest first. `--limit` defaults to 20 and applies after ordering; pass
-  `--limit 0` for no limit.
+  `--limit 0` to use the 10,000-result safety cap.
 - Each hit in the plain listing is numbered and prints a resume command, prefixed with `cd` when
   the session belongs to another directory, so it can be pasted as-is.
 - Notes and warnings go to stderr in both modes, keeping stdout a clean, pipeable result list.

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,0 +1,630 @@
+import os from "node:os";
+import path from "node:path";
+import type { CommandModule } from "yargs";
+import { DEFAULT_AGENTS_DIR, resolveAgentsDir, validateAgentsDir } from "../../lib/agents-dir.js";
+import { ClipboardError, copyToClipboard } from "../../lib/history/clipboard.js";
+import {
+	expandHome,
+	InvalidFilterError,
+	isPathLikeProject,
+	parseWhen,
+} from "../../lib/history/filters.js";
+import {
+	buildSearchEnvelope,
+	formatSearchSummary,
+	formatTimestamp,
+	shouldUseColor,
+} from "../../lib/history/format.js";
+import { runPicker } from "../../lib/history/picker.js";
+import { compileQuery, InvalidQueryError } from "../../lib/history/query.js";
+import { searchHistory } from "../../lib/history/search.js";
+import {
+	HISTORY_ROLES,
+	type HistoryRole,
+	isHistoryRole,
+	type SearchMatch,
+	type SearchNote,
+	type SearchScope,
+} from "../../lib/history/types.js";
+import { findRepoRoot } from "../../lib/repo-root.js";
+import { buildSupportedTargetLabel } from "../../lib/supported-targets.js";
+import { createTargetNameResolver, resolveEffectiveTargets } from "../../lib/sync-targets.js";
+import {
+	BUILTIN_TARGETS,
+	loadTargetConfig,
+	type ResolvedTarget,
+	resolveTargets,
+	validateTargetConfig,
+} from "../../lib/targets/index.js";
+
+type SearchArgs = {
+	query?: Array<string | number>;
+	role?: string;
+	project?: string;
+	only?: string | string[];
+	skip?: string | string[];
+	since?: string;
+	until?: string;
+	limit?: number;
+	caseSensitive?: boolean;
+	regex?: boolean;
+	agentsDir?: string;
+	json?: boolean;
+	interactive?: boolean;
+	copy?: number | boolean | string;
+	print?: number | boolean | string;
+	full?: boolean;
+	"--"?: Array<string | number>;
+};
+
+const DEFAULT_LIMIT = 20;
+
+/** Same comma-or-repeat handling `sync` and `usage` use for target lists. */
+function parseList(value?: string | string[]): string[] {
+	if (!value) {
+		return [];
+	}
+	const raw = Array.isArray(value) ? value : [value];
+	return raw
+		.flatMap((entry) => entry.split(","))
+		.map((entry) => entry.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+function printError(options: {
+	json: boolean;
+	code: string;
+	message: string;
+	exitCode: number;
+}): void {
+	if (options.json) {
+		console.log(
+			JSON.stringify(
+				{
+					schemaVersion: 1,
+					matches: [],
+					errors: [{ targetId: "", displayName: "", code: options.code, message: options.message }],
+					notes: [],
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		console.error(`Error: ${options.message}`);
+	}
+	process.exit(options.exitCode);
+}
+
+/**
+ * Notes always go to stderr, in both modes — a deliberate divergence from `sync`'s
+ * `logWithChannel`. stdout is the pipeable result list, and a warning in the middle of it
+ * would break `| head`, `| fzf`, or `| pbcopy`.
+ */
+function emitNotes(notes: SearchNote[]): void {
+	const useColor = shouldUseColor();
+	for (const note of notes) {
+		const line = `Note: ${note.message}`;
+		console.error(useColor ? `\x1b[2m${line}\x1b[0m` : line);
+	}
+}
+
+/**
+ * Resolves a 1-based result number for --copy / --print. A bare flag means "the newest match".
+ * yargs yields NaN when the flag swallowed a query word (`--copy merge conflict`), so that case
+ * fails loudly with a message that names the fix instead of silently acting on the wrong result.
+ */
+function resolveIndex(
+	value: number | boolean | string | undefined,
+	count: number,
+	json: boolean,
+	flag: string,
+): number | null {
+	if (count === 0) {
+		printError({ json, code: "no_matches", message: "No matches to select from.", exitCode: 2 });
+		return null;
+	}
+	// A bare flag means "the newest match".
+	if (value === undefined || value === true) {
+		return 1;
+	}
+	if (typeof value !== "number" || !Number.isInteger(value)) {
+		printError({
+			json,
+			code: `invalid_${flag}_index`,
+			message: `--${flag} expects a result number. Put the query before the flag, for example: omniagent search merge conflict --${flag} 2.`,
+			exitCode: 2,
+		});
+		return null;
+	}
+	if (value < 1 || value > count) {
+		printError({
+			json,
+			code: "index_out_of_range",
+			message: `--${flag} ${value} is out of range; ${count} match${count === 1 ? "" : "es"} available.`,
+			exitCode: 2,
+		});
+		return null;
+	}
+	return value;
+}
+
+function writeText(match: SearchMatch): void {
+	process.stdout.write(match.text.endsWith("\n") ? match.text : `${match.text}\n`);
+}
+
+function describeMatch(match: SearchMatch): string {
+	return [match.agentId, match.project, formatTimestamp(match.timestamp)]
+		.filter((part): part is string => Boolean(part))
+		.join(" · ");
+}
+
+/**
+ * Copies to the clipboard, and on failure prints the value to stdout instead — losing the text
+ * because a helper binary is missing would defeat the point of the command.
+ */
+async function copyValue(value: string, label: string, match: SearchMatch): Promise<boolean> {
+	try {
+		await copyToClipboard(value);
+	} catch (error) {
+		console.error(`Error: ${error instanceof ClipboardError ? error.message : String(error)}`);
+		console.error("Printing it instead:");
+		process.stdout.write(value.endsWith("\n") ? value : `${value}\n`);
+		return false;
+	}
+	const useColor = shouldUseColor();
+	const check = useColor ? "\x1b[32m✓\x1b[0m" : "✓";
+	console.error(`${check} Copied ${label} (${value.length} chars) to clipboard`);
+	console.error(useColor ? `\x1b[2m  ${describeMatch(match)}\x1b[0m` : `  ${describeMatch(match)}`);
+	return true;
+}
+
+async function runSearchCommand(argv: SearchArgs): Promise<void> {
+	const jsonOutput = argv.json === true;
+
+	// yargs sends anything after `--` to argv["--"], which is how a leading-dash query is typed.
+	const pieces = [...(argv.query ?? []), ...(argv["--"] ?? [])].map((value) => String(value));
+	if (pieces.length === 0) {
+		printError({
+			json: jsonOutput,
+			code: "missing_query",
+			message: 'Provide a search query. Example: omniagent search "merge conflict".',
+			exitCode: 2,
+		});
+		return;
+	}
+
+	// Validated by hand rather than with yargs `choices:`, whose failures route through the root
+	// .fail() handler and would exit 1 without a JSON envelope.
+	const roleInput = (argv.role ?? "user").trim().toLowerCase();
+	let roles: HistoryRole[];
+	if (roleInput === "all") {
+		roles = [...HISTORY_ROLES];
+	} else if (isHistoryRole(roleInput)) {
+		roles = [roleInput];
+	} else {
+		printError({
+			json: jsonOutput,
+			code: "invalid_role",
+			message: `--role must be one of: ${HISTORY_ROLES.join(", ")}, all.`,
+			exitCode: 2,
+		});
+		return;
+	}
+
+	const limit = argv.limit ?? DEFAULT_LIMIT;
+	if (!Number.isInteger(limit) || limit < 0) {
+		printError({
+			json: jsonOutput,
+			code: "invalid_limit",
+			message: "--limit must be a non-negative integer. Use 0 for no limit.",
+			exitCode: 2,
+		});
+		return;
+	}
+
+	let since: Date | null = null;
+	let until: Date | null = null;
+	try {
+		if (argv.since) {
+			since = parseWhen(argv.since, { flag: "--since" });
+		}
+		if (argv.until) {
+			until = parseWhen(argv.until, { flag: "--until", endOfDay: true });
+		}
+	} catch (error) {
+		if (error instanceof InvalidFilterError) {
+			printError({ json: jsonOutput, code: error.code, message: error.message, exitCode: 2 });
+			return;
+		}
+		throw error;
+	}
+	if (since && until && since.getTime() > until.getTime()) {
+		printError({
+			json: jsonOutput,
+			code: "invalid_range",
+			message: "--since must be before --until.",
+			exitCode: 2,
+		});
+		return;
+	}
+
+	const onlyTargets = parseList(argv.only);
+	const skipTargets = parseList(argv.skip);
+	if (onlyTargets.length > 0 && skipTargets.length > 0) {
+		printError({
+			json: jsonOutput,
+			code: "conflicting_target_selection",
+			message: "Use either --only or --skip, not both.",
+			exitCode: 2,
+		});
+		return;
+	}
+
+	let query: ReturnType<typeof compileQuery>;
+	try {
+		query = compileQuery(pieces, { regex: argv.regex === true, caseSensitive: argv.caseSensitive });
+	} catch (error) {
+		if (error instanceof InvalidQueryError) {
+			printError({ json: jsonOutput, code: error.code, message: error.message, exitCode: 2 });
+			return;
+		}
+		throw error;
+	}
+
+	const startDir = process.cwd();
+	const repoRoot = (await findRepoRoot(startDir)) ?? startDir;
+	const agentsDirResolution = resolveAgentsDir(repoRoot, argv.agentsDir);
+	if (agentsDirResolution.source === "override") {
+		const validation = await validateAgentsDir(repoRoot, argv.agentsDir, { requireWrite: false });
+		if (validation.validationStatus !== "valid") {
+			printError({
+				json: jsonOutput,
+				code: "invalid_agents_dir",
+				message: validation.errorMessage,
+				exitCode: 1,
+			});
+			return;
+		}
+	}
+	const agentsDir = agentsDirResolution.resolvedPath;
+	const homeDir = os.homedir();
+
+	const { config } = await loadTargetConfig({ repoRoot, agentsDir });
+	const configValidation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+	if (!configValidation.valid) {
+		printError({
+			json: jsonOutput,
+			code: "invalid_target_config",
+			message: `Invalid target configuration:\n- ${configValidation.errors.join("\n- ")}`,
+			exitCode: 1,
+		});
+		return;
+	}
+
+	const resolved = resolveTargets({ config: configValidation.config, builtIns: BUILTIN_TARGETS });
+	const searchable = resolved.targets.filter((target) => target.history);
+	const supportedLabel = `Searchable targets: ${buildSupportedTargetLabel(searchable)}.`;
+	const resolver = createTargetNameResolver(resolved.targets);
+
+	const explicitNames = onlyTargets.length > 0 ? onlyTargets : skipTargets;
+	const unknown = explicitNames.filter((name) => !resolver.resolveTargetName(name));
+	if (unknown.length > 0) {
+		printError({
+			json: jsonOutput,
+			code: "unknown_target",
+			message: `Unknown target name(s): ${unknown.join(", ")}. ${supportedLabel}`,
+			exitCode: 2,
+		});
+		return;
+	}
+
+	const onlyIds = onlyTargets.map((name) => resolver.resolveTargetName(name) as string);
+	const skipIds = skipTargets.map((name) => resolver.resolveTargetName(name) as string);
+	const unsupported = onlyIds.filter((id) => !resolved.byId.get(id.toLowerCase())?.history);
+	if (unsupported.length > 0) {
+		printError({
+			json: jsonOutput,
+			code: "history_unsupported",
+			message: `${unsupported.join(", ")} does not record searchable history. ${supportedLabel}`,
+			exitCode: 2,
+		});
+		return;
+	}
+
+	const selectedIds = resolveEffectiveTargets({
+		defaultTargets: null,
+		overrideOnly: onlyIds.length > 0 ? onlyIds : null,
+		overrideSkip: skipIds.length > 0 ? skipIds : null,
+		allTargets: searchable.map((target) => target.id),
+	});
+	const selected = selectedIds.flatMap((id) => {
+		const target = resolved.byId.get(id.toLowerCase());
+		return target?.history ? [target] : [];
+	}) as ResolvedTarget[];
+	if (selected.length === 0) {
+		printError({
+			json: jsonOutput,
+			code: "no_search_targets",
+			message: `No history-capable targets are enabled. ${supportedLabel}`,
+			exitCode: 2,
+		});
+		return;
+	}
+
+	const scope: SearchScope = { projectPath: null, projectMatch: null, since, until };
+	if (argv.project) {
+		if (isPathLikeProject(argv.project)) {
+			// A location: resolve it, then scope to the repository containing it, so
+			// `--project .` from anywhere inside a repo means "this project".
+			const absolute = path.resolve(startDir, expandHome(argv.project, homeDir));
+			scope.projectPath = (await findRepoRoot(absolute)) ?? absolute;
+		} else {
+			scope.projectMatch = argv.project;
+		}
+	}
+
+	const controller = new AbortController();
+	const onInterrupt = () => controller.abort();
+	process.once("SIGINT", onInterrupt);
+
+	let result: Awaited<ReturnType<typeof searchHistory>>;
+	try {
+		result = await searchHistory({
+			targets: selected,
+			query,
+			scope,
+			roles: new Set(roles),
+			limit,
+			homeDir,
+			cwd: startDir,
+			signal: controller.signal,
+		});
+	} finally {
+		process.removeListener("SIGINT", onInterrupt);
+	}
+
+	if (controller.signal.aborted) {
+		console.error("Search cancelled.");
+		process.exit(130);
+		return;
+	}
+
+	const notes = [...result.notes];
+	if (result.stats.skippedFiles > 0) {
+		// Aggregated deliberately: a live session leaves a torn trailing record on every run, so
+		// per-file warnings would fire constantly and train people to ignore stderr.
+		notes.push({
+			targetId: "",
+			displayName: "",
+			code: "unreadable_files",
+			message: `Skipped ${result.stats.skippedFiles} unreadable history file(s).`,
+		});
+	}
+
+	const envelope = buildSearchEnvelope({
+		hits: result.hits,
+		stats: result.stats,
+		errors: result.errors,
+		notes,
+		query,
+		roles,
+		targets: selected.map((target) => target.id),
+		projectPath: scope.projectPath,
+		projectMatch: scope.projectMatch,
+		since,
+		until,
+		cwd: startDir,
+		homeDir,
+		generatedAt: new Date().toISOString(),
+	});
+
+	emitNotes(notes);
+
+	// An explicitly requested agent that produced nothing is a failure; the same silence across
+	// all agents is just an empty result.
+	const explicitlyEmpty =
+		onlyIds.length > 0 &&
+		result.notes.some(
+			(note) => note.code === "history_unavailable" && onlyIds.includes(note.targetId),
+		);
+	const failed = result.errors.length > 0 || explicitlyEmpty;
+	const matches = envelope.matches;
+
+	// --print emits only the message text, so an agent or a pipe gets something clean to consume.
+	if (argv.print !== undefined) {
+		const index = resolveIndex(argv.print, matches.length, jsonOutput, "print");
+		if (index === null) {
+			return;
+		}
+		writeText(matches[index - 1] as SearchMatch);
+		if (failed) {
+			process.exit(1);
+		}
+		return;
+	}
+
+	const wantsCopy = argv.copy !== undefined;
+	// Interactive is the default, but only where it can actually work and where nothing else has
+	// already declared a non-interactive intent.
+	const interactive =
+		argv.interactive !== false &&
+		!jsonOutput &&
+		!wantsCopy &&
+		matches.length > 0 &&
+		Boolean(process.stdin.isTTY) &&
+		Boolean(process.stdout.isTTY);
+
+	if (interactive) {
+		const outcome = await runPicker(
+			matches,
+			{ input: process.stdin, output: process.stdout, useColor: shouldUseColor() },
+			{ query: envelope.query.raw },
+		);
+		if (outcome.type === "copy-text") {
+			const ok = await copyValue(outcome.match.text, "message", outcome.match);
+			if (!ok) {
+				process.exit(1);
+			}
+		} else if (outcome.type === "copy-resume") {
+			const command = outcome.match.resumeCommand;
+			if (command) {
+				const ok = await copyValue(command, "resume command", outcome.match);
+				if (!ok) {
+					process.exit(1);
+				}
+			} else {
+				console.error("Note: that session has no resume command.");
+			}
+		}
+		if (failed) {
+			process.exit(1);
+		}
+		return;
+	}
+
+	if (wantsCopy) {
+		if (matches.length === 0) {
+			console.log(formatSearchSummary(envelope, jsonOutput, { full: argv.full === true }));
+			return;
+		}
+		const index = resolveIndex(argv.copy, matches.length, jsonOutput, "copy");
+		if (index === null) {
+			return;
+		}
+		const match = matches[index - 1] as SearchMatch;
+		const ok = await copyValue(match.text, "message", match);
+		if (!ok || failed) {
+			process.exit(1);
+		}
+		return;
+	}
+
+	console.log(formatSearchSummary(envelope, jsonOutput, { full: argv.full === true }));
+
+	if (failed) {
+		process.exit(1);
+	}
+}
+
+export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
+	command: "search [query..]",
+	describe: "Search past agent conversations across projects",
+	builder: (yargs) =>
+		yargs
+			.usage(
+				"omniagent search <query..> [--role <role>] [--project <path|substring>] " +
+					"[--only <targets>] [--skip <targets>] [--since <when>] [--until <when>] " +
+					"[--limit <n>] [--case-sensitive] [--regex] [--full] [--copy [n]] [--print [n]] " +
+					"[--no-interactive] [--agentsDir <path>] [--json]",
+			)
+			.positional("query", {
+				type: "string",
+				array: true,
+				describe: "Search terms. All terms must match; quote a phrase to match it exactly.",
+			})
+			.option("role", {
+				type: "string",
+				default: "user",
+				describe: "Which messages to search (user, assistant, agent, all)",
+			})
+			.option("project", {
+				type: "string",
+				describe:
+					"Scope to a project. A path (., ./x, ~/x, /x) scopes to the repository containing " +
+					"it; anything else matches the project path as a substring.",
+			})
+			.option("only", {
+				type: "string",
+				describe: "Comma-separated targets to search",
+			})
+			.option("skip", {
+				type: "string",
+				describe: "Comma-separated targets to exclude from the search",
+			})
+			.option("since", {
+				type: "string",
+				describe:
+					"Only match messages at or after this time (YYYY-MM-DD, ISO timestamp, or 7d/24h/30m)",
+			})
+			.option("until", {
+				type: "string",
+				describe:
+					"Only match messages at or before this time (YYYY-MM-DD, ISO timestamp, or 7d/24h/30m)",
+			})
+			.option("limit", {
+				type: "number",
+				default: DEFAULT_LIMIT,
+				describe: "Maximum matches to print, newest first (0 for no limit)",
+			})
+			.option("case-sensitive", {
+				type: "boolean",
+				default: false,
+				describe: "Match case exactly instead of case-insensitively",
+			})
+			.option("regex", {
+				type: "boolean",
+				default: false,
+				describe: "Treat the query as a regular expression (requires a single quoted pattern)",
+			})
+			.option("agentsDir", {
+				type: "string",
+				describe:
+					"Override the agents directory (relative paths resolve from the project root, or the current directory outside a repo)",
+				defaultDescription: DEFAULT_AGENTS_DIR,
+				coerce: (value) => {
+					if (typeof value !== "string") {
+						return value;
+					}
+					const trimmed = value.trim();
+					return trimmed.length > 0 ? trimmed : undefined;
+				},
+			})
+			.option("interactive", {
+				type: "boolean",
+				default: true,
+				describe:
+					"Open the result picker. On by default; use --no-interactive for plain output. " +
+					"Automatically disabled outside a TTY and with --json, --copy, or --print.",
+			})
+			.option("copy", {
+				describe:
+					"Copy a result to the clipboard without opening the picker. Defaults to the newest match; pass a result number to choose another.",
+			})
+			.option("print", {
+				describe:
+					"Write only a result's full message text to stdout. Defaults to the newest match.",
+			})
+			.option("full", {
+				type: "boolean",
+				default: false,
+				describe: "Print each match's complete text instead of a one-line excerpt",
+			})
+			.option("json", {
+				type: "boolean",
+				default: false,
+				describe: "Print a stable JSON envelope.",
+			})
+			.epilog(
+				"Reads agent transcripts directly from disk. No agent CLI is launched, nothing is " +
+					"written, and no network request is made.\n" +
+					"Multiple terms are ANDed; quote a phrase to match it exactly.\n" +
+					"Transcripts may contain secrets you pasted; --json prints full message text.",
+			)
+			.example("omniagent search merge conflict", "Open the picker and copy a past prompt")
+			.example("omniagent search merge conflict --copy", "Copy the newest match, no picker")
+			.example("omniagent search merge conflict --copy 3", "Copy the third result")
+			.example("omniagent search merge conflict --print 2", "Write one result's text to stdout")
+			.example("omniagent search merge conflict --full", "Show complete text for every match")
+			.example('omniagent search "merge conflict"', "Match the exact phrase")
+			.example("omniagent search --project . migration", "Search only this repository")
+			.example("omniagent search --project bt-monorepo rls", "Filter by project path substring")
+			.example("omniagent search --role assistant flaky test", "Search agent replies, not prompts")
+			.example("omniagent search --role agent exploration", "Search subagent transcripts")
+			.example("omniagent search --only codex --since 7d deploy", "One agent, last week only")
+			.example('omniagent search --regex "TODO\\(\\w+\\)"', "Match with a regular expression")
+			.example("omniagent search --limit 50 --json refactor", "Emit machine-readable results"),
+	handler: async (argv) => {
+		await runSearchCommand(argv);
+	},
+};

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -11,8 +11,10 @@ import {
 } from "../../lib/history/filters.js";
 import {
 	buildSearchEnvelope,
+	collapseText,
 	formatSearchSummary,
 	formatTimestamp,
+	sanitizeTerminalText,
 	shouldUseColor,
 } from "../../lib/history/format.js";
 import { runPicker } from "../../lib/history/picker.js";
@@ -91,7 +93,7 @@ function printError(options: {
 			),
 		);
 	} else {
-		console.error(`Error: ${options.message}`);
+		console.error(`Error: ${sanitizeTerminalText(options.message)}`);
 	}
 	process.exit(options.exitCode);
 }
@@ -104,7 +106,7 @@ function printError(options: {
 function emitNotes(notes: SearchNote[]): void {
 	const useColor = shouldUseColor();
 	for (const note of notes) {
-		const line = `Note: ${note.message}`;
+		const line = `Note: ${sanitizeTerminalText(note.message)}`;
 		console.error(useColor ? `\x1b[2m${line}\x1b[0m` : line);
 	}
 }
@@ -156,6 +158,7 @@ function writeText(match: SearchMatch): void {
 function describeMatch(match: SearchMatch): string {
 	return [match.agentId, match.project, formatTimestamp(match.timestamp)]
 		.filter((part): part is string => Boolean(part))
+		.map(collapseText)
 		.join(" · ");
 }
 
@@ -486,6 +489,9 @@ async function runSearchCommand(argv: SearchArgs): Promise<void> {
 	if (wantsCopy) {
 		if (matches.length === 0) {
 			console.log(formatSearchSummary(envelope, jsonOutput, { full: argv.full === true }));
+			if (failed) {
+				process.exit(1);
+			}
 			return;
 		}
 		const index = resolveIndex(argv.copy, matches.length, jsonOutput, "copy");

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -220,7 +220,7 @@ async function runSearchCommand(argv: SearchArgs): Promise<void> {
 		printError({
 			json: jsonOutput,
 			code: "invalid_limit",
-			message: "--limit must be a non-negative integer. Use 0 for no limit.",
+			message: "--limit must be a non-negative integer. Use 0 for the 10,000-result cap.",
 			exitCode: 2,
 		});
 		return;
@@ -561,7 +561,7 @@ export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
 			.option("limit", {
 				type: "number",
 				default: DEFAULT_LIMIT,
-				describe: "Maximum matches to print, newest first (0 for no limit)",
+				describe: "Maximum matches to print, newest first (0 uses the 10,000-result cap)",
 			})
 			.option("case-sensitive", {
 				type: "boolean",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { echoCommand } from "./commands/echo.js";
 import { greetCommand } from "./commands/greet.js";
 import { helloCommand } from "./commands/hello.js";
 import { profilesCommand } from "./commands/profiles.js";
+import { searchCommand } from "./commands/search.js";
 import { syncCommand } from "./commands/sync.js";
 import { usageCommand } from "./commands/usage.js";
 import { runShim } from "./shim/index.js";
@@ -36,7 +37,16 @@ function resolveVersion(): string {
 }
 
 const VERSION = resolveVersion();
-const KNOWN_COMMANDS = new Set(["hello", "greet", "echo", "sync", "dev", "profiles", "usage"]);
+const KNOWN_COMMANDS = new Set([
+	"hello",
+	"greet",
+	"echo",
+	"sync",
+	"dev",
+	"profiles",
+	"usage",
+	"search",
+]);
 const SHIM_CAPABILITIES = [
 	"Capabilities by agent:",
 	"  codex: approval, sandbox, output, model, web, output-schema",
@@ -118,6 +128,7 @@ export function runCli(argv = process.argv, options: RunCliOptions = {}) {
 		.command(devCommand)
 		.command(profilesCommand)
 		.command(usageCommand)
+		.command(searchCommand)
 		.command(
 			"$0",
 			"omniagent CLI",

--- a/src/lib/history/bounded-top-k.ts
+++ b/src/lib/history/bounded-top-k.ts
@@ -1,0 +1,88 @@
+export type BoundedTopKOffer = {
+	retained: boolean;
+	discarded: boolean;
+};
+
+/**
+ * Retains the best values according to an Array.sort-style comparator. The least-preferred
+ * retained value stays at the root so each new candidate costs O(log capacity) at worst.
+ */
+export class BoundedTopK<T> {
+	readonly capacity: number;
+	readonly #compare: (a: T, b: T) => number;
+	readonly #items: T[] = [];
+
+	constructor(capacity: number, compare: (a: T, b: T) => number) {
+		if (!Number.isInteger(capacity) || capacity <= 0) {
+			throw new RangeError("BoundedTopK capacity must be a positive integer.");
+		}
+		this.capacity = capacity;
+		this.#compare = compare;
+	}
+
+	get size(): number {
+		return this.#items.length;
+	}
+
+	offer(value: T): BoundedTopKOffer {
+		if (this.#items.length < this.capacity) {
+			this.#items.push(value);
+			this.#siftUp(this.#items.length - 1);
+			return { retained: true, discarded: false };
+		}
+
+		const worst = this.#items[0] as T;
+		if (this.#compare(value, worst) >= 0) {
+			return { retained: false, discarded: true };
+		}
+
+		this.#items[0] = value;
+		this.#siftDown(0);
+		return { retained: true, discarded: true };
+	}
+
+	toSortedArray(): T[] {
+		return [...this.#items].sort(this.#compare);
+	}
+
+	#siftUp(start: number): void {
+		let index = start;
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (this.#compare(this.#items[index] as T, this.#items[parent] as T) <= 0) {
+				return;
+			}
+			this.#swap(index, parent);
+			index = parent;
+		}
+	}
+
+	#siftDown(start: number): void {
+		let index = start;
+		for (;;) {
+			const left = index * 2 + 1;
+			if (left >= this.#items.length) {
+				return;
+			}
+
+			const right = left + 1;
+			let worse = left;
+			if (
+				right < this.#items.length &&
+				this.#compare(this.#items[right] as T, this.#items[left] as T) > 0
+			) {
+				worse = right;
+			}
+
+			if (this.#compare(this.#items[worse] as T, this.#items[index] as T) <= 0) {
+				return;
+			}
+			this.#swap(index, worse);
+			index = worse;
+		}
+	}
+
+	#swap(left: number, right: number): void {
+		[this.#items[left], this.#items[right]] = [this.#items[right] as T, this.#items[left] as T];
+	}
+}

--- a/src/lib/history/claude.ts
+++ b/src/lib/history/claude.ts
@@ -1,6 +1,7 @@
 import type { Dirent, Stats } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import { type HistoryQuery, prefilterJsonLine } from "./query.js";
 import type {
 	HistoryContext,
 	HistoryFile,
@@ -209,6 +210,11 @@ export function cleanClaudeText(raw: string): string {
 		return "";
 	}
 	return stripped;
+}
+
+export function prefilterClaudeLine(line: string, query: HistoryQuery): boolean {
+	// Removing a reminder can join text that was not contiguous in the raw JSON line.
+	return line.includes("<system-reminder>") || prefilterJsonLine(query, line);
 }
 
 export function normalizeClaudeLine(

--- a/src/lib/history/claude.ts
+++ b/src/lib/history/claude.ts
@@ -1,0 +1,275 @@
+import type { Dirent, Stats } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import type {
+	HistoryContext,
+	HistoryFile,
+	HistoryResume,
+	HistoryRole,
+	SearchRecord,
+	SearchScope,
+} from "./types.js";
+
+const SUBAGENTS_DIR = "subagents";
+const TRANSCRIPT_EXTENSION = ".jsonl";
+
+const SYSTEM_REMINDER = /<system-reminder>[\s\S]*?<\/system-reminder>/g;
+const LEADING_TAG = /^<([a-zA-Z][\w-]*)>/;
+
+/**
+ * Wrapper tags Claude writes into user-role records that are not something the human typed.
+ * Derived by scanning a real corpus, not guessed — `task-notification` alone accounts for more
+ * noise than every other tag combined.
+ */
+const SUPPRESSED_TAGS = new Set([
+	"bash-input",
+	"bash-stderr",
+	"bash-stdout",
+	"command-args",
+	"command-message",
+	"command-name",
+	"local-command-caveat",
+	"local-command-stderr",
+	"local-command-stdout",
+	"user-prompt-submit-hook",
+	"task-notification",
+]);
+
+export function resolveClaudeProjectsDir(
+	homeDir: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const override = env.CLAUDE_CONFIG_DIR?.trim();
+	const base = override && override.length > 0 ? override : path.join(homeDir, ".claude");
+	return path.join(base, "projects");
+}
+
+/**
+ * Claude names each project directory after the session cwd with every non-alphanumeric
+ * character replaced by a hyphen. Verified against every project directory in a real install.
+ */
+export function slugifyProjectPath(absolutePath: string): string {
+	return absolutePath.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
+ * Always slugify forward and compare; never try to reverse a slug, which is ambiguous
+ * (`-a-b-c` could be `/a/b/c` or `/a/b-c`). The trailing-hyphen guard is what stops repo
+ * `/a/b/foo` from swallowing `/a/b/foobar`, while still matching sessions started in a
+ * subdirectory of the repo.
+ */
+export function projectSlugMatches(dirName: string, absolutePath: string): boolean {
+	const slug = slugifyProjectPath(absolutePath);
+	return dirName === slug || dirName.startsWith(`${slug}-`);
+}
+
+function projectDirAllowed(dirName: string, scope: SearchScope): boolean {
+	if (scope.projectPath) {
+		return projectSlugMatches(dirName, scope.projectPath);
+	}
+	if (scope.projectMatch) {
+		// The filter is slugified too, so `open-source/omniagent` matches `-open-source-omniagent`.
+		return dirName.toLowerCase().includes(slugifyProjectPath(scope.projectMatch).toLowerCase());
+	}
+	return true;
+}
+
+async function describeFile(
+	filePath: string,
+	sessionId: string,
+	scope: SearchScope,
+): Promise<HistoryFile | null> {
+	let info: Stats;
+	try {
+		info = await stat(filePath);
+	} catch {
+		return null;
+	}
+	// One-directional prune only: a file last written before `since` cannot contain a newer
+	// record, but a file written after it may still contain older ones.
+	if (scope.since && info.mtimeMs < scope.since.getTime()) {
+		return null;
+	}
+	return {
+		path: filePath,
+		// Claude records carry an exact cwd, so slug matching above is purely a pruning
+		// optimization and the authoritative value is filled in per record.
+		projectPath: null,
+		sessionId,
+		modifiedAt: new Date(info.mtimeMs).toISOString(),
+		sizeBytes: info.size,
+	};
+}
+
+export async function* listClaudeFiles(
+	scope: SearchScope,
+	context: HistoryContext,
+): AsyncGenerator<HistoryFile> {
+	const root = resolveClaudeProjectsDir(context.homeDir);
+	let projects: Dirent[];
+	try {
+		projects = await readdir(root, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	const wantAgent = context.roles.has("agent");
+	const wantMain = context.roles.has("user") || context.roles.has("assistant");
+
+	for (const project of projects) {
+		if (context.signal.aborted) {
+			return;
+		}
+		if (!project.isDirectory() || !projectDirAllowed(project.name, scope)) {
+			continue;
+		}
+		const projectDir = path.join(root, project.name);
+		let children: Dirent[];
+		try {
+			children = await readdir(projectDir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const child of children) {
+			if (context.signal.aborted) {
+				return;
+			}
+			if (child.isFile() && child.name.endsWith(TRANSCRIPT_EXTENSION)) {
+				if (!wantMain) {
+					continue;
+				}
+				const file = await describeFile(
+					path.join(projectDir, child.name),
+					path.basename(child.name, TRANSCRIPT_EXTENSION),
+					scope,
+				);
+				if (file) {
+					yield file;
+				}
+				continue;
+			}
+
+			// Subagent transcripts live one level deeper, at <session-id>/subagents/agent-*.jsonl.
+			// They are the majority of files on a busy install, so the walk must recurse.
+			if (!child.isDirectory() || !wantAgent) {
+				continue;
+			}
+			const subagentDir = path.join(projectDir, child.name, SUBAGENTS_DIR);
+			let agents: Dirent[];
+			try {
+				agents = await readdir(subagentDir, { withFileTypes: true });
+			} catch {
+				continue;
+			}
+			for (const agent of agents) {
+				if (!agent.isFile() || !agent.name.endsWith(TRANSCRIPT_EXTENSION)) {
+					continue;
+				}
+				const file = await describeFile(path.join(subagentDir, agent.name), child.name, scope);
+				if (file) {
+					yield file;
+				}
+			}
+		}
+	}
+}
+
+function extractText(content: unknown): string {
+	if (typeof content === "string") {
+		return content;
+	}
+	if (!Array.isArray(content)) {
+		return "";
+	}
+	// Only `text` blocks are message content. `tool_result` blocks are tool OUTPUT that happens
+	// to be carried on a user-role record, and they outnumber real prompts roughly 20:1.
+	const parts: string[] = [];
+	for (const block of content) {
+		if (block && typeof block === "object") {
+			const typed = block as { type?: unknown; text?: unknown };
+			if (typed.type === "text" && typeof typed.text === "string") {
+				parts.push(typed.text);
+			}
+		}
+	}
+	return parts.join("\n");
+}
+
+export function cleanClaudeText(raw: string): string {
+	const stripped = raw.replace(SYSTEM_REMINDER, "").trim();
+	if (stripped.length === 0) {
+		return "";
+	}
+	const tag = LEADING_TAG.exec(stripped);
+	if (tag?.[1] && SUPPRESSED_TAGS.has(tag[1])) {
+		return "";
+	}
+	if (stripped.startsWith("Caveat:")) {
+		return "";
+	}
+	return stripped;
+}
+
+export function normalizeClaudeLine(
+	line: string,
+	file: HistoryFile,
+	index: number,
+	context: HistoryContext,
+): SearchRecord | null {
+	let record: Record<string, unknown>;
+	try {
+		record = JSON.parse(line) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+	if (!record || typeof record !== "object") {
+		return null;
+	}
+
+	const type = record.type;
+	if (type !== "user" && type !== "assistant") {
+		return null;
+	}
+	// isMeta records are skill payloads and image placeholders injected into the turn, never
+	// something the human typed.
+	if (record.isMeta === true) {
+		return null;
+	}
+
+	// Subagent transcripts are flagged isSidechain. Their user-role records are dispatch prompts
+	// written by the orchestrator, so classifying them as "agent" is what keeps --role user
+	// limited to things the human actually wrote.
+	const role: HistoryRole =
+		record.isSidechain === true ? "agent" : type === "user" ? "user" : "assistant";
+	if (!context.roles.has(role)) {
+		return null;
+	}
+
+	const message = record.message as { content?: unknown } | undefined;
+	const text = cleanClaudeText(extractText(message?.content));
+	if (text.length === 0) {
+		return null;
+	}
+
+	return {
+		agentId: context.targetId,
+		role,
+		timestamp: typeof record.timestamp === "string" ? record.timestamp : null,
+		text,
+		sessionId: typeof record.sessionId === "string" ? record.sessionId : (file.sessionId ?? ""),
+		cwd: typeof record.cwd === "string" ? record.cwd : file.projectPath,
+		gitBranch: typeof record.gitBranch === "string" ? record.gitBranch : null,
+		sourcePath: file.path,
+		recordIndex: index,
+	};
+}
+
+export function resumeClaudeSession(record: SearchRecord): HistoryResume | null {
+	if (!record.sessionId) {
+		return null;
+	}
+	// Claude keys its transcripts by project directory, so a resume launched from elsewhere
+	// will not find the session. Reporting the cwd lets the renderer emit a `cd` prefix.
+	return { command: "claude", args: ["--resume", record.sessionId], cwd: record.cwd };
+}

--- a/src/lib/history/clipboard.ts
+++ b/src/lib/history/clipboard.ts
@@ -1,0 +1,107 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+export type ClipboardCommand = {
+	command: string;
+	args: string[];
+};
+
+export class ClipboardError extends Error {
+	readonly code = "clipboard_unavailable";
+
+	constructor(message: string) {
+		super(message);
+		this.name = "ClipboardError";
+	}
+}
+
+/**
+ * Ordered candidates per platform. On Linux the session type decides which helper is likely to
+ * exist, but every candidate is still attempted so an unusual setup keeps working.
+ */
+export function clipboardCandidates(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+): ClipboardCommand[] {
+	if (platform === "darwin") {
+		return [{ command: "pbcopy", args: [] }];
+	}
+	if (platform === "win32") {
+		return [{ command: "clip", args: [] }];
+	}
+	const wayland: ClipboardCommand = { command: "wl-copy", args: [] };
+	const x11: ClipboardCommand[] = [
+		{ command: "xclip", args: ["-selection", "clipboard"] },
+		{ command: "xsel", args: ["--clipboard", "--input"] },
+	];
+	return env.WAYLAND_DISPLAY ? [wayland, ...x11] : [...x11, wayland];
+}
+
+export function clipboardHint(platform: NodeJS.Platform = process.platform): string {
+	if (platform === "darwin") {
+		return "pbcopy was not found on PATH.";
+	}
+	if (platform === "win32") {
+		return "clip was not found on PATH.";
+	}
+	return "No clipboard helper found. Install wl-clipboard, xclip, or xsel.";
+}
+
+type SpawnLike = typeof nodeSpawn;
+
+function tryCopy(candidate: ClipboardCommand, text: string, spawn: SpawnLike): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const child = spawn(candidate.command, candidate.args, {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		const fail = (error: Error) => {
+			if (!settled) {
+				settled = true;
+				reject(error);
+			}
+		};
+		child.on("error", fail);
+		child.on("close", (code) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`${candidate.command} exited with code ${code}`));
+			}
+		});
+		child.stdin?.on("error", fail);
+		child.stdin?.end(text);
+	});
+}
+
+/**
+ * Copies text to the system clipboard, returning the helper that succeeded.
+ * Throws ClipboardError only when every candidate fails, so a missing helper produces one clear
+ * message rather than a stack trace.
+ */
+export async function copyToClipboard(
+	text: string,
+	options: {
+		platform?: NodeJS.Platform;
+		env?: NodeJS.ProcessEnv;
+		spawn?: SpawnLike;
+	} = {},
+): Promise<ClipboardCommand> {
+	const platform = options.platform ?? process.platform;
+	const spawn = options.spawn ?? nodeSpawn;
+	const candidates = clipboardCandidates(platform, options.env ?? process.env);
+
+	const failures: string[] = [];
+	for (const candidate of candidates) {
+		try {
+			await tryCopy(candidate, text, spawn);
+			return candidate;
+		} catch (error) {
+			failures.push(`${candidate.command}: ${error instanceof Error ? error.message : error}`);
+		}
+	}
+	throw new ClipboardError(`${clipboardHint(platform)} (tried ${failures.join("; ")})`);
+}

--- a/src/lib/history/codex.ts
+++ b/src/lib/history/codex.ts
@@ -1,0 +1,246 @@
+import type { Dirent, Stats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { open, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import type {
+	HistoryContext,
+	HistoryFile,
+	HistoryResume,
+	HistoryRole,
+	SearchRecord,
+	SearchScope,
+} from "./types.js";
+
+const TRANSCRIPT_EXTENSION = ".jsonl";
+const DAY_MS = 86_400_000;
+/** Enough to hold the session_meta line, which is always first and carries the cwd. */
+const META_PROBE_BYTES = 64 * 1024;
+const NEWLINE = 0x0a;
+
+export function resolveCodexSessionsDir(
+	homeDir: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const override = env.CODEX_HOME?.trim();
+	const base = override && override.length > 0 ? override : path.join(homeDir, ".codex");
+	return path.join(base, "sessions");
+}
+
+export type CodexSessionMeta = {
+	cwd: string | null;
+	sessionId: string | null;
+	timestamp: string | null;
+};
+
+/**
+ * Reads only the first line of a rollout file. Codex writes `session_meta` there in every file,
+ * so this recovers the session cwd for ~1/5000th of the cost of scanning the file — which is what
+ * makes a path-scoped search fast despite Codex encoding no cwd in its paths.
+ */
+export async function readCodexSessionMeta(filePath: string): Promise<CodexSessionMeta | null> {
+	let handle: FileHandle;
+	try {
+		handle = await open(filePath, "r");
+	} catch {
+		return null;
+	}
+	try {
+		const buffer = Buffer.alloc(META_PROBE_BYTES);
+		const { bytesRead } = await handle.read(buffer, 0, META_PROBE_BYTES, 0);
+		if (bytesRead === 0) {
+			return null;
+		}
+		const newline = buffer.indexOf(NEWLINE);
+		const end = newline === -1 || newline > bytesRead ? bytesRead : newline;
+		const record = JSON.parse(buffer.toString("utf8", 0, end)) as Record<string, unknown>;
+		if (record?.type !== "session_meta") {
+			return null;
+		}
+		const payload = (record.payload ?? {}) as Record<string, unknown>;
+		const id = payload.id ?? payload.session_id;
+		return {
+			cwd: typeof payload.cwd === "string" ? payload.cwd : null,
+			// The rollout id (also in the filename) is the resumable one. `session_id` diverges on
+			// forked sessions and does not resolve.
+			sessionId: typeof id === "string" ? id : null,
+			timestamp:
+				typeof payload.timestamp === "string"
+					? payload.timestamp
+					: typeof record.timestamp === "string"
+						? record.timestamp
+						: null,
+		};
+	} catch {
+		return null;
+	} finally {
+		await handle.close();
+	}
+}
+
+/**
+ * Date shards are local-time-ish while record timestamps are absolute, so pad a day on each side
+ * and let the authoritative per-record filter make the exact cut.
+ */
+function shardAllowed(year: number, month: number, day: number, scope: SearchScope): boolean {
+	if (!scope.since && !scope.until) {
+		return true;
+	}
+	const start = Date.UTC(year, month - 1, day) - DAY_MS;
+	const end = Date.UTC(year, month - 1, day) + 2 * DAY_MS;
+	if (scope.since && end < scope.since.getTime()) {
+		return false;
+	}
+	if (scope.until && start > scope.until.getTime()) {
+		return false;
+	}
+	return true;
+}
+
+function projectAllowed(cwd: string | null, scope: SearchScope): boolean {
+	if (!scope.projectPath && !scope.projectMatch) {
+		return true;
+	}
+	// Fail open: a file with an unreadable or absent header still gets scanned, and its records
+	// are filtered individually. Never silently drop data because a header was torn.
+	if (cwd === null) {
+		return true;
+	}
+	if (scope.projectPath) {
+		const root = scope.projectPath;
+		return cwd === root || cwd.startsWith(`${root}${path.sep}`);
+	}
+	return cwd.toLowerCase().includes((scope.projectMatch as string).toLowerCase());
+}
+
+async function numericDirs(parent: string): Promise<string[]> {
+	try {
+		const entries = await readdir(parent, { withFileTypes: true });
+		return entries
+			.filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+			.map((entry) => entry.name)
+			.sort();
+	} catch {
+		return [];
+	}
+}
+
+export async function* listCodexFiles(
+	scope: SearchScope,
+	context: HistoryContext,
+): AsyncGenerator<HistoryFile> {
+	const root = resolveCodexSessionsDir(context.homeDir);
+	// Codex records nothing that maps to a subagent transcript.
+	if (!context.roles.has("user") && !context.roles.has("assistant")) {
+		return;
+	}
+
+	for (const year of await numericDirs(root)) {
+		for (const month of await numericDirs(path.join(root, year))) {
+			for (const day of await numericDirs(path.join(root, year, month))) {
+				if (context.signal.aborted) {
+					return;
+				}
+				if (!shardAllowed(Number(year), Number(month), Number(day), scope)) {
+					continue;
+				}
+				const dayDir = path.join(root, year, month, day);
+				let entries: Dirent[];
+				try {
+					entries = await readdir(dayDir, { withFileTypes: true });
+				} catch {
+					continue;
+				}
+				for (const entry of entries) {
+					if (context.signal.aborted) {
+						return;
+					}
+					if (!entry.isFile() || !entry.name.endsWith(TRANSCRIPT_EXTENSION)) {
+						continue;
+					}
+					const filePath = path.join(dayDir, entry.name);
+					const meta = await readCodexSessionMeta(filePath);
+					if (!projectAllowed(meta?.cwd ?? null, scope)) {
+						continue;
+					}
+					let info: Stats;
+					try {
+						info = await stat(filePath);
+					} catch {
+						continue;
+					}
+					if (scope.since && info.mtimeMs < scope.since.getTime()) {
+						continue;
+					}
+					yield {
+						path: filePath,
+						projectPath: meta?.cwd ?? null,
+						sessionId: meta?.sessionId ?? path.basename(entry.name, TRANSCRIPT_EXTENSION),
+						modifiedAt: new Date(info.mtimeMs).toISOString(),
+						sizeBytes: info.size,
+					};
+				}
+			}
+		}
+	}
+}
+
+export function normalizeCodexLine(
+	line: string,
+	file: HistoryFile,
+	index: number,
+	context: HistoryContext,
+): SearchRecord | null {
+	let record: Record<string, unknown>;
+	try {
+		record = JSON.parse(line) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+	// This single check is what excludes the `response_item` duplicates. Those carry the same
+	// user text but with injected <environment_context> blocks, so widening this predicate
+	// silently doubles every result and pollutes it with harness noise.
+	if (record?.type !== "event_msg") {
+		return null;
+	}
+	const payload = record.payload as Record<string, unknown> | undefined;
+	if (!payload || typeof payload !== "object") {
+		return null;
+	}
+
+	let role: HistoryRole;
+	if (payload.type === "user_message") {
+		role = "user";
+	} else if (payload.type === "agent_message") {
+		role = "assistant";
+	} else {
+		return null;
+	}
+	if (!context.roles.has(role)) {
+		return null;
+	}
+
+	const text = typeof payload.message === "string" ? payload.message.trim() : "";
+	if (text.length === 0) {
+		return null;
+	}
+
+	return {
+		agentId: context.targetId,
+		role,
+		timestamp: typeof record.timestamp === "string" ? record.timestamp : null,
+		text,
+		sessionId: file.sessionId ?? "",
+		cwd: file.projectPath,
+		gitBranch: null,
+		sourcePath: file.path,
+		recordIndex: index,
+	};
+}
+
+export function resumeCodexSession(record: SearchRecord): HistoryResume | null {
+	if (!record.sessionId) {
+		return null;
+	}
+	// `codex resume` scopes to the current directory, so a hit from another project needs a cd.
+	return { command: "codex", args: ["resume", record.sessionId], cwd: record.cwd };
+}

--- a/src/lib/history/codex.ts
+++ b/src/lib/history/codex.ts
@@ -184,6 +184,31 @@ export async function* listCodexFiles(
 	}
 }
 
+/**
+ * Pulls text out of a thread item's content blocks. Block `type` casing differs between item
+ * kinds (`text` on user messages, `Text` on agent messages), so the presence of a string `text`
+ * field is what counts rather than the label.
+ */
+function extractItemText(item: Record<string, unknown>): string {
+	const content = item.content;
+	if (typeof content === "string") {
+		return content;
+	}
+	if (!Array.isArray(content)) {
+		return "";
+	}
+	const parts: string[] = [];
+	for (const block of content) {
+		if (block && typeof block === "object") {
+			const text = (block as { text?: unknown }).text;
+			if (typeof text === "string") {
+				parts.push(text);
+			}
+		}
+	}
+	return parts.join("");
+}
+
 export function normalizeCodexLine(
 	line: string,
 	file: HistoryFile,
@@ -196,9 +221,9 @@ export function normalizeCodexLine(
 	} catch {
 		return null;
 	}
-	// This single check is what excludes the `response_item` duplicates. Those carry the same
-	// user text but with injected <environment_context> blocks, so widening this predicate
-	// silently doubles every result and pollutes it with harness noise.
+	// Excludes the `response_item` copies of every turn. In older transcripts those carry the
+	// user's text wrapped in injected <environment_context> blocks; in newer ones they simply
+	// duplicate the item event below. Either way, accepting them doubles and pollutes results.
 	if (record?.type !== "event_msg") {
 		return null;
 	}
@@ -207,19 +232,30 @@ export function normalizeCodexLine(
 		return null;
 	}
 
-	let role: HistoryRole;
-	if (payload.type === "user_message") {
-		role = "user";
-	} else if (payload.type === "agent_message") {
-		role = "assistant";
-	} else {
-		return null;
-	}
-	if (!context.roles.has(role)) {
-		return null;
+	let role: HistoryRole | null = null;
+	let text = "";
+
+	if (payload.type === "user_message" || payload.type === "agent_message") {
+		// Legacy shape, written by Codex through 2026-08-06.
+		role = payload.type === "user_message" ? "user" : "assistant";
+		text = typeof payload.message === "string" ? payload.message.trim() : "";
+	} else if (payload.type === "item_completed") {
+		// Current shape: messages arrive as completed thread items instead of bespoke events.
+		const item = payload.item as Record<string, unknown> | undefined;
+		const itemType = item?.type;
+		if (itemType === "UserMessage") {
+			role = "user";
+		} else if (itemType === "AgentMessage") {
+			role = "assistant";
+		}
+		if (role && item) {
+			text = extractItemText(item).trim();
+		}
 	}
 
-	const text = typeof payload.message === "string" ? payload.message.trim() : "";
+	if (role === null || !context.roles.has(role)) {
+		return null;
+	}
 	if (text.length === 0) {
 		return null;
 	}

--- a/src/lib/history/codex.ts
+++ b/src/lib/history/codex.ts
@@ -2,6 +2,7 @@ import type { Dirent, Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import { open, readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import { type HistoryQuery, prefilterJsonLine } from "./query.js";
 import type {
 	HistoryContext,
 	HistoryFile,
@@ -16,6 +17,10 @@ const DAY_MS = 86_400_000;
 /** Enough to hold the session_meta line, which is always first and carries the cwd. */
 const META_PROBE_BYTES = 64 * 1024;
 const NEWLINE = 0x0a;
+
+export function prefilterCodexLine(line: string, query: HistoryQuery): boolean {
+	return prefilterJsonLine(query, line);
+}
 
 export function resolveCodexSessionsDir(
 	homeDir: string,

--- a/src/lib/history/filters.ts
+++ b/src/lib/history/filters.ts
@@ -35,7 +35,7 @@ export function parseWhen(
 ): Date {
 	const trimmed = value.trim();
 	const code = options.flag === "--until" ? "invalid_until" : "invalid_since";
-	const fail = () => {
+	const fail = (): never => {
 		throw new InvalidFilterError(
 			code,
 			`${options.flag} must be YYYY-MM-DD, an ISO timestamp, or a relative duration like 7d, 24h, or 30m.`,
@@ -50,7 +50,12 @@ export function parseWhen(
 		const amount = Number(relative[1]);
 		const unit = (relative[2] as string).toLowerCase();
 		const now = options.now ?? new Date();
-		return new Date(now.getTime() - amount * (DURATION_MS[unit] as number));
+		const timestamp = now.getTime() - amount * (DURATION_MS[unit] as number);
+		const resolved = new Date(timestamp);
+		if (!Number.isFinite(timestamp) || Number.isNaN(resolved.getTime())) {
+			fail();
+		}
+		return resolved;
 	}
 
 	const dateOnly = DATE_ONLY.exec(trimmed);
@@ -63,7 +68,12 @@ export function parseWhen(
 		const resolved = options.endOfDay
 			? new Date(year, month - 1, day, 23, 59, 59, 999)
 			: new Date(year, month - 1, day, 0, 0, 0, 0);
-		if (Number.isNaN(resolved.getTime())) {
+		if (
+			Number.isNaN(resolved.getTime()) ||
+			resolved.getFullYear() !== year ||
+			resolved.getMonth() !== month - 1 ||
+			resolved.getDate() !== day
+		) {
 			fail();
 		}
 		return resolved;

--- a/src/lib/history/filters.ts
+++ b/src/lib/history/filters.ts
@@ -1,0 +1,147 @@
+import path from "node:path";
+import type { SearchRecord, SearchScope } from "./types.js";
+
+const RELATIVE_DURATION = /^(\d+)\s*(s|m|h|d|w)$/i;
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+const WINDOWS_ABSOLUTE = /^[a-zA-Z]:[\\/]/;
+
+const DURATION_MS: Record<string, number> = {
+	s: 1_000,
+	m: 60_000,
+	h: 3_600_000,
+	d: 86_400_000,
+	w: 604_800_000,
+};
+
+export class InvalidFilterError extends Error {
+	readonly code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "InvalidFilterError";
+		this.code = code;
+	}
+}
+
+/**
+ * Accepts `YYYY-MM-DD`, a full ISO timestamp, or a relative duration like `7d` / `24h` / `30m`.
+ *
+ * Date-only values resolve in local time, and `--until 2026-08-05` covers that entire day, which
+ * is what people mean by "up to the 5th".
+ */
+export function parseWhen(
+	value: string,
+	options: { flag: string; endOfDay?: boolean; now?: Date } = { flag: "--since" },
+): Date {
+	const trimmed = value.trim();
+	const code = options.flag === "--until" ? "invalid_until" : "invalid_since";
+	const fail = () => {
+		throw new InvalidFilterError(
+			code,
+			`${options.flag} must be YYYY-MM-DD, an ISO timestamp, or a relative duration like 7d, 24h, or 30m.`,
+		);
+	};
+	if (trimmed.length === 0) {
+		fail();
+	}
+
+	const relative = RELATIVE_DURATION.exec(trimmed);
+	if (relative) {
+		const amount = Number(relative[1]);
+		const unit = (relative[2] as string).toLowerCase();
+		const now = options.now ?? new Date();
+		return new Date(now.getTime() - amount * (DURATION_MS[unit] as number));
+	}
+
+	const dateOnly = DATE_ONLY.exec(trimmed);
+	if (dateOnly) {
+		const [year, month, day] = [
+			Number(dateOnly[1]),
+			Number(dateOnly[2]),
+			Number(dateOnly[3]),
+		] as const;
+		const resolved = options.endOfDay
+			? new Date(year, month - 1, day, 23, 59, 59, 999)
+			: new Date(year, month - 1, day, 0, 0, 0, 0);
+		if (Number.isNaN(resolved.getTime())) {
+			fail();
+		}
+		return resolved;
+	}
+
+	const parsed = new Date(trimmed);
+	if (Number.isNaN(parsed.getTime())) {
+		fail();
+	}
+	return parsed;
+}
+
+/**
+ * Distinguishes `--project ./src` (a location) from `--project src` (a name fragment). Anything
+ * that starts like a path is resolved and scoped to the repository containing it; everything else
+ * is a case-insensitive substring match. This is what lets `--project .` mean "this repo".
+ */
+export function isPathLikeProject(value: string): boolean {
+	const trimmed = value.trim();
+	return (
+		trimmed === "." ||
+		trimmed === ".." ||
+		trimmed.startsWith("./") ||
+		trimmed.startsWith("../") ||
+		trimmed.startsWith(".\\") ||
+		trimmed.startsWith("..\\") ||
+		trimmed.startsWith("/") ||
+		trimmed.startsWith("~") ||
+		WINDOWS_ABSOLUTE.test(trimmed)
+	);
+}
+
+export function expandHome(value: string, homeDir: string): string {
+	const trimmed = value.trim();
+	if (trimmed === "~") {
+		return homeDir;
+	}
+	if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+		return path.join(homeDir, trimmed.slice(2));
+	}
+	return trimmed;
+}
+
+export function isWithinPath(candidate: string, root: string): boolean {
+	return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/**
+ * The authoritative filter. Targets may prune files however they like in `listFiles`, but every
+ * surviving record is re-checked here, so an over-eager or absent prune can never change results.
+ */
+export function recordMatchesScope(record: SearchRecord, scope: SearchScope): boolean {
+	if (scope.projectPath) {
+		// A record with no cwd cannot be confirmed to belong to the requested project. Excluding
+		// it keeps an explicit filter predictable rather than leaking unverifiable rows.
+		if (!record.cwd || !isWithinPath(record.cwd, scope.projectPath)) {
+			return false;
+		}
+	}
+	if (scope.projectMatch) {
+		if (!record.cwd || !record.cwd.toLowerCase().includes(scope.projectMatch.toLowerCase())) {
+			return false;
+		}
+	}
+	if (scope.since || scope.until) {
+		if (!record.timestamp) {
+			return false;
+		}
+		const at = Date.parse(record.timestamp);
+		if (Number.isNaN(at)) {
+			return false;
+		}
+		if (scope.since && at < scope.since.getTime()) {
+			return false;
+		}
+		if (scope.until && at > scope.until.getTime()) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/lib/history/format.ts
+++ b/src/lib/history/format.ts
@@ -1,0 +1,373 @@
+import path from "node:path";
+import { findRanges, type HistoryQuery } from "./query.js";
+import type {
+	HistoryResume,
+	HistoryRole,
+	SearchEnvelope,
+	SearchHit,
+	SearchMatch,
+	SearchNote,
+	SearchStats,
+} from "./types.js";
+
+const ANSI = {
+	reset: "\x1b[0m",
+	bold: "\x1b[1m",
+	dim: "\x1b[2m",
+	gray: "\x1b[90m",
+} as const;
+
+type AnsiStyle = keyof typeof ANSI;
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping real ANSI escapes is the point.
+const ANSI_ESCAPE = /\u001b\[[0-9;]*[a-zA-Z]/g;
+const EXCERPT_LEAD = 24;
+const EXCERPT_SNAP = 12;
+const DEFAULT_WIDTH = 100;
+const MAX_WIDTH = 120;
+const INDENT = "  ";
+/** Guards the JSON envelope against one pathological pasted prompt bloating the document. */
+const MAX_TEXT_BYTES = 64 * 1024;
+
+export function shouldUseColor(): boolean {
+	if (process.env.FORCE_COLOR != null && process.env.FORCE_COLOR !== "0") {
+		return true;
+	}
+	if (process.env.NO_COLOR != null) {
+		return false;
+	}
+	return Boolean(process.stdout.isTTY);
+}
+
+function color(value: string, style: AnsiStyle, useColor: boolean): string {
+	if (!useColor) {
+		return value;
+	}
+	return `${ANSI[style]}${value}${ANSI.reset}`;
+}
+
+/**
+ * Prompts are long and multi-line, and some agents store raw terminal output verbatim. Collapsing
+ * to a single logical line is what makes results scannable.
+ */
+export function collapseText(text: string): string {
+	return text.replace(ANSI_ESCAPE, "").replace(/\s+/g, " ").trim();
+}
+
+export function buildExcerpt(
+	text: string,
+	ranges: Array<[number, number]>,
+	width: number,
+): { excerpt: string; ranges: Array<[number, number]> } {
+	if (text.length <= width) {
+		return { excerpt: text, ranges };
+	}
+
+	const first = ranges[0]?.[0] ?? 0;
+	let start = Math.max(0, first - EXCERPT_LEAD);
+	if (start > 0) {
+		const space = text.lastIndexOf(" ", start);
+		if (space !== -1 && start - space <= EXCERPT_SNAP) {
+			start = space + 1;
+		}
+	}
+	let end = Math.min(text.length, start + width);
+	if (end < text.length) {
+		const space = text.indexOf(" ", Math.max(start, end - EXCERPT_SNAP));
+		if (space !== -1 && space > start && space <= end) {
+			end = space;
+		}
+	}
+
+	const head = start > 0 ? "… " : "";
+	const tail = end < text.length ? " …" : "";
+	const shifted = ranges
+		.filter(([from, to]) => to > start && from < end)
+		.map(
+			([from, to]) =>
+				[Math.max(from, start) - start + head.length, Math.min(to, end) - start + head.length] as [
+					number,
+					number,
+				],
+		);
+	return { excerpt: `${head}${text.slice(start, end)}${tail}`, ranges: shifted };
+}
+
+function highlight(text: string, ranges: Array<[number, number]>, useColor: boolean): string {
+	if (!useColor || ranges.length === 0) {
+		return text;
+	}
+	let out = "";
+	let cursor = 0;
+	for (const [from, to] of ranges) {
+		if (from >= text.length) {
+			break;
+		}
+		out += text.slice(cursor, from);
+		// Bold rather than a color: it survives both light and dark terminals.
+		out += color(text.slice(from, Math.min(to, text.length)), "bold", true);
+		cursor = Math.min(to, text.length);
+	}
+	return out + text.slice(cursor);
+}
+
+export function shortenHome(value: string, homeDir: string): string {
+	if (homeDir && (value === homeDir || value.startsWith(`${homeDir}${path.sep}`))) {
+		return `~${value.slice(homeDir.length)}`;
+	}
+	return value;
+}
+
+/**
+ * The renderer never learns which agent it is printing: the target supplies the verb, and the
+ * `cwd` it reports decides whether a `cd` prefix is needed.
+ */
+export function formatResumeCommand(
+	resume: HistoryResume | null,
+	currentCwd: string,
+	homeDir: string,
+): string | null {
+	if (!resume) {
+		return null;
+	}
+	const command = [resume.command, ...resume.args].join(" ");
+	if (!resume.cwd || resume.cwd === currentCwd) {
+		return command;
+	}
+	return `cd ${shortenHome(resume.cwd, homeDir)} && ${command}`;
+}
+
+function truncateText(text: string): { text: string; truncated: boolean } {
+	if (Buffer.byteLength(text, "utf8") <= MAX_TEXT_BYTES) {
+		return { text, truncated: false };
+	}
+	return {
+		text: Buffer.from(text, "utf8").subarray(0, MAX_TEXT_BYTES).toString("utf8"),
+		truncated: true,
+	};
+}
+
+function terminalWidth(): number {
+	const columns = process.stdout.columns ?? DEFAULT_WIDTH;
+	return Math.max(40, Math.min(columns, MAX_WIDTH)) - INDENT.length;
+}
+
+/** `basename`, promoted to two segments only when two different projects would collide. */
+function projectLabels(hits: SearchHit[]): Map<string, string> {
+	const byBase = new Map<string, Set<string>>();
+	for (const hit of hits) {
+		if (!hit.record.cwd) {
+			continue;
+		}
+		const base = path.basename(hit.record.cwd);
+		const set = byBase.get(base) ?? new Set<string>();
+		set.add(hit.record.cwd);
+		byBase.set(base, set);
+	}
+	const labels = new Map<string, string>();
+	for (const [base, paths] of byBase) {
+		for (const cwd of paths) {
+			labels.set(cwd, paths.size > 1 ? path.join(path.basename(path.dirname(cwd)), base) : base);
+		}
+	}
+	return labels;
+}
+
+export function buildSearchEnvelope(options: {
+	hits: SearchHit[];
+	stats: SearchStats;
+	errors: SearchNote[];
+	notes: SearchNote[];
+	query: HistoryQuery;
+	roles: HistoryRole[];
+	targets: string[];
+	projectPath: string | null;
+	projectMatch: string | null;
+	since: Date | null;
+	until: Date | null;
+	cwd: string;
+	homeDir: string;
+	generatedAt: string;
+}): SearchEnvelope {
+	const labels = projectLabels(options.hits);
+	const width = terminalWidth();
+
+	const matches: SearchMatch[] = options.hits.map((hit) => {
+		const collapsed = collapseText(hit.record.text);
+		const ranges = findRanges(options.query, collapsed);
+		const excerpt = buildExcerpt(collapsed, ranges, width);
+		const text = truncateText(hit.record.text);
+		return {
+			agentId: hit.record.agentId,
+			displayName: hit.displayName,
+			role: hit.record.role,
+			timestamp: hit.record.timestamp,
+			sessionId: hit.record.sessionId,
+			cwd: hit.record.cwd,
+			project: hit.record.cwd ? (labels.get(hit.record.cwd) ?? null) : null,
+			gitBranch: hit.record.gitBranch ?? null,
+			sourcePath: hit.record.sourcePath,
+			// Newlines are preserved here so the full prompt round-trips and stays reusable;
+			// `excerpt` is the collapsed display form.
+			text: text.text,
+			textTruncated: text.truncated,
+			excerpt: excerpt.excerpt,
+			matchRanges: excerpt.ranges,
+			resumeCommand: formatResumeCommand(hit.resume, options.cwd, options.homeDir),
+		};
+	});
+
+	return {
+		schemaVersion: 1,
+		generatedAt: options.generatedAt,
+		query: {
+			raw: options.query.raw,
+			terms: options.query.terms,
+			mode: options.query.regex ? "regex" : "literal",
+			caseSensitive: options.query.caseSensitive,
+		},
+		scope: {
+			kind: options.projectPath ? "path" : options.projectMatch ? "substring" : "all",
+			projectPath: options.projectPath,
+			projectMatch: options.projectMatch,
+			roles: options.roles,
+			since: options.since ? options.since.toISOString() : null,
+			until: options.until ? options.until.toISOString() : null,
+			targets: options.targets,
+		},
+		matches,
+		stats: options.stats,
+		errors: options.errors,
+		notes: options.notes,
+	};
+}
+
+export function formatTimestamp(iso: string | null): string {
+	if (!iso) {
+		return "????-??-?? ??:??";
+	}
+	const at = new Date(iso);
+	if (Number.isNaN(at.getTime())) {
+		return "????-??-?? ??:??";
+	}
+	const pad = (value: number) => String(value).padStart(2, "0");
+	return `${at.getFullYear()}-${pad(at.getMonth() + 1)}-${pad(at.getDate())} ${pad(at.getHours())}:${pad(at.getMinutes())}`;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= 1_000_000_000) {
+		return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+	}
+	if (bytes >= 1_000_000) {
+		return `${Math.round(bytes / 1_000_000)} MB`;
+	}
+	return `${Math.round(bytes / 1_000)} KB`;
+}
+
+/** Wraps text to a width, preserving blank lines, and breaking words longer than the viewport. */
+export function wrapText(text: string, width: number, maxLines: number): string[] {
+	const out: string[] = [];
+	const safeWidth = Math.max(8, width);
+	for (const rawLine of text.split("\n")) {
+		if (out.length >= maxLines) {
+			break;
+		}
+		if (rawLine.trim().length === 0) {
+			out.push("");
+			continue;
+		}
+		let current = "";
+		for (const word of rawLine.split(/\s+/).filter(Boolean)) {
+			if (current.length === 0) {
+				current = word;
+			} else if (current.length + 1 + word.length <= safeWidth) {
+				current = `${current} ${word}`;
+			} else {
+				out.push(current);
+				if (out.length >= maxLines) {
+					break;
+				}
+				current = word;
+			}
+			while (current.length > safeWidth) {
+				out.push(current.slice(0, safeWidth));
+				current = current.slice(safeWidth);
+				if (out.length >= maxLines) {
+					break;
+				}
+			}
+		}
+		if (current.length > 0 && out.length < maxLines) {
+			out.push(current);
+		}
+	}
+	return out.slice(0, maxLines);
+}
+
+export function formatSearchSummary(
+	envelope: SearchEnvelope,
+	jsonOutput: boolean,
+	options: { full?: boolean } = {},
+): string {
+	if (jsonOutput) {
+		return JSON.stringify(envelope, null, 2);
+	}
+
+	const useColor = shouldUseColor();
+	if (envelope.matches.length === 0) {
+		return `No matches for ${JSON.stringify(envelope.query.raw)}.`;
+	}
+
+	// With the default single role the column would be constant, so it is folded away.
+	const showRole = envelope.scope.roles.length > 1 || envelope.scope.roles[0] !== "user";
+	const agentLabels = envelope.matches.map((match) =>
+		showRole ? `${match.agentId}/${match.role}` : match.agentId,
+	);
+	const agentWidth = Math.max(...agentLabels.map((label) => label.length));
+	// Results are numbered so --copy and --print can address one without a second search.
+	const numberWidth = String(envelope.matches.length).length;
+	const bodyIndent = " ".repeat(numberWidth + 3);
+
+	const lines: string[] = [];
+	envelope.matches.forEach((match, index) => {
+		if (index > 0) {
+			lines.push("");
+		}
+		const label = `[${String(index + 1).padStart(numberWidth)}] `;
+		const header =
+			label +
+			[
+				color(formatTimestamp(match.timestamp), "gray", useColor),
+				color((agentLabels[index] as string).padEnd(agentWidth), "bold", useColor),
+				color(match.project ?? "", "gray", useColor),
+			]
+				.join("  ")
+				.trimEnd();
+		lines.push(header);
+		if (options.full) {
+			for (const line of wrapText(match.text, terminalWidth() - bodyIndent.length, 200)) {
+				lines.push(line.length === 0 ? "" : `${bodyIndent}${line}`);
+			}
+		} else {
+			lines.push(`${bodyIndent}${highlight(match.excerpt, match.matchRanges, useColor)}`);
+		}
+		if (match.resumeCommand) {
+			lines.push(`${bodyIndent}${color(match.resumeCommand, "dim", useColor)}`);
+		}
+	});
+
+	const { stats } = envelope;
+	const shown =
+		stats.returnedMatches < stats.matchedRecords
+			? `Showing ${stats.returnedMatches} of ${stats.matchedRecords} matches`
+			: `${stats.matchedRecords} ${stats.matchedRecords === 1 ? "match" : "matches"}`;
+	lines.push("");
+	lines.push(
+		color(
+			`${shown} (scanned ${stats.scannedFiles} files, ${formatBytes(stats.scannedBytes)}, ${(stats.elapsedMs / 1000).toFixed(1)}s)`,
+			"dim",
+			useColor,
+		),
+	);
+	return lines.join("\n");
+}

--- a/src/lib/history/format.ts
+++ b/src/lib/history/format.ts
@@ -175,6 +175,9 @@ function quoteShellLiteral(value: string): string {
 }
 
 function quoteShellPath(value: string): string {
+	if (value === "~") {
+		return "~";
+	}
 	if (value.startsWith("~/")) {
 		return `~/${quoteShellToken(value.slice(2))}`;
 	}

--- a/src/lib/history/format.ts
+++ b/src/lib/history/format.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { findRanges, type HistoryQuery } from "./query.js";
 import type {
 	HistoryResume,
@@ -19,15 +20,15 @@ const ANSI = {
 
 type AnsiStyle = keyof typeof ANSI;
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping real ANSI escapes is the point.
-const ANSI_ESCAPE = /\u001b\[[0-9;]*[a-zA-Z]/g;
+// Preserve line feeds and tabs for display layout; strip every other C0/C1 control after VT
+// sequences so transcript content cannot rewrite the terminal or its clipboard.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: terminal controls are the point.
+const TERMINAL_CONTROL = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g;
 const EXCERPT_LEAD = 24;
 const EXCERPT_SNAP = 12;
 const DEFAULT_WIDTH = 100;
 const MAX_WIDTH = 120;
 const INDENT = "  ";
-/** Guards the JSON envelope against one pathological pasted prompt bloating the document. */
-const MAX_TEXT_BYTES = 64 * 1024;
 
 export function shouldUseColor(): boolean {
 	if (process.env.FORCE_COLOR != null && process.env.FORCE_COLOR !== "0") {
@@ -51,7 +52,11 @@ function color(value: string, style: AnsiStyle, useColor: boolean): string {
  * to a single logical line is what makes results scannable.
  */
 export function collapseText(text: string): string {
-	return text.replace(ANSI_ESCAPE, "").replace(/\s+/g, " ").trim();
+	return sanitizeTerminalText(text).replace(/\s+/g, " ").trim();
+}
+
+export function sanitizeTerminalText(text: string): string {
+	return stripVTControlCharacters(text).replace(TERMINAL_CONTROL, "");
 }
 
 export function buildExcerpt(
@@ -126,25 +131,54 @@ export function formatResumeCommand(
 	resume: HistoryResume | null,
 	currentCwd: string,
 	homeDir: string,
+	platform: NodeJS.Platform = process.platform,
 ): string | null {
 	if (!resume) {
 		return null;
 	}
-	const command = [resume.command, ...resume.args].join(" ");
+	if (platform === "win32") {
+		const command = `& ${[resume.command, ...resume.args].map(quotePowerShellToken).join(" ")}`;
+		if (!resume.cwd || resume.cwd === currentCwd) {
+			return command;
+		}
+		return `Set-Location -LiteralPath ${quotePowerShellToken(resume.cwd)}; if ($?) { ${command} }`;
+	}
+	const command = [quoteShellCommand(resume.command), ...resume.args.map(quoteShellToken)].join(
+		" ",
+	);
 	if (!resume.cwd || resume.cwd === currentCwd) {
 		return command;
 	}
-	return `cd ${shortenHome(resume.cwd, homeDir)} && ${command}`;
+	return `cd ${quoteShellPath(shortenHome(resume.cwd, homeDir))} && ${command}`;
 }
 
-function truncateText(text: string): { text: string; truncated: boolean } {
-	if (Buffer.byteLength(text, "utf8") <= MAX_TEXT_BYTES) {
-		return { text, truncated: false };
+function quotePowerShellToken(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+const SAFE_SHELL_COMMAND = /^[a-zA-Z0-9_./-]+$/;
+const SAFE_SHELL_TOKEN = /^[a-zA-Z0-9_@%+=:,./-]+$/;
+
+function quoteShellCommand(value: string): string {
+	return SAFE_SHELL_COMMAND.test(value) ? value : quoteShellLiteral(value);
+}
+
+function quoteShellToken(value: string): string {
+	if (SAFE_SHELL_TOKEN.test(value)) {
+		return value;
 	}
-	return {
-		text: Buffer.from(text, "utf8").subarray(0, MAX_TEXT_BYTES).toString("utf8"),
-		truncated: true,
-	};
+	return quoteShellLiteral(value);
+}
+
+function quoteShellLiteral(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function quoteShellPath(value: string): string {
+	if (value.startsWith("~/")) {
+		return `~/${quoteShellToken(value.slice(2))}`;
+	}
+	return quoteShellToken(value);
 }
 
 function terminalWidth(): number {
@@ -196,7 +230,6 @@ export function buildSearchEnvelope(options: {
 		const collapsed = collapseText(hit.record.text);
 		const ranges = findRanges(options.query, collapsed);
 		const excerpt = buildExcerpt(collapsed, ranges, width);
-		const text = truncateText(hit.record.text);
 		return {
 			agentId: hit.record.agentId,
 			displayName: hit.displayName,
@@ -209,8 +242,8 @@ export function buildSearchEnvelope(options: {
 			sourcePath: hit.record.sourcePath,
 			// Newlines are preserved here so the full prompt round-trips and stays reusable;
 			// `excerpt` is the collapsed display form.
-			text: text.text,
-			textTruncated: text.truncated,
+			text: hit.record.text,
+			textTruncated: false,
 			excerpt: excerpt.excerpt,
 			matchRanges: excerpt.ranges,
 			resumeCommand: formatResumeCommand(hit.resume, options.cwd, options.homeDir),
@@ -321,7 +354,7 @@ export function formatSearchSummary(
 	// With the default single role the column would be constant, so it is folded away.
 	const showRole = envelope.scope.roles.length > 1 || envelope.scope.roles[0] !== "user";
 	const agentLabels = envelope.matches.map((match) =>
-		showRole ? `${match.agentId}/${match.role}` : match.agentId,
+		collapseText(showRole ? `${match.agentId}/${match.role}` : match.agentId),
 	);
 	const agentWidth = Math.max(...agentLabels.map((label) => label.length));
 	// Results are numbered so --copy and --print can address one without a second search.
@@ -339,20 +372,24 @@ export function formatSearchSummary(
 			[
 				color(formatTimestamp(match.timestamp), "gray", useColor),
 				color((agentLabels[index] as string).padEnd(agentWidth), "bold", useColor),
-				color(match.project ?? "", "gray", useColor),
+				color(collapseText(match.project ?? ""), "gray", useColor),
 			]
 				.join("  ")
 				.trimEnd();
 		lines.push(header);
 		if (options.full) {
-			for (const line of wrapText(match.text, terminalWidth() - bodyIndent.length, 200)) {
+			for (const line of wrapText(
+				sanitizeTerminalText(match.text),
+				terminalWidth() - bodyIndent.length,
+				Number.POSITIVE_INFINITY,
+			)) {
 				lines.push(line.length === 0 ? "" : `${bodyIndent}${line}`);
 			}
 		} else {
 			lines.push(`${bodyIndent}${highlight(match.excerpt, match.matchRanges, useColor)}`);
 		}
 		if (match.resumeCommand) {
-			lines.push(`${bodyIndent}${color(match.resumeCommand, "dim", useColor)}`);
+			lines.push(`${bodyIndent}${color(collapseText(match.resumeCommand), "dim", useColor)}`);
 		}
 	});
 

--- a/src/lib/history/jsonl.ts
+++ b/src/lib/history/jsonl.ts
@@ -1,0 +1,142 @@
+import { createReadStream } from "node:fs";
+
+const DEFAULT_HIGH_WATER_MARK = 1 << 20;
+/** A single line above this is dropped rather than buffered. Real transcripts peak near 3 MB. */
+const DEFAULT_MAX_LINE_BYTES = 8 * 1024 * 1024;
+const NEWLINE = 0x0a;
+const CARRIAGE_RETURN = 0x0d;
+
+export type JsonlCounters = {
+	scannedBytes: number;
+	oversizedLines: number;
+};
+
+export type ReadJsonlOptions = {
+	/**
+	 * Gate applied to the decoded line before it is yielded. This is where the engine skips
+	 * ~99.98% of lines without ever calling JSON.parse, so it must stay cheap.
+	 */
+	prefilter?: (line: string) => boolean;
+	signal?: AbortSignal;
+	counters?: JsonlCounters;
+	highWaterMark?: number;
+	maxLineBytes?: number;
+};
+
+export type JsonlLine = {
+	text: string;
+	/** 0-based ordinal of this line in the file, counting lines the prefilter dropped. */
+	index: number;
+};
+
+/**
+ * Streams a JSONL file line by line without ever holding more than one line in memory.
+ *
+ * Deliberately hand-rolled rather than using `node:readline`: benchmarked over the real 1.6 GB
+ * corpus, manual chunk splitting is ~3.4x faster. Equally deliberate is decoding each line to a
+ * string before testing it — a byte-level scan that avoids decoding measured ~2.7x *slower*,
+ * because `String.prototype.toLowerCase`/`includes` are SIMD intrinsics and a JS byte loop is not.
+ * Please benchmark before "optimizing" either choice.
+ */
+export async function* readJsonlLines(
+	filePath: string,
+	options: ReadJsonlOptions = {},
+): AsyncGenerator<JsonlLine> {
+	const {
+		prefilter,
+		signal,
+		counters,
+		highWaterMark = DEFAULT_HIGH_WATER_MARK,
+		maxLineBytes = DEFAULT_MAX_LINE_BYTES,
+	} = options;
+
+	const stream = createReadStream(filePath, { highWaterMark });
+	let remainder = Buffer.alloc(0);
+	let index = 0;
+	// True while discarding the tail of an over-length line; cleared at the next newline.
+	let overflowing = false;
+
+	const take = (buffer: Buffer): JsonlLine | null => {
+		const current = index;
+		index += 1;
+		const end =
+			buffer.length > 0 && buffer[buffer.length - 1] === CARRIAGE_RETURN
+				? buffer.length - 1
+				: buffer.length;
+		if (end === 0) {
+			return null;
+		}
+		const text = buffer.toString("utf8", 0, end);
+		if (prefilter && !prefilter(text)) {
+			return null;
+		}
+		return { text, index: current };
+	};
+
+	try {
+		for await (const chunk of stream) {
+			if (signal?.aborted) {
+				return;
+			}
+			const buffer = chunk as Buffer;
+			if (counters) {
+				counters.scannedBytes += buffer.length;
+			}
+
+			const data = remainder.length > 0 ? Buffer.concat([remainder, buffer]) : buffer;
+			let start = 0;
+			for (;;) {
+				const newline = data.indexOf(NEWLINE, start);
+				if (newline === -1) {
+					break;
+				}
+				if (overflowing) {
+					overflowing = false;
+					start = newline + 1;
+					continue;
+				}
+				const lineBuffer = data.subarray(start, newline);
+				if (lineBuffer.length > maxLineBytes) {
+					if (counters) {
+						counters.oversizedLines += 1;
+					}
+					index += 1;
+				} else {
+					const line = take(lineBuffer);
+					if (line) {
+						yield line;
+					}
+				}
+				start = newline + 1;
+				if (signal?.aborted) {
+					return;
+				}
+			}
+
+			const rest = data.subarray(start);
+			if (overflowing) {
+				remainder = Buffer.alloc(0);
+			} else if (rest.length > maxLineBytes) {
+				if (counters) {
+					counters.oversizedLines += 1;
+				}
+				index += 1;
+				overflowing = true;
+				remainder = Buffer.alloc(0);
+			} else {
+				remainder = Buffer.from(rest);
+			}
+		}
+
+		// A file being appended to right now ends mid-record. Yield it anyway and let the caller's
+		// JSON.parse fail into the malformed counter — that is EOF, not an error.
+		if (!overflowing && remainder.length > 0 && !signal?.aborted) {
+			const line = take(remainder);
+			if (line) {
+				yield line;
+			}
+		}
+	} finally {
+		stream.destroy();
+	}
+}

--- a/src/lib/history/picker.ts
+++ b/src/lib/history/picker.ts
@@ -261,6 +261,10 @@ export type PickerIo = {
 	useColor: boolean;
 };
 
+function rewindFrame(lineCount: number): string {
+	return lineCount > 1 ? `\r\x1b[${lineCount - 1}A` : "\r";
+}
+
 /**
  * Thin IO shell. All decisions live in the pure helpers above; this only paints frames and feeds
  * keystrokes in, so the picker's behavior is testable without a terminal.
@@ -285,10 +289,7 @@ export function runPicker(
 				query: options.query,
 				useColor: io.useColor,
 			});
-			let out = "";
-			if (painted > 0) {
-				out += `\x1b[${painted}A`;
-			}
+			let out = rewindFrame(painted);
 			out += ANSI.clearDown;
 			out += frame.join("\n");
 			io.output.write(out);
@@ -309,9 +310,7 @@ export function runPicker(
 			}
 			io.input.pause();
 			// Erase the picker so the terminal is left exactly as it was found.
-			io.output.write(
-				`${painted > 0 ? `\x1b[${painted}A` : ""}${ANSI.clearDown}${ANSI.showCursor}`,
-			);
+			io.output.write(`${rewindFrame(painted)}${ANSI.clearDown}${ANSI.showCursor}`);
 			resolve(outcome);
 		};
 

--- a/src/lib/history/picker.ts
+++ b/src/lib/history/picker.ts
@@ -1,0 +1,348 @@
+import readline from "node:readline";
+import { formatTimestamp, wrapText } from "./format.js";
+import type { SearchMatch } from "./types.js";
+
+const MAX_LIST_ROWS = 10;
+const MIN_BODY_ROWS = 3;
+/** title, blank, separator, blank, hint */
+const CHROME_ROWS = 5;
+
+const ANSI = {
+	reset: "\x1b[0m",
+	bold: "\x1b[1m",
+	dim: "\x1b[2m",
+	reverse: "\x1b[7m",
+	hideCursor: "\x1b[?25l",
+	showCursor: "\x1b[?25h",
+	clearDown: "\x1b[0J",
+} as const;
+
+export type PickerKey = {
+	name?: string;
+	ctrl?: boolean;
+	meta?: boolean;
+	sequence?: string;
+};
+
+export type PickerOutcome =
+	| { type: "active" }
+	| { type: "quit" }
+	| { type: "copy-text"; match: SearchMatch }
+	| { type: "copy-resume"; match: SearchMatch };
+
+export type PickerEntry = {
+	match: SearchMatch;
+	/** 1-based position in the unfiltered result list, so numbers stay stable while filtering. */
+	number: number;
+	haystack: string;
+};
+
+export type PickerState = {
+	entries: PickerEntry[];
+	filter: string;
+	visible: number[];
+	selected: number;
+	offset: number;
+	outcome: PickerOutcome;
+};
+
+export type PickerDimensions = {
+	rows: number;
+	columns: number;
+};
+
+export function buildEntries(matches: SearchMatch[]): PickerEntry[] {
+	return matches.map((match, index) => ({
+		match,
+		number: index + 1,
+		// Filtering also spans agent and project so `codex` or a repo name narrows the list.
+		haystack: `${match.text}\n${match.agentId}\n${match.project ?? ""}`.toLowerCase(),
+	}));
+}
+
+function computeVisible(entries: PickerEntry[], filter: string): number[] {
+	const terms = filter.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (terms.length === 0) {
+		return entries.map((_, index) => index);
+	}
+	// Same AND-across-terms rule as the command-line query, so the filter behaves predictably.
+	const visible: number[] = [];
+	entries.forEach((entry, index) => {
+		if (terms.every((term) => entry.haystack.includes(term))) {
+			visible.push(index);
+		}
+	});
+	return visible;
+}
+
+export function createPickerState(entries: PickerEntry[]): PickerState {
+	return {
+		entries,
+		filter: "",
+		visible: computeVisible(entries, ""),
+		selected: 0,
+		offset: 0,
+		outcome: { type: "active" },
+	};
+}
+
+function clampSelection(state: PickerState, listRows: number): PickerState {
+	const maxIndex = Math.max(0, state.visible.length - 1);
+	const selected = Math.min(Math.max(state.selected, 0), maxIndex);
+	let offset = state.offset;
+	if (selected < offset) {
+		offset = selected;
+	} else if (selected >= offset + listRows) {
+		offset = selected - listRows + 1;
+	}
+	offset = Math.max(0, Math.min(offset, Math.max(0, state.visible.length - listRows)));
+	return { ...state, selected, offset };
+}
+
+export function selectedMatch(state: PickerState): SearchMatch | null {
+	const entryIndex = state.visible[state.selected];
+	if (entryIndex === undefined) {
+		return null;
+	}
+	return state.entries[entryIndex]?.match ?? null;
+}
+
+function withFilter(state: PickerState, filter: string): PickerState {
+	const visible = computeVisible(state.entries, filter);
+	return { ...state, filter, visible, selected: 0, offset: 0 };
+}
+
+function isPrintable(key: PickerKey): boolean {
+	const sequence = key.sequence;
+	if (!sequence || key.ctrl || key.meta) {
+		return false;
+	}
+	return sequence.length === 1 && sequence >= " " && sequence !== "\x7f";
+}
+
+export function handleKey(state: PickerState, key: PickerKey, listRows: number): PickerState {
+	if (key.ctrl && (key.name === "c" || key.name === "d")) {
+		return { ...state, outcome: { type: "quit" } };
+	}
+	if (key.ctrl && key.name === "r") {
+		const match = selectedMatch(state);
+		return match ? { ...state, outcome: { type: "copy-resume", match } } : state;
+	}
+	if (key.name === "return" || key.name === "enter") {
+		const match = selectedMatch(state);
+		return match ? { ...state, outcome: { type: "copy-text", match } } : state;
+	}
+	if (key.name === "escape") {
+		// Escape peels off the filter first; only an already-empty filter exits.
+		return state.filter.length > 0
+			? clampSelection(withFilter(state, ""), listRows)
+			: { ...state, outcome: { type: "quit" } };
+	}
+	if (key.name === "up" || (key.ctrl && key.name === "p")) {
+		return clampSelection({ ...state, selected: state.selected - 1 }, listRows);
+	}
+	if (key.name === "down" || (key.ctrl && key.name === "n")) {
+		return clampSelection({ ...state, selected: state.selected + 1 }, listRows);
+	}
+	if (key.name === "pageup") {
+		return clampSelection({ ...state, selected: state.selected - listRows }, listRows);
+	}
+	if (key.name === "pagedown") {
+		return clampSelection({ ...state, selected: state.selected + listRows }, listRows);
+	}
+	if (key.name === "home") {
+		return clampSelection({ ...state, selected: 0 }, listRows);
+	}
+	if (key.name === "end") {
+		return clampSelection({ ...state, selected: state.visible.length - 1 }, listRows);
+	}
+	if (key.name === "backspace") {
+		return state.filter.length === 0
+			? state
+			: clampSelection(withFilter(state, state.filter.slice(0, -1)), listRows);
+	}
+	if (isPrintable(key)) {
+		return clampSelection(withFilter(state, state.filter + key.sequence), listRows);
+	}
+	return state;
+}
+
+export function layout(
+	dimensions: PickerDimensions,
+	entryCount: number,
+): { listRows: number; previewRows: number } {
+	const usable = Math.max(10, dimensions.rows - 1);
+	const body = Math.max(MIN_BODY_ROWS, usable - CHROME_ROWS);
+	const listRows = Math.max(1, Math.min(entryCount || 1, MAX_LIST_ROWS, Math.ceil(body * 0.6)));
+	const previewRows = Math.max(1, body - listRows);
+	return { listRows, previewRows };
+}
+
+function truncate(value: string, width: number): string {
+	if (value.length <= width) {
+		return value;
+	}
+	return width <= 1 ? value.slice(0, width) : `${value.slice(0, width - 1)}…`;
+}
+
+export function renderPicker(
+	state: PickerState,
+	dimensions: PickerDimensions,
+	options: { query: string; useColor: boolean },
+): string[] {
+	const width = Math.max(20, dimensions.columns - 1);
+	const { listRows, previewRows } = layout(dimensions, state.entries.length);
+	const positioned = clampSelection(state, listRows);
+	const style = (value: string, code: string) =>
+		options.useColor ? `${code}${value}${ANSI.reset}` : value;
+
+	const total = state.entries.length;
+	const shown = positioned.visible.length;
+	const counter = shown === total ? `${total} matches` : `${shown} of ${total}`;
+	const header =
+		positioned.filter.length > 0
+			? `${options.query} › ${positioned.filter}▏  ${counter}`
+			: `${options.query} · ${counter}`;
+
+	const lines: string[] = [style(truncate(header, width), ANSI.dim), ""];
+
+	if (shown === 0) {
+		lines.push(style(truncate("  no matches for this filter", width), ANSI.dim));
+		for (let index = 1; index < listRows; index += 1) {
+			lines.push("");
+		}
+	} else {
+		const numberWidth = String(total).length;
+		// Pad the agent column so the project column lines up across agents of differing name length.
+		const agentWidth = Math.max(...positioned.entries.map((entry) => entry.match.agentId.length));
+		for (let row = 0; row < listRows; row += 1) {
+			const visibleIndex = positioned.offset + row;
+			if (visibleIndex >= shown) {
+				lines.push("");
+				continue;
+			}
+			const entry = positioned.entries[positioned.visible[visibleIndex] as number] as PickerEntry;
+			const marker = visibleIndex === positioned.selected ? "▸" : " ";
+			const label = `${marker} [${String(entry.number).padStart(numberWidth)}] ${formatTimestamp(
+				entry.match.timestamp,
+			)}  ${entry.match.agentId.padEnd(agentWidth)}  ${entry.match.project ?? ""}`;
+			const clamped = truncate(label.trimEnd(), width);
+			lines.push(
+				visibleIndex === positioned.selected ? style(clamped.padEnd(width), ANSI.reverse) : clamped,
+			);
+		}
+	}
+
+	lines.push(style("─".repeat(width), ANSI.dim));
+
+	const match = selectedMatch(positioned);
+	const preview = match ? wrapText(match.text, width, previewRows) : [];
+	for (let row = 0; row < previewRows; row += 1) {
+		lines.push(preview[row] ?? "");
+	}
+
+	lines.push("");
+	lines.push(
+		style(
+			truncate(
+				"↑↓ move · type to filter · enter copy · ctrl-r resume cmd · esc/ctrl-c quit",
+				width,
+			),
+			ANSI.dim,
+		),
+	);
+	return lines;
+}
+
+export type PickerIo = {
+	input: NodeJS.ReadStream;
+	output: NodeJS.WriteStream;
+	useColor: boolean;
+};
+
+/**
+ * Thin IO shell. All decisions live in the pure helpers above; this only paints frames and feeds
+ * keystrokes in, so the picker's behavior is testable without a terminal.
+ */
+export function runPicker(
+	matches: SearchMatch[],
+	io: PickerIo,
+	options: { query: string },
+): Promise<PickerOutcome> {
+	return new Promise((resolve) => {
+		let state = createPickerState(buildEntries(matches));
+		let painted = 0;
+		let settled = false;
+
+		const dimensions = (): PickerDimensions => ({
+			rows: io.output.rows ?? 24,
+			columns: io.output.columns ?? 80,
+		});
+
+		const paint = () => {
+			const frame = renderPicker(state, dimensions(), {
+				query: options.query,
+				useColor: io.useColor,
+			});
+			let out = "";
+			if (painted > 0) {
+				out += `\x1b[${painted}A`;
+			}
+			out += ANSI.clearDown;
+			out += frame.join("\n");
+			io.output.write(out);
+			painted = frame.length;
+		};
+
+		const finish = (outcome: PickerOutcome) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			io.input.removeListener("keypress", onKeypress);
+			io.input.removeListener("end", onClosed);
+			io.input.removeListener("close", onClosed);
+			io.output.removeListener("resize", paint);
+			if (io.input.isTTY) {
+				io.input.setRawMode(false);
+			}
+			io.input.pause();
+			// Erase the picker so the terminal is left exactly as it was found.
+			io.output.write(
+				`${painted > 0 ? `\x1b[${painted}A` : ""}${ANSI.clearDown}${ANSI.showCursor}`,
+			);
+			resolve(outcome);
+		};
+
+		// Without this, a stdin that reaches EOF (a closed pipe, a detached terminal) leaves the
+		// picker waiting for a keystroke that can never arrive.
+		function onClosed() {
+			finish({ type: "quit" });
+		}
+
+		function onKeypress(_: string | undefined, key: PickerKey | undefined) {
+			if (!key) {
+				return;
+			}
+			const { listRows } = layout(dimensions(), state.entries.length);
+			state = handleKey(state, key, listRows);
+			if (state.outcome.type !== "active") {
+				finish(state.outcome);
+				return;
+			}
+			paint();
+		}
+
+		readline.emitKeypressEvents(io.input);
+		if (io.input.isTTY) {
+			io.input.setRawMode(true);
+		}
+		io.input.resume();
+		io.input.on("keypress", onKeypress);
+		io.input.on("end", onClosed);
+		io.input.on("close", onClosed);
+		io.output.on("resize", paint);
+		io.output.write(ANSI.hideCursor);
+		paint();
+	});
+}

--- a/src/lib/history/picker.ts
+++ b/src/lib/history/picker.ts
@@ -1,9 +1,8 @@
 import readline from "node:readline";
-import { formatTimestamp, wrapText } from "./format.js";
+import { collapseText, formatTimestamp, sanitizeTerminalText, wrapText } from "./format.js";
 import type { SearchMatch } from "./types.js";
 
 const MAX_LIST_ROWS = 10;
-const MIN_BODY_ROWS = 3;
 /** title, blank, separator, blank, hint */
 const CHROME_ROWS = 5;
 
@@ -171,10 +170,9 @@ export function layout(
 	dimensions: PickerDimensions,
 	entryCount: number,
 ): { listRows: number; previewRows: number } {
-	const usable = Math.max(10, dimensions.rows - 1);
-	const body = Math.max(MIN_BODY_ROWS, usable - CHROME_ROWS);
+	const body = Math.max(1, dimensions.rows - CHROME_ROWS);
 	const listRows = Math.max(1, Math.min(entryCount || 1, MAX_LIST_ROWS, Math.ceil(body * 0.6)));
-	const previewRows = Math.max(1, body - listRows);
+	const previewRows = Math.max(0, body - listRows);
 	return { listRows, previewRows };
 }
 
@@ -199,10 +197,11 @@ export function renderPicker(
 	const total = state.entries.length;
 	const shown = positioned.visible.length;
 	const counter = shown === total ? `${total} matches` : `${shown} of ${total}`;
-	const header =
+	const header = collapseText(
 		positioned.filter.length > 0
 			? `${options.query} › ${positioned.filter}▏  ${counter}`
-			: `${options.query} · ${counter}`;
+			: `${options.query} · ${counter}`,
+	);
 
 	const lines: string[] = [style(truncate(header, width), ANSI.dim), ""];
 
@@ -223,9 +222,11 @@ export function renderPicker(
 			}
 			const entry = positioned.entries[positioned.visible[visibleIndex] as number] as PickerEntry;
 			const marker = visibleIndex === positioned.selected ? "▸" : " ";
-			const label = `${marker} [${String(entry.number).padStart(numberWidth)}] ${formatTimestamp(
-				entry.match.timestamp,
-			)}  ${entry.match.agentId.padEnd(agentWidth)}  ${entry.match.project ?? ""}`;
+			const label = collapseText(
+				`${marker} [${String(entry.number).padStart(numberWidth)}] ${formatTimestamp(
+					entry.match.timestamp,
+				)}  ${entry.match.agentId.padEnd(agentWidth)}  ${entry.match.project ?? ""}`,
+			);
 			const clamped = truncate(label.trimEnd(), width);
 			lines.push(
 				visibleIndex === positioned.selected ? style(clamped.padEnd(width), ANSI.reverse) : clamped,
@@ -236,7 +237,7 @@ export function renderPicker(
 	lines.push(style("─".repeat(width), ANSI.dim));
 
 	const match = selectedMatch(positioned);
-	const preview = match ? wrapText(match.text, width, previewRows) : [];
+	const preview = match ? wrapText(sanitizeTerminalText(match.text), width, previewRows) : [];
 	for (let row = 0; row < previewRows; row += 1) {
 		lines.push(preview[row] ?? "");
 	}
@@ -251,7 +252,7 @@ export function renderPicker(
 			ANSI.dim,
 		),
 	);
-	return lines;
+	return lines.slice(0, Math.max(1, dimensions.rows));
 }
 
 export type PickerIo = {

--- a/src/lib/history/query.ts
+++ b/src/lib/history/query.ts
@@ -18,9 +18,8 @@ export type HistoryQuery = {
 	regex: RegExp | null;
 	caseSensitive: boolean;
 	/**
-	 * Case-normalized substring safe to test against a raw JSON line before parsing it.
-	 * Null when no safe needle is derivable, in which case every candidate line is parsed.
-	 * May yield false positives (rejected after parse); never false negatives.
+	 * Case-normalized substring candidate for a target-owned raw-line prefilter. The target must
+	 * account for its encoding and normalization; null means every candidate line must be parsed.
 	 */
 	prefilter: string | null;
 };
@@ -93,8 +92,8 @@ export function compileQuery(
 }
 
 /**
- * Cheap gate run on the raw JSON line before `JSON.parse`. Skips the overwhelming majority of
- * lines; a `true` result only means "worth parsing", never "matches".
+ * Cheap literal gate for encodings guaranteed to retain the needle verbatim. Targets whose
+ * records can escape or transform text must wrap this with their own conservative checks.
  */
 export function prefilterLine(query: HistoryQuery, line: string): boolean {
 	if (query.prefilter === null) {
@@ -104,6 +103,37 @@ export function prefilterLine(query: HistoryQuery, line: string): boolean {
 	// make search results depend on the ambient LANG.
 	const haystack = query.caseSensitive ? line : line.toLowerCase();
 	return haystack.includes(query.prefilter);
+}
+
+/**
+ * Conservative prefilter for JSON records whose normalized text is assembled from string fields.
+ * Legal JSON may escape any character as `\uXXXX` (and `/` as `\/`), so those lines must be
+ * parsed. Multiple text fields are also admitted because normalization may join their values.
+ */
+export function prefilterJsonLine(query: HistoryQuery, line: string): boolean {
+	if (line.includes("\\u") || line.includes("\\/")) {
+		return true;
+	}
+	const firstTextField = findJsonTextField(line);
+	if (firstTextField !== -1 && findJsonTextField(line, firstTextField + 6) !== -1) {
+		return true;
+	}
+	return prefilterLine(query, line);
+}
+
+function findJsonTextField(line: string, from = 0): number {
+	let index = line.indexOf('"text"', from);
+	while (index !== -1) {
+		let cursor = index + 6;
+		while (cursor < line.length && /\s/.test(line[cursor] as string)) {
+			cursor += 1;
+		}
+		if (line[cursor] === ":") {
+			return index;
+		}
+		index = line.indexOf('"text"', index + 6);
+	}
+	return -1;
 }
 
 /** Authoritative match, run against a record's cleaned text. */

--- a/src/lib/history/query.ts
+++ b/src/lib/history/query.ts
@@ -1,0 +1,168 @@
+/** Shortest prefilter needle worth using. Below this the scan cost beats the parse it saves. */
+const MIN_PREFILTER_LENGTH = 3;
+
+/**
+ * Characters JSON string-escaping rewrites, plus whitespace. A needle spanning one of these
+ * cannot be tested against a raw transcript line: the prompt `say "hi"` is stored as
+ * `say \"hi\"`, so the needle `"hi"` would false-negative, and a newline inside a prompt is
+ * stored as the two characters `\n`. Splitting on them yields runs that survive escaping intact.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: control chars are exactly what JSON escapes.
+const PREFILTER_UNSAFE = /[\u0000-\u0020"\\]+/;
+
+export type HistoryQuery = {
+	/** The query as the user typed it, for display and the JSON envelope. */
+	raw: string;
+	/** Literal mode only. Every term must be present. Case-normalized unless caseSensitive. */
+	terms: string[];
+	regex: RegExp | null;
+	caseSensitive: boolean;
+	/**
+	 * Case-normalized substring safe to test against a raw JSON line before parsing it.
+	 * Null when no safe needle is derivable, in which case every candidate line is parsed.
+	 * May yield false positives (rejected after parse); never false negatives.
+	 */
+	prefilter: string | null;
+};
+
+export class InvalidQueryError extends Error {
+	readonly code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "InvalidQueryError";
+		this.code = code;
+	}
+}
+
+function longestSafeRun(value: string): string {
+	let best = "";
+	for (const run of value.split(PREFILTER_UNSAFE)) {
+		if (run.length > best.length) {
+			best = run;
+		}
+	}
+	return best;
+}
+
+function derivePrefilter(terms: string[]): string | null {
+	let best = "";
+	for (const term of terms) {
+		const run = longestSafeRun(term);
+		if (run.length > best.length) {
+			best = run;
+		}
+	}
+	return best.length >= MIN_PREFILTER_LENGTH ? best : null;
+}
+
+/**
+ * Each positional argument is one term. That is what makes quoting the phrase operator without
+ * a dedicated flag: `search merge conflict` arrives as two terms (ANDed), while
+ * `search "merge conflict"` arrives as a single term containing a space (matched as a phrase).
+ * Joining and re-splitting on whitespace would erase that distinction.
+ */
+export function compileQuery(
+	input: string[],
+	options: { regex?: boolean; caseSensitive?: boolean } = {},
+): HistoryQuery {
+	const caseSensitive = options.caseSensitive === true;
+	const pieces = input.map((value) => String(value)).filter((value) => value.length > 0);
+	const raw = pieces.join(" ");
+
+	if (options.regex === true) {
+		const pattern = pieces[0];
+		if (pieces.length !== 1 || pattern === undefined) {
+			throw new InvalidQueryError(
+				"invalid_regex_query",
+				"--regex requires a single quoted pattern.",
+			);
+		}
+		let regex: RegExp;
+		try {
+			regex = new RegExp(pattern, caseSensitive ? "" : "i");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new InvalidQueryError("invalid_regex", `--regex pattern is invalid: ${message}`);
+		}
+		return { raw, terms: [], regex, caseSensitive, prefilter: null };
+	}
+
+	const terms = pieces.map((term) => (caseSensitive ? term : term.toLowerCase()));
+	return { raw, terms, regex: null, caseSensitive, prefilter: derivePrefilter(terms) };
+}
+
+/**
+ * Cheap gate run on the raw JSON line before `JSON.parse`. Skips the overwhelming majority of
+ * lines; a `true` result only means "worth parsing", never "matches".
+ */
+export function prefilterLine(query: HistoryQuery, line: string): boolean {
+	if (query.prefilter === null) {
+		return true;
+	}
+	// Deliberately toLowerCase, never toLocaleLowerCase: the Turkish dotless i would otherwise
+	// make search results depend on the ambient LANG.
+	const haystack = query.caseSensitive ? line : line.toLowerCase();
+	return haystack.includes(query.prefilter);
+}
+
+/** Authoritative match, run against a record's cleaned text. */
+export function matchesText(query: HistoryQuery, text: string): boolean {
+	if (query.regex) {
+		return query.regex.test(text);
+	}
+	if (query.terms.length === 0) {
+		return false;
+	}
+	const haystack = query.caseSensitive ? text : text.toLowerCase();
+	return query.terms.every((term) => haystack.includes(term));
+}
+
+function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
+	if (ranges.length < 2) {
+		return ranges;
+	}
+	const sorted = [...ranges].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+	const first = sorted[0] as [number, number];
+	const merged: Array<[number, number]> = [[first[0], first[1]]];
+	for (const range of sorted.slice(1)) {
+		const last = merged[merged.length - 1] as [number, number];
+		if (range[0] <= last[1]) {
+			last[1] = Math.max(last[1], range[1]);
+		} else {
+			merged.push([range[0], range[1]]);
+		}
+	}
+	return merged;
+}
+
+/** Highlight ranges within display text. Offsets index the string passed in, not the raw record. */
+export function findRanges(query: HistoryQuery, text: string): Array<[number, number]> {
+	const ranges: Array<[number, number]> = [];
+
+	if (query.regex) {
+		const flags = query.regex.flags.includes("g") ? query.regex.flags : `${query.regex.flags}g`;
+		const global = new RegExp(query.regex.source, flags);
+		for (const match of text.matchAll(global)) {
+			if (match.index === undefined || match[0].length === 0) {
+				continue;
+			}
+			ranges.push([match.index, match.index + match[0].length]);
+		}
+		return mergeRanges(ranges);
+	}
+
+	const haystack = query.caseSensitive ? text : text.toLowerCase();
+	for (const term of query.terms) {
+		let from = 0;
+		for (;;) {
+			const index = haystack.indexOf(term, from);
+			if (index === -1) {
+				break;
+			}
+			ranges.push([index, index + term.length]);
+			from = index + term.length;
+		}
+	}
+	return mergeRanges(ranges);
+}

--- a/src/lib/history/search.ts
+++ b/src/lib/history/search.ts
@@ -1,0 +1,281 @@
+import type { ResolvedTarget } from "../targets/config-types.js";
+import { recordMatchesScope } from "./filters.js";
+import { type JsonlCounters, readJsonlLines } from "./jsonl.js";
+import { type HistoryQuery, matchesText, prefilterLine } from "./query.js";
+import type {
+	HistoryContext,
+	HistoryFile,
+	HistoryRole,
+	SearchHit,
+	SearchNote,
+	SearchRecord,
+	SearchScope,
+	SearchStats,
+	TargetHistoryDefinition,
+} from "./types.js";
+
+const DEFAULT_CONCURRENCY = 8;
+/**
+ * Backstop against a pathological query (`--regex .` over `--role all`). Buffering hits is cheap
+ * — a real corpus holds only a few thousand user records — but it must still be bounded.
+ */
+const MAX_BUFFERED_HITS = 10_000;
+
+export type SearchOptions = {
+	targets: ResolvedTarget[];
+	query: HistoryQuery;
+	scope: SearchScope;
+	roles: Set<HistoryRole>;
+	limit: number;
+	homeDir: string;
+	cwd: string;
+	signal: AbortSignal;
+	concurrency?: number;
+};
+
+export type SearchResult = {
+	hits: SearchHit[];
+	stats: SearchStats;
+	errors: SearchNote[];
+	notes: SearchNote[];
+};
+
+type QueuedFile = {
+	file: HistoryFile;
+	target: ResolvedTarget;
+	history: TargetHistoryDefinition;
+	context: HistoryContext;
+};
+
+/**
+ * Tolerates a capability that hands back a promise, or a plain sync iterable, instead of the
+ * declared async iterable. Built-ins get this right by construction; a hand-written custom target
+ * should degrade rather than crash with "undefined is not async iterable".
+ */
+async function* toAsyncIterable<T>(value: unknown): AsyncGenerator<T> {
+	const resolved = (await value) as AsyncIterable<T> | Iterable<T> | null | undefined;
+	if (!resolved) {
+		return;
+	}
+	if (typeof (resolved as AsyncIterable<T>)[Symbol.asyncIterator] === "function") {
+		yield* resolved as AsyncIterable<T>;
+		return;
+	}
+	if (typeof (resolved as Iterable<T>)[Symbol.iterator] === "function") {
+		yield* resolved as Iterable<T>;
+	}
+}
+
+function isUsableRecord(value: unknown): value is SearchRecord {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const record = value as SearchRecord;
+	return typeof record.text === "string" && record.text.length > 0;
+}
+
+async function runPool<T>(
+	items: T[],
+	concurrency: number,
+	worker: (item: T) => Promise<void>,
+): Promise<void> {
+	let cursor = 0;
+	const size = Math.max(1, Math.min(concurrency, items.length));
+	const workers = Array.from({ length: size }, async () => {
+		for (;;) {
+			const index = cursor;
+			cursor += 1;
+			if (index >= items.length) {
+				return;
+			}
+			await worker(items[index] as T);
+		}
+	});
+	await Promise.all(workers);
+}
+
+function compareHits(a: SearchHit, b: SearchHit): number {
+	const left = a.record.timestamp ? Date.parse(a.record.timestamp) : Number.NaN;
+	const right = b.record.timestamp ? Date.parse(b.record.timestamp) : Number.NaN;
+	const leftValid = !Number.isNaN(left);
+	const rightValid = !Number.isNaN(right);
+	// Records without a usable timestamp sort last rather than jumbling the newest-first order.
+	if (leftValid !== rightValid) {
+		return leftValid ? -1 : 1;
+	}
+	if (leftValid && rightValid && left !== right) {
+		return right - left;
+	}
+	// Deterministic tie-break so output is stable across runs and across machines.
+	return (
+		a.record.agentId.localeCompare(b.record.agentId) ||
+		a.record.sessionId.localeCompare(b.record.sessionId) ||
+		a.record.recordIndex - b.record.recordIndex
+	);
+}
+
+export async function searchHistory(options: SearchOptions): Promise<SearchResult> {
+	const startedAt = Date.now();
+	const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+	const stats: SearchStats = {
+		scannedFiles: 0,
+		skippedFiles: 0,
+		scannedBytes: 0,
+		malformedRecords: 0,
+		oversizedLines: 0,
+		matchedRecords: 0,
+		returnedMatches: 0,
+		truncated: false,
+		elapsedMs: 0,
+	};
+	const errors: SearchNote[] = [];
+	const notes: SearchNote[] = [];
+	const hits: SearchHit[] = [];
+
+	const queue: QueuedFile[] = [];
+	for (const target of options.targets) {
+		const history = target.history;
+		if (!history) {
+			continue;
+		}
+		const supported = new Set(history.roles);
+		const requested = new Set([...options.roles].filter((role) => supported.has(role)));
+		if (requested.size === 0) {
+			notes.push({
+				targetId: target.id,
+				displayName: target.displayName,
+				code: "role_unsupported",
+				message: `${target.displayName} does not record ${[...options.roles].join(", ")} messages.`,
+			});
+			continue;
+		}
+
+		const context: HistoryContext = {
+			targetId: target.id,
+			displayName: target.displayName,
+			homeDir: options.homeDir,
+			cwd: options.cwd,
+			roles: requested,
+			signal: options.signal,
+		};
+
+		try {
+			let found = 0;
+			for await (const file of toAsyncIterable<HistoryFile>(
+				history.listFiles(options.scope, context),
+			)) {
+				found += 1;
+				queue.push({ file, target, history, context });
+			}
+			if (found === 0) {
+				notes.push({
+					targetId: target.id,
+					displayName: target.displayName,
+					code: "history_unavailable",
+					message: `No ${target.displayName} history was found to search.`,
+				});
+			}
+		} catch (error) {
+			errors.push({
+				targetId: target.id,
+				displayName: target.displayName,
+				code: "history_list_failed",
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	// Newest file first. Results are sorted authoritatively at the end regardless, but this makes
+	// the MAX_BUFFERED_HITS backstop discard the least interesting matches if it ever fires.
+	queue.sort((a, b) => (b.file.modifiedAt ?? "").localeCompare(a.file.modifiedAt ?? ""));
+
+	const counters: JsonlCounters = { scannedBytes: 0, oversizedLines: 0 };
+
+	const collect = (record: SearchRecord, entry: QueuedFile): void => {
+		if (!options.roles.has(record.role)) {
+			return;
+		}
+		if (!recordMatchesScope(record, options.scope)) {
+			return;
+		}
+		if (!matchesText(options.query, record.text)) {
+			return;
+		}
+		stats.matchedRecords += 1;
+		hits.push({
+			record,
+			displayName: entry.target.displayName,
+			resume: entry.history.resume ? (entry.history.resume(record) ?? null) : null,
+		});
+		if (hits.length > MAX_BUFFERED_HITS) {
+			hits.sort(compareHits);
+			hits.length = MAX_BUFFERED_HITS;
+			stats.truncated = true;
+		}
+	};
+
+	await runPool(queue, concurrency, async (entry) => {
+		if (options.signal.aborted) {
+			return;
+		}
+		try {
+			const custom = entry.history.scan?.kind === "custom" ? entry.history.scan : null;
+			if (custom) {
+				// A bespoke store forgoes the raw-line prefilter; it hands back records directly.
+				for await (const record of toAsyncIterable<SearchRecord>(
+					custom.read(entry.file, entry.context),
+				)) {
+					if (options.signal.aborted) {
+						return;
+					}
+					if (!isUsableRecord(record)) {
+						stats.malformedRecords += 1;
+						continue;
+					}
+					collect(record, entry);
+				}
+				stats.scannedFiles += 1;
+				return;
+			}
+
+			const normalize = entry.history.normalize;
+			if (!normalize) {
+				return;
+			}
+			for await (const line of readJsonlLines(entry.file.path, {
+				prefilter: (text) => prefilterLine(options.query, text),
+				signal: options.signal,
+				counters,
+			})) {
+				const record = normalize(line.text, entry.file, line.index, entry.context);
+				if (record === null) {
+					continue;
+				}
+				if (!isUsableRecord(record)) {
+					stats.malformedRecords += 1;
+					continue;
+				}
+				collect(record, entry);
+			}
+			stats.scannedFiles += 1;
+		} catch {
+			// One unreadable or hostile transcript must never abort a whole-corpus search, and it
+			// is not an error worth failing the command over. The caller aggregates the count into
+			// a single note.
+			stats.skippedFiles += 1;
+		}
+	});
+
+	stats.scannedBytes = counters.scannedBytes;
+	stats.oversizedLines = counters.oversizedLines;
+
+	hits.sort(compareHits);
+	const limited = options.limit > 0 ? hits.slice(0, options.limit) : hits;
+	if (limited.length < hits.length) {
+		stats.truncated = true;
+	}
+	stats.returnedMatches = limited.length;
+	stats.elapsedMs = Date.now() - startedAt;
+
+	return { hits: limited, stats, errors, notes };
+}

--- a/src/lib/history/search.ts
+++ b/src/lib/history/search.ts
@@ -1,7 +1,7 @@
 import type { ResolvedTarget } from "../targets/config-types.js";
 import { recordMatchesScope } from "./filters.js";
 import { type JsonlCounters, readJsonlLines } from "./jsonl.js";
-import { type HistoryQuery, matchesText, prefilterLine } from "./query.js";
+import { type HistoryQuery, matchesText } from "./query.js";
 import type {
 	HistoryContext,
 	HistoryFile,
@@ -242,8 +242,9 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 			if (!normalize) {
 				return;
 			}
+			const prefilter = entry.history.prefilter;
 			for await (const line of readJsonlLines(entry.file.path, {
-				prefilter: (text) => prefilterLine(options.query, text),
+				prefilter: prefilter ? (text) => prefilter(text, options.query) : undefined,
 				signal: options.signal,
 				counters,
 			})) {

--- a/src/lib/history/search.ts
+++ b/src/lib/history/search.ts
@@ -1,17 +1,19 @@
 import type { ResolvedTarget } from "../targets/config-types.js";
+import { BoundedTopK } from "./bounded-top-k.js";
 import { recordMatchesScope } from "./filters.js";
 import { type JsonlCounters, readJsonlLines } from "./jsonl.js";
 import { type HistoryQuery, matchesText } from "./query.js";
-import type {
-	HistoryContext,
-	HistoryFile,
-	HistoryRole,
-	SearchHit,
-	SearchNote,
-	SearchRecord,
-	SearchScope,
-	SearchStats,
-	TargetHistoryDefinition,
+import {
+	type HistoryContext,
+	type HistoryFile,
+	type HistoryRole,
+	isHistoryRole,
+	type SearchHit,
+	type SearchNote,
+	type SearchRecord,
+	type SearchScope,
+	type SearchStats,
+	type TargetHistoryDefinition,
 } from "./types.js";
 
 const DEFAULT_CONCURRENCY = 8;
@@ -66,12 +68,28 @@ async function* toAsyncIterable<T>(value: unknown): AsyncGenerator<T> {
 	}
 }
 
-function isUsableRecord(value: unknown): value is SearchRecord {
+function isSearchRecord(value: unknown): value is SearchRecord {
 	if (!value || typeof value !== "object") {
 		return false;
 	}
-	const record = value as SearchRecord;
-	return typeof record.text === "string" && record.text.length > 0;
+	const record = value as Record<string, unknown>;
+	return (
+		typeof record.agentId === "string" &&
+		typeof record.role === "string" &&
+		isHistoryRole(record.role) &&
+		(record.timestamp === null || typeof record.timestamp === "string") &&
+		typeof record.text === "string" &&
+		record.text.length > 0 &&
+		typeof record.sessionId === "string" &&
+		(record.cwd === null || typeof record.cwd === "string") &&
+		(record.gitBranch === undefined ||
+			record.gitBranch === null ||
+			typeof record.gitBranch === "string") &&
+		typeof record.sourcePath === "string" &&
+		typeof record.recordIndex === "number" &&
+		Number.isInteger(record.recordIndex) &&
+		record.recordIndex >= 0
+	);
 }
 
 async function runPool<T>(
@@ -130,7 +148,9 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 	};
 	const errors: SearchNote[] = [];
 	const notes: SearchNote[] = [];
-	const hits: SearchHit[] = [];
+	const hitCapacity =
+		options.limit > 0 ? Math.min(options.limit, MAX_BUFFERED_HITS) : MAX_BUFFERED_HITS;
+	const hits = new BoundedTopK<SearchHit>(hitCapacity, compareHits);
 
 	const queue: QueuedFile[] = [];
 	for (const target of options.targets) {
@@ -185,8 +205,8 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 		}
 	}
 
-	// Newest file first. Results are sorted authoritatively at the end regardless, but this makes
-	// the MAX_BUFFERED_HITS backstop discard the least interesting matches if it ever fires.
+	// Process recent transcripts first for predictable scan behavior. The bounded heap and its
+	// comparator determine which hits survive regardless of file or worker completion order.
 	queue.sort((a, b) => (b.file.modifiedAt ?? "").localeCompare(a.file.modifiedAt ?? ""));
 
 	const counters: JsonlCounters = { scannedBytes: 0, oversizedLines: 0 };
@@ -202,14 +222,12 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 			return;
 		}
 		stats.matchedRecords += 1;
-		hits.push({
+		const offered = hits.offer({
 			record,
 			displayName: entry.target.displayName,
 			resume: entry.history.resume ? (entry.history.resume(record) ?? null) : null,
 		});
-		if (hits.length > MAX_BUFFERED_HITS) {
-			hits.sort(compareHits);
-			hits.length = MAX_BUFFERED_HITS;
+		if (offered.discarded) {
 			stats.truncated = true;
 		}
 	};
@@ -228,7 +246,7 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 					if (options.signal.aborted) {
 						return;
 					}
-					if (!isUsableRecord(record)) {
+					if (!isSearchRecord(record)) {
 						stats.malformedRecords += 1;
 						continue;
 					}
@@ -252,7 +270,7 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 				if (record === null) {
 					continue;
 				}
-				if (!isUsableRecord(record)) {
+				if (!isSearchRecord(record)) {
 					stats.malformedRecords += 1;
 					continue;
 				}
@@ -270,13 +288,9 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 	stats.scannedBytes = counters.scannedBytes;
 	stats.oversizedLines = counters.oversizedLines;
 
-	hits.sort(compareHits);
-	const limited = options.limit > 0 ? hits.slice(0, options.limit) : hits;
-	if (limited.length < hits.length) {
-		stats.truncated = true;
-	}
-	stats.returnedMatches = limited.length;
+	const retained = hits.toSortedArray();
+	stats.returnedMatches = retained.length;
 	stats.elapsedMs = Date.now() - startedAt;
 
-	return { hits: limited, stats, errors, notes };
+	return { hits: retained, stats, errors, notes };
 }

--- a/src/lib/history/search.ts
+++ b/src/lib/history/search.ts
@@ -128,6 +128,7 @@ function compareHits(a: SearchHit, b: SearchHit): number {
 	return (
 		a.record.agentId.localeCompare(b.record.agentId) ||
 		a.record.sessionId.localeCompare(b.record.sessionId) ||
+		a.record.sourcePath.localeCompare(b.record.sourcePath) ||
 		a.record.recordIndex - b.record.recordIndex
 	);
 }

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -45,7 +45,10 @@ export type HistoryFile = {
 	meta?: Record<string, unknown>;
 };
 
-/** The one shape every target's reader emits. `text` is cleaned and never empty. */
+/**
+ * The runtime-validated shape every target reader emits. `text` is cleaned and never empty;
+ * `recordIndex` is a non-negative integer.
+ */
 export type SearchRecord = {
 	agentId: string;
 	role: HistoryRole;

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -1,0 +1,171 @@
+export const HISTORY_ROLES = ["user", "assistant", "agent"] as const;
+export type HistoryRole = (typeof HISTORY_ROLES)[number];
+
+export function isHistoryRole(value: string): value is HistoryRole {
+	return (HISTORY_ROLES as readonly string[]).includes(value);
+}
+
+/**
+ * What subset of history the caller wants. Targets MAY use this to prune files cheaply in
+ * `listFiles`; the engine re-applies every predicate authoritatively afterwards, so a target
+ * that prunes nothing is still correct — just slower.
+ */
+export type SearchScope = {
+	/** Absolute path. Sessions whose cwd is at or below this path match. */
+	projectPath: string | null;
+	/** Case-insensitive substring match against the session cwd. */
+	projectMatch: string | null;
+	since: Date | null;
+	until: Date | null;
+};
+
+export type HistoryContext = {
+	targetId: string;
+	displayName: string;
+	homeDir: string;
+	cwd: string;
+	/** Roles the caller asked for. Readers may skip work for roles nobody wants. */
+	roles: ReadonlySet<HistoryRole>;
+	signal: AbortSignal;
+};
+
+/** A candidate transcript, discovered by `listFiles` before any content is parsed. */
+export type HistoryFile = {
+	path: string;
+	/** Session cwd when derivable from the file's location or header; else null. */
+	projectPath: string | null;
+	/** Session id when derivable from the path or header; else null. */
+	sessionId: string | null;
+	/** ISO 8601. Drives newest-first file ordering so `--limit` short-circuits sensibly. */
+	modifiedAt: string | null;
+	sizeBytes: number | null;
+	/** Free-form payload carried from `listFiles` through to `normalize`. */
+	meta?: Record<string, unknown>;
+};
+
+/** The one shape every target's reader emits. `text` is cleaned and never empty. */
+export type SearchRecord = {
+	agentId: string;
+	role: HistoryRole;
+	timestamp: string | null;
+	text: string;
+	sessionId: string;
+	cwd: string | null;
+	gitBranch?: string | null;
+	sourcePath: string;
+	recordIndex: number;
+};
+
+export type HistoryResume = {
+	command: string;
+	args: string[];
+	/** Set when the agent's resume verb is directory-scoped, so the renderer emits a `cd` prefix. */
+	cwd: string | null;
+};
+
+/**
+ * The per-target history capability. Everything agent-specific lives here — directory layout,
+ * record shapes, resume verb — so the search engine never branches on target id.
+ */
+export type TargetHistoryDefinition = {
+	/** Roles this agent can produce. Declared, not inferred, so partial support is reportable. */
+	roles: HistoryRole[];
+	/** Enumerate candidate transcripts. Owns all discovery and pruning. readdir/stat only. */
+	listFiles: (scope: SearchScope, context: HistoryContext) => AsyncIterable<HistoryFile>;
+	/**
+	 * How the engine turns a file into records. Omit for the JSONL fast path, where the engine
+	 * owns the read loop so it can prefilter raw lines before `JSON.parse`.
+	 * Use `custom` for agents whose history is not line-oriented.
+	 */
+	scan?:
+		| { kind: "jsonl" }
+		| {
+				kind: "custom";
+				read: (file: HistoryFile, context: HistoryContext) => AsyncIterable<SearchRecord>;
+		  };
+	/** JSONL fast path: one raw line in, one record out, or null to discard. */
+	normalize?: (
+		line: string,
+		file: HistoryFile,
+		index: number,
+		context: HistoryContext,
+	) => SearchRecord | null;
+	/** How to re-enter this session. Returning null means "not resumable". */
+	resume?: (record: SearchRecord) => HistoryResume | null;
+};
+
+export type SearchHit = {
+	record: SearchRecord;
+	displayName: string;
+	resume: HistoryResume | null;
+};
+
+export type SearchNote = {
+	targetId: string;
+	displayName: string;
+	code: string;
+	message: string;
+};
+
+export type SearchStats = {
+	scannedFiles: number;
+	skippedFiles: number;
+	scannedBytes: number;
+	malformedRecords: number;
+	oversizedLines: number;
+	matchedRecords: number;
+	returnedMatches: number;
+	truncated: boolean;
+	elapsedMs: number;
+};
+
+export type SearchEnvelope = {
+	schemaVersion: 1;
+	generatedAt: string;
+	query: {
+		raw: string;
+		terms: string[];
+		mode: "literal" | "regex";
+		caseSensitive: boolean;
+	};
+	scope: {
+		kind: "all" | "path" | "substring";
+		projectPath: string | null;
+		projectMatch: string | null;
+		roles: HistoryRole[];
+		since: string | null;
+		until: string | null;
+		targets: string[];
+	};
+	matches: SearchMatch[];
+	stats: SearchStats;
+	errors: SearchNote[];
+	notes: SearchNote[];
+};
+
+export type SearchMatch = {
+	agentId: string;
+	displayName: string;
+	role: HistoryRole;
+	timestamp: string | null;
+	sessionId: string;
+	cwd: string | null;
+	project: string | null;
+	gitBranch: string | null;
+	sourcePath: string;
+	text: string;
+	textTruncated: boolean;
+	excerpt: string;
+	matchRanges: Array<[number, number]>;
+	resumeCommand: string | null;
+};
+
+export class HistoryReadError extends Error {
+	readonly code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "HistoryReadError";
+		this.code = code;
+	}
+}

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -1,3 +1,5 @@
+import type { HistoryQuery } from "./query.js";
+
 export const HISTORY_ROLES = ["user", "assistant", "agent"] as const;
 export type HistoryRole = (typeof HISTORY_ROLES)[number];
 
@@ -72,6 +74,11 @@ export type TargetHistoryDefinition = {
 	roles: HistoryRole[];
 	/** Enumerate candidate transcripts. Owns all discovery and pruning. readdir/stat only. */
 	listFiles: (scope: SearchScope, context: HistoryContext) => AsyncIterable<HistoryFile>;
+	/**
+	 * Optional raw-line optimization. Omit unless returning false proves the normalized record could
+	 * not match; the engine defaults to parsing every line so normalization cannot lose results.
+	 */
+	prefilter?: (line: string, query: HistoryQuery) => boolean;
 	/**
 	 * How the engine turns a file into records. Omit for the JSONL fast path, where the engine
 	 * owns the read loop so it can prefilter raw lines before `JSON.parse`.

--- a/src/lib/targets/builtins/claude-code/target.test.ts
+++ b/src/lib/targets/builtins/claude-code/target.test.ts
@@ -116,6 +116,7 @@ describe("claude builtin target", () => {
 		// Claude persists subagent transcripts on disk, so it can answer --role agent.
 		expect(claudeTarget.history?.roles).toEqual(["user", "assistant", "agent"]);
 		expect(typeof claudeTarget.history?.listFiles).toBe("function");
+		expect(typeof claudeTarget.history?.prefilter).toBe("function");
 		expect(typeof claudeTarget.history?.normalize).toBe("function");
 		expect(typeof claudeTarget.history?.resume).toBe("function");
 	});

--- a/src/lib/targets/builtins/claude-code/target.test.ts
+++ b/src/lib/targets/builtins/claude-code/target.test.ts
@@ -111,4 +111,12 @@ describe("claude builtin target", () => {
 		});
 		expect(filename).toBe("CLAUDE.md");
 	});
+
+	it("declares searchable history for all three roles", () => {
+		// Claude persists subagent transcripts on disk, so it can answer --role agent.
+		expect(claudeTarget.history?.roles).toEqual(["user", "assistant", "agent"]);
+		expect(typeof claudeTarget.history?.listFiles).toBe("function");
+		expect(typeof claudeTarget.history?.normalize).toBe("function");
+		expect(typeof claudeTarget.history?.resume).toBe("function");
+	});
 });

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -1,6 +1,7 @@
 import {
 	listClaudeFiles,
 	normalizeClaudeLine,
+	prefilterClaudeLine,
 	resumeClaudeSession,
 } from "../../../history/claude.js";
 import type { TargetDefinition } from "../../config-types.js";
@@ -74,6 +75,7 @@ export const claudeTarget: TargetDefinition = {
 		// Subagent transcripts are on disk, so Claude can answer for all three roles.
 		roles: ["user", "assistant", "agent"],
 		listFiles: listClaudeFiles,
+		prefilter: prefilterClaudeLine,
 		normalize: normalizeClaudeLine,
 		resume: resumeClaudeSession,
 	},

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -1,3 +1,8 @@
+import {
+	listClaudeFiles,
+	normalizeClaudeLine,
+	resumeClaudeSession,
+} from "../../../history/claude.js";
 import type { TargetDefinition } from "../../config-types.js";
 
 export const claudeTarget: TargetDefinition = {
@@ -59,5 +64,17 @@ export const claudeTarget: TargetDefinition = {
 			const { extractClaudeUsage } = await import("../../../usage/claude.js");
 			return extractClaudeUsage(context);
 		},
+	},
+	// Everything Claude-specific about searching history lives here, not in the search engine:
+	// where transcripts are, how the cwd is encoded into a directory name, which record shapes
+	// count as messages, and how to get back into a session.
+	// Imported statically rather than through a lazy thunk (as `usage.extract` does) because
+	// `normalize` runs per line and must stay synchronous, so deferring the import buys nothing.
+	history: {
+		// Subagent transcripts are on disk, so Claude can answer for all three roles.
+		roles: ["user", "assistant", "agent"],
+		listFiles: listClaudeFiles,
+		normalize: normalizeClaudeLine,
+		resume: resumeClaudeSession,
 	},
 };

--- a/src/lib/targets/builtins/codex/target.test.ts
+++ b/src/lib/targets/builtins/codex/target.test.ts
@@ -92,4 +92,14 @@ describe("codex builtin target", () => {
 		});
 		expect(filename).toBe("AGENTS.md");
 	});
+
+	it("declares searchable history for user and assistant roles only", () => {
+		// Codex stores nothing equivalent to a subagent transcript, so declaring the agent role
+		// would promise rows it can never produce.
+		expect(codexTarget.history?.roles).toEqual(["user", "assistant"]);
+		expect(codexTarget.history?.roles).not.toContain("agent");
+		expect(typeof codexTarget.history?.listFiles).toBe("function");
+		expect(typeof codexTarget.history?.normalize).toBe("function");
+		expect(typeof codexTarget.history?.resume).toBe("function");
+	});
 });

--- a/src/lib/targets/builtins/codex/target.test.ts
+++ b/src/lib/targets/builtins/codex/target.test.ts
@@ -99,6 +99,7 @@ describe("codex builtin target", () => {
 		expect(codexTarget.history?.roles).toEqual(["user", "assistant"]);
 		expect(codexTarget.history?.roles).not.toContain("agent");
 		expect(typeof codexTarget.history?.listFiles).toBe("function");
+		expect(typeof codexTarget.history?.prefilter).toBe("function");
 		expect(typeof codexTarget.history?.normalize).toBe("function");
 		expect(typeof codexTarget.history?.resume).toBe("function");
 	});

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -1,4 +1,9 @@
-import { listCodexFiles, normalizeCodexLine, resumeCodexSession } from "../../../history/codex.js";
+import {
+	listCodexFiles,
+	normalizeCodexLine,
+	prefilterCodexLine,
+	resumeCodexSession,
+} from "../../../history/codex.js";
 import type { TargetDefinition } from "../../config-types.js";
 
 export const codexTarget: TargetDefinition = {
@@ -90,6 +95,7 @@ export const codexTarget: TargetDefinition = {
 		// support rather than silently returning no rows for `--role agent`.
 		roles: ["user", "assistant"],
 		listFiles: listCodexFiles,
+		prefilter: prefilterCodexLine,
 		normalize: normalizeCodexLine,
 		resume: resumeCodexSession,
 	},

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -1,3 +1,4 @@
+import { listCodexFiles, normalizeCodexLine, resumeCodexSession } from "../../../history/codex.js";
 import type { TargetDefinition } from "../../config-types.js";
 
 export const codexTarget: TargetDefinition = {
@@ -83,5 +84,13 @@ export const codexTarget: TargetDefinition = {
 			const { extractCodexUsage } = await import("../../../usage/codex.js");
 			return extractCodexUsage(context);
 		},
+	},
+	history: {
+		// Codex persists nothing equivalent to a subagent transcript, so it declares partial
+		// support rather than silently returning no rows for `--role agent`.
+		roles: ["user", "assistant"],
+		listFiles: listCodexFiles,
+		normalize: normalizeCodexLine,
+		resume: resumeCodexSession,
 	},
 };

--- a/src/lib/targets/config-types.ts
+++ b/src/lib/targets/config-types.ts
@@ -1,6 +1,8 @@
+import type { TargetHistoryDefinition } from "../history/types.js";
 import type { TemplateScriptRuntime } from "../template-scripts.js";
 import type { TargetUsageDefinition } from "../usage/types.js";
 
+export type { TargetHistoryDefinition } from "../history/types.js";
 export type { TargetUsageDefinition } from "../usage/types.js";
 
 export const APPROVAL_POLICIES = ["prompt", "auto-edit", "yolo"] as const;
@@ -263,6 +265,7 @@ export type TargetDefinition = {
 	outputs?: TargetOutputs;
 	cli?: TargetCliDefinition;
 	usage?: TargetUsageDefinition;
+	history?: TargetHistoryDefinition;
 	hooks?: TargetHooks;
 };
 
@@ -280,6 +283,7 @@ export type ResolvedTarget = {
 	outputs: TargetOutputs;
 	cli?: TargetCliDefinition;
 	usage?: TargetUsageDefinition;
+	history?: TargetHistoryDefinition;
 	hooks?: TargetHooks;
 	isBuiltIn: boolean;
 	isCustomized: boolean;

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -392,6 +392,9 @@ function validateHistoryDefinition(
 	if (typeof history.listFiles !== "function") {
 		errors.push(`${label}.listFiles must be a function.`);
 	}
+	if (history.prefilter !== undefined && typeof history.prefilter !== "function") {
+		errors.push(`${label}.prefilter must be a function when provided.`);
+	}
 
 	const scan = history.scan;
 	let customRead = false;

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -1,3 +1,4 @@
+import { HISTORY_ROLES } from "../history/types.js";
 import type {
 	CommandOutputDefinition,
 	FallbackRule,
@@ -7,6 +8,7 @@ import type {
 	OutputTemplateValue,
 	TargetCliDefinition,
 	TargetDefinition,
+	TargetHistoryDefinition,
 	TargetOutputs,
 	TargetUsageDefinition,
 } from "./config-types.js";
@@ -364,6 +366,62 @@ function validateUsageDefinition(
 	}
 }
 
+function validateHistoryDefinition(
+	history: TargetHistoryDefinition | undefined,
+	label: string,
+	errors: string[],
+): void {
+	if (history === undefined) {
+		return;
+	}
+	if (!isPlainObject(history)) {
+		errors.push(`${label} must be an object.`);
+		return;
+	}
+
+	if (!Array.isArray(history.roles) || history.roles.length === 0) {
+		errors.push(`${label}.roles must be a non-empty array.`);
+	} else {
+		for (const role of history.roles) {
+			if (!(HISTORY_ROLES as readonly string[]).includes(role)) {
+				errors.push(`${label}.roles contains an unknown role (${String(role)}).`);
+			}
+		}
+	}
+
+	if (typeof history.listFiles !== "function") {
+		errors.push(`${label}.listFiles must be a function.`);
+	}
+
+	const scan = history.scan;
+	let customRead = false;
+	if (scan !== undefined) {
+		if (!isPlainObject(scan)) {
+			errors.push(`${label}.scan must be an object.`);
+		} else if (scan.kind === "custom") {
+			customRead = typeof scan.read === "function";
+			if (!customRead) {
+				errors.push(`${label}.scan.read must be a function when scan.kind is "custom".`);
+			}
+		} else if (scan.kind !== "jsonl") {
+			errors.push(`${label}.scan.kind must be "jsonl" or "custom".`);
+		}
+	}
+
+	// Exactly one reader: the JSONL fast path needs `normalize`, a bespoke store needs
+	// `scan.read`. Supplying both is ambiguous; supplying neither yields no records at all.
+	const hasNormalize = typeof history.normalize === "function";
+	if (hasNormalize && customRead) {
+		errors.push(`${label} must define either normalize or scan.read, not both.`);
+	} else if (!hasNormalize && !customRead) {
+		errors.push(`${label} must define normalize (for JSONL) or scan.read (for a custom store).`);
+	}
+
+	if (history.resume !== undefined && typeof history.resume !== "function") {
+		errors.push(`${label}.resume must be a function when provided.`);
+	}
+}
+
 function validateTemplate(
 	value: OutputTemplateValue,
 	label: string,
@@ -662,6 +720,7 @@ export function validateTargetConfig(options: {
 				validateOutputs(entry.outputs, `${label}.outputs`, errors);
 				validateCliDefinition(entry.cli, `${label}.cli`, errors);
 				validateUsageDefinition(entry.usage, `${label}.usage`, errors);
+				validateHistoryDefinition(entry.history, `${label}.history`, errors);
 			}
 		}
 	}

--- a/src/lib/targets/resolve-targets.ts
+++ b/src/lib/targets/resolve-targets.ts
@@ -4,6 +4,7 @@ import type {
 	ResolvedTarget,
 	TargetCliDefinition,
 	TargetDefinition,
+	TargetHistoryDefinition,
 	TargetOutputs,
 	TargetUsageDefinition,
 } from "./config-types.js";
@@ -34,6 +35,15 @@ function cloneUsage(usage: TargetUsageDefinition | undefined): TargetUsageDefini
 				}
 			: undefined,
 	};
+}
+
+function cloneHistory(
+	history: TargetHistoryDefinition | undefined,
+): TargetHistoryDefinition | undefined {
+	if (!history) {
+		return undefined;
+	}
+	return { ...history, roles: [...history.roles] };
 }
 
 function mergeOutputs(
@@ -126,6 +136,7 @@ export function resolveTargets(options: {
 				outputs: cloneOutputs(builtIn.outputs),
 				cli: cloneCli(builtIn.cli),
 				usage: cloneUsage(builtIn.usage),
+				history: cloneHistory(builtIn.history),
 				hooks: builtIn.hooks,
 				isBuiltIn: true,
 				isCustomized: false,
@@ -147,6 +158,7 @@ export function resolveTargets(options: {
 				outputs: mergedOutputs,
 				cli: cloneCli(customTarget.cli ?? inherited?.cli),
 				usage: cloneUsage(customTarget.usage ?? inherited?.usage),
+				history: cloneHistory(customTarget.history ?? inherited?.history),
 				hooks: customTarget.hooks ?? inherited?.hooks,
 				isBuiltIn: true,
 				isCustomized: true,
@@ -160,6 +172,7 @@ export function resolveTargets(options: {
 				outputs: cloneOutputs(customTarget.outputs),
 				cli: cloneCli(customTarget.cli),
 				usage: cloneUsage(customTarget.usage),
+				history: cloneHistory(customTarget.history),
 				hooks: customTarget.hooks,
 				isBuiltIn: true,
 				isCustomized: true,
@@ -186,6 +199,7 @@ export function resolveTargets(options: {
 			outputs: mergedOutputs,
 			cli: cloneCli(target.cli ?? inherited?.cli),
 			usage: cloneUsage(target.usage ?? inherited?.usage),
+			history: cloneHistory(target.history ?? inherited?.history),
 			hooks: target.hooks ?? inherited?.hooks,
 			isBuiltIn: false,
 			isCustomized: true,

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -1,0 +1,870 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../../src/cli/index.js";
+
+// The clipboard is stubbed so the suite never writes to the developer's real clipboard, and so
+// the copy paths behave identically on a CI box with no clipboard helper installed.
+const clipboard = vi.hoisted(() => ({ copied: [] as string[], shouldFail: false }));
+vi.mock("../../src/lib/history/clipboard.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/lib/history/clipboard.js")>();
+	return {
+		...actual,
+		copyToClipboard: vi.fn(async (text: string) => {
+			if (clipboard.shouldFail) {
+				throw new actual.ClipboardError("No clipboard helper found.");
+			}
+			clipboard.copied.push(text);
+			return { command: "stub", args: [] };
+		}),
+	};
+});
+
+function slug(absolutePath: string): string {
+	return absolutePath.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+type Fixture = {
+	root: string;
+	homeDir: string;
+	repoAlpha: string;
+	repoBeta: string;
+};
+
+const claudeUser = (text: string, timestamp: string, cwd: string, sessionId: string) =>
+	JSON.stringify({
+		type: "user",
+		sessionId,
+		cwd,
+		gitBranch: "main",
+		timestamp,
+		message: { role: "user", content: text },
+	});
+
+const claudeAssistant = (text: string, timestamp: string, cwd: string, sessionId: string) =>
+	JSON.stringify({
+		type: "assistant",
+		sessionId,
+		cwd,
+		timestamp,
+		message: { role: "assistant", content: [{ type: "text", text }] },
+	});
+
+const claudeToolResult = (text: string, cwd: string, sessionId: string) =>
+	JSON.stringify({
+		type: "user",
+		sessionId,
+		cwd,
+		timestamp: "2026-08-01T09:00:00.000Z",
+		message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: text }] },
+	});
+
+const claudeSidechain = (text: string, timestamp: string, cwd: string, sessionId: string) =>
+	JSON.stringify({
+		type: "user",
+		sessionId,
+		cwd,
+		timestamp,
+		isSidechain: true,
+		message: { role: "user", content: text },
+	});
+
+const codexMeta = (cwd: string, id: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-01T09:00:00.000Z",
+		type: "session_meta",
+		payload: { id, session_id: `${id}-forked`, cwd },
+	});
+
+const codexUser = (text: string, timestamp: string) =>
+	JSON.stringify({
+		timestamp,
+		type: "event_msg",
+		payload: { type: "user_message", message: text },
+	});
+
+const codexResponseItem = (text: string, timestamp: string) =>
+	JSON.stringify({
+		timestamp,
+		type: "response_item",
+		payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+	});
+
+async function withSearchHome(fn: (fixture: Fixture) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-search-"));
+	const homeDir = path.join(root, "home");
+	const repoAlpha = path.join(root, "repo-alpha");
+	const repoBeta = path.join(root, "repo-beta");
+	const nested = path.join(repoAlpha, "src", "nested");
+
+	await mkdir(nested, { recursive: true });
+	await mkdir(repoBeta, { recursive: true });
+	// findRepoRoot looks for .git or package.json.
+	await writeFile(path.join(repoAlpha, "package.json"), "{}\n");
+	await writeFile(path.join(repoBeta, "package.json"), "{}\n");
+
+	const claudeAlpha = path.join(homeDir, ".claude", "projects", slug(repoAlpha));
+	const claudeBeta = path.join(homeDir, ".claude", "projects", slug(repoBeta));
+	await mkdir(path.join(claudeAlpha, "sess-a", "subagents"), { recursive: true });
+	await mkdir(claudeBeta, { recursive: true });
+
+	await writeFile(
+		path.join(claudeAlpha, "sess-a.jsonl"),
+		[
+			claudeUser(
+				"resolve the MERGE conflict on alpha",
+				"2026-08-05T10:00:00.000Z",
+				repoAlpha,
+				"sess-a",
+			),
+			claudeAssistant(
+				"assistant mentions merge conflict",
+				"2026-08-05T10:01:00.000Z",
+				repoAlpha,
+				"sess-a",
+			),
+			claudeToolResult("merge conflict in generated output", repoAlpha, "sess-a"),
+			JSON.stringify({
+				type: "user",
+				sessionId: "sess-a",
+				cwd: repoAlpha,
+				isMeta: true,
+				timestamp: "2026-08-05T10:02:00.000Z",
+				message: { role: "user", content: "Base directory for this skill: merge conflict" },
+			}),
+			JSON.stringify({
+				type: "user",
+				sessionId: "sess-a",
+				cwd: repoAlpha,
+				timestamp: "2026-08-05T10:03:00.000Z",
+				message: { role: "user", content: "<task-notification>merge conflict</task-notification>" },
+			}),
+			"",
+		].join("\n"),
+	);
+	await writeFile(
+		path.join(claudeAlpha, "sess-a", "subagents", "agent-x.jsonl"),
+		`${claudeSidechain("dispatch: investigate the merge conflict", "2026-08-05T10:04:00.000Z", repoAlpha, "sess-a")}\n`,
+	);
+	await writeFile(
+		path.join(claudeBeta, "sess-b.jsonl"),
+		`${claudeUser("beta wants a merge conflict fix", "2026-08-04T10:00:00.000Z", repoBeta, "sess-b")}\n`,
+	);
+
+	const codexDay = path.join(homeDir, ".codex", "sessions", "2026", "08", "06");
+	await mkdir(codexDay, { recursive: true });
+	await writeFile(
+		path.join(codexDay, "rollout-alpha.jsonl"),
+		[
+			codexMeta(repoAlpha, "roll-alpha"),
+			codexUser("codex handles the merge conflict", "2026-08-06T10:00:00.000Z"),
+			// The polluted duplicate of the same turn.
+			codexResponseItem(
+				"<environment_context><cwd>/x</cwd></environment_context> codex handles the merge conflict",
+				"2026-08-06T10:00:00.000Z",
+			),
+			"",
+		].join("\n"),
+	);
+
+	try {
+		await fn({ root, homeDir, repoAlpha, repoBeta });
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+describe.sequential("search command", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let homeSpy: ReturnType<typeof vi.spyOn> | null = null;
+	let cwdSpy: ReturnType<typeof vi.spyOn> | null = null;
+	let originalNoColor: string | undefined;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		originalNoColor = process.env.NO_COLOR;
+		process.env.NO_COLOR = "1";
+		process.exitCode = undefined;
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+		homeSpy?.mockRestore();
+		cwdSpy?.mockRestore();
+		homeSpy = null;
+		cwdSpy = null;
+		if (originalNoColor === undefined) {
+			delete process.env.NO_COLOR;
+		} else {
+			process.env.NO_COLOR = originalNoColor;
+		}
+		process.exitCode = undefined;
+	});
+
+	function useFixture(fixture: Fixture, cwd = fixture.repoAlpha): void {
+		homeSpy = vi.spyOn(os, "homedir").mockReturnValue(fixture.homeDir);
+		cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
+	}
+
+	function stdout(): string {
+		return logSpy.mock.calls.map(([value]) => String(value)).join("\n");
+	}
+
+	function stderr(): string {
+		return errorSpy.mock.calls.map(([value]) => String(value)).join("\n");
+	}
+
+	async function search(args: string[]): Promise<void> {
+		await runCli(["node", "omniagent", "search", ...args]);
+	}
+
+	function envelope(): {
+		matches: Array<Record<string, unknown>>;
+		stats: Record<string, number | boolean>;
+		scope: Record<string, unknown>;
+		errors: Array<Record<string, string>>;
+		notes: Array<Record<string, string>>;
+	} {
+		return JSON.parse(stdout());
+	}
+
+	describe("matching", () => {
+		it("finds prompts case-insensitively across both agents", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				const texts = envelope().matches.map((match) => match.text as string);
+				expect(texts).toContain("resolve the MERGE conflict on alpha");
+				expect(texts).toContain("codex handles the merge conflict");
+			});
+		});
+
+		it("ANDs separate terms regardless of order", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["conflict", "resolve", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.text)).toEqual([
+					"resolve the MERGE conflict on alpha",
+				]);
+			});
+		});
+
+		it("treats a quoted phrase as an exact match", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["conflict on alpha", "--json", "--limit", "0"]);
+
+				expect(envelope().matches).toHaveLength(1);
+			});
+		});
+
+		it("honours --case-sensitive", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["MERGE", "--case-sensitive", "--json", "--limit", "0"]);
+
+				expect(envelope().matches).toHaveLength(1);
+			});
+		});
+
+		it("supports --regex", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["--regex", "merge\\s+conflict", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.length).toBeGreaterThan(0);
+			});
+		});
+
+		// yargs hands back a number for a bare numeric positional unless the type is declared.
+		it("does not throw on a purely numeric query", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["123", "--json"]);
+
+				expect(envelope().matches).toEqual([]);
+				expect(exitSpy).not.toHaveBeenCalledWith(1);
+			});
+		});
+	});
+
+	describe("role filtering", () => {
+		it("returns only what the human typed by default", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				const texts = envelope().matches.map((match) => match.text as string);
+				// tool output, isMeta skill payloads, task-notification wrappers, assistant replies,
+				// and subagent dispatch prompts are all excluded.
+				expect(texts).not.toContain("merge conflict in generated output");
+				expect(texts.some((text) => text.includes("Base directory"))).toBe(false);
+				expect(texts.some((text) => text.includes("task-notification"))).toBe(false);
+				expect(texts).not.toContain("assistant mentions merge conflict");
+				expect(texts.some((text) => text.startsWith("dispatch:"))).toBe(false);
+			});
+		});
+
+		it("returns assistant replies under --role assistant", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--role", "assistant", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.text)).toContain(
+					"assistant mentions merge conflict",
+				);
+			});
+		});
+
+		it("returns subagent transcripts under --role agent", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--role", "agent", "--json", "--limit", "0"]);
+
+				const matches = envelope().matches;
+				expect(matches.map((match) => match.text)).toEqual([
+					"dispatch: investigate the merge conflict",
+				]);
+				expect(matches[0]?.role).toBe("agent");
+			});
+		});
+
+		it("notes that an agent cannot answer a role it does not record", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--role", "agent", "--json", "--limit", "0"]);
+
+				expect(envelope().notes.some((note) => note.code === "role_unsupported")).toBe(true);
+			});
+		});
+
+		// The single most important regression: the same Codex turn is stored twice.
+		it("never double-counts the Codex response_item duplicate", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["codex handles", "--only", "codex", "--json", "--limit", "0"]);
+
+				const matches = envelope().matches;
+				expect(matches).toHaveLength(1);
+				expect(matches[0]?.text).toBe("codex handles the merge conflict");
+			});
+		});
+
+		it("never surfaces injected environment_context", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["environment_context", "--json", "--limit", "0"]);
+
+				expect(envelope().matches).toEqual([]);
+			});
+		});
+	});
+
+	describe("scope", () => {
+		it("searches every project by default", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				const cwds = new Set(envelope().matches.map((match) => match.cwd));
+				expect(cwds.has(fixture.repoAlpha)).toBe(true);
+				expect(cwds.has(fixture.repoBeta)).toBe(true);
+			});
+		});
+
+		it("scopes to the current repository with --project .", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--project", ".", "--json", "--limit", "0"]);
+
+				const result = envelope();
+				expect(result.scope.kind).toBe("path");
+				expect(new Set(result.matches.map((match) => match.cwd))).toEqual(
+					new Set([fixture.repoAlpha]),
+				);
+			});
+		});
+
+		it("resolves --project . from a subdirectory up to the repository root", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture, path.join(fixture.repoAlpha, "src", "nested"));
+				await search(["merge conflict", "--project", ".", "--json", "--limit", "0"]);
+
+				const result = envelope();
+				expect(result.scope.projectPath).toBe(fixture.repoAlpha);
+				expect(result.matches.length).toBeGreaterThan(0);
+			});
+		});
+
+		it("scopes by substring when --project is not path-like", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--project", "repo-beta", "--json", "--limit", "0"]);
+
+				const result = envelope();
+				expect(result.scope.kind).toBe("substring");
+				expect(new Set(result.matches.map((match) => match.cwd))).toEqual(
+					new Set([fixture.repoBeta]),
+				);
+			});
+		});
+
+		it("filters by --since", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--since", "2026-08-06", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.text)).toEqual([
+					"codex handles the merge conflict",
+				]);
+			});
+		});
+
+		it("filters by --until", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--until", "2026-08-04", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.text)).toEqual([
+					"beta wants a merge conflict fix",
+				]);
+			});
+		});
+	});
+
+	describe("targets", () => {
+		it("restricts to one agent with --only", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--only", "claude", "--json", "--limit", "0"]);
+
+				expect(new Set(envelope().matches.map((match) => match.agentId))).toEqual(
+					new Set(["claude"]),
+				);
+			});
+		});
+
+		it("excludes an agent with --skip", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--skip", "codex", "--json", "--limit", "0"]);
+
+				expect(new Set(envelope().matches.map((match) => match.agentId))).toEqual(
+					new Set(["claude"]),
+				);
+			});
+		});
+
+		it("rejects an unknown target", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--only", "bogus"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(
+					expect.stringContaining("Unknown target name(s): bogus"),
+				);
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects a target that records no history", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--only", "copilot"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(
+					expect.stringContaining("does not record searchable history"),
+				);
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects --only together with --skip", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--only", "claude", "--skip", "codex"]);
+
+				expect(errorSpy).toHaveBeenCalledWith("Error: Use either --only or --skip, not both.");
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+	});
+
+	describe("ordering and limit", () => {
+		it("returns matches newest first across agents", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.timestamp)).toEqual([
+					"2026-08-06T10:00:00.000Z",
+					"2026-08-05T10:00:00.000Z",
+					"2026-08-04T10:00:00.000Z",
+				]);
+			});
+		});
+
+		it("is deterministic across repeated runs", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+				const first = envelope().matches.map((match) => match.sessionId);
+				logSpy.mockClear();
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				expect(envelope().matches.map((match) => match.sessionId)).toEqual(first);
+			});
+		});
+
+		it("truncates to --limit while reporting the true total", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--limit", "1", "--json"]);
+
+				const result = envelope();
+				expect(result.matches).toHaveLength(1);
+				expect(result.stats.matchedRecords).toBe(3);
+				expect(result.stats.truncated).toBe(true);
+			});
+		});
+
+		it("shows the truncation in human output", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--limit", "1"]);
+
+				expect(stdout()).toContain("Showing 1 of 3 matches");
+			});
+		});
+	});
+
+	describe("output", () => {
+		it("prints a resume command per hit, with a cd when the project differs", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture, fixture.repoBeta);
+				await search(["merge conflict", "--only", "claude", "--limit", "0"]);
+
+				const output = stdout();
+				expect(output).toContain("claude --resume sess-a");
+				expect(output).toContain(`cd ${fixture.repoAlpha} && claude --resume sess-a`);
+				// The hit whose cwd is the current directory needs no cd prefix.
+				expect(output).toContain("claude --resume sess-b");
+				expect(output).not.toContain(`cd ${fixture.repoBeta}`);
+			});
+		});
+
+		it("uses the Codex rollout id, not the forked session id", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["codex handles", "--only", "codex", "--json"]);
+
+				expect(envelope().matches[0]?.resumeCommand).toContain("codex resume roll-alpha");
+			});
+		});
+
+		it("collapses multi-line prompts into a single excerpt line", async () => {
+			await withSearchHome(async (fixture) => {
+				const sessionFile = path.join(
+					fixture.homeDir,
+					".claude",
+					"projects",
+					slug(fixture.repoAlpha),
+					"multiline.jsonl",
+				);
+				await writeFile(
+					sessionFile,
+					`${claudeUser("line one\nline two\n\n   line three about zebras", "2026-08-07T10:00:00.000Z", fixture.repoAlpha, "sess-m")}\n`,
+				);
+				useFixture(fixture);
+				await search(["zebras", "--json"]);
+
+				const match = envelope().matches[0] as Record<string, string>;
+				expect(match.excerpt).toBe("line one line two line three about zebras");
+				// The full prompt keeps its newlines so it can be reused verbatim.
+				expect(match.text).toContain("\n");
+			});
+		});
+
+		it("reports zero matches on stdout and exits successfully", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["nothingmatchesthis"]);
+
+				expect(stdout()).toContain('No matches for "nothingmatchesthis".');
+				expect(exitSpy).not.toHaveBeenCalled();
+			});
+		});
+
+		// stdout must stay a clean, pipeable result list even when there is something to say.
+		it("keeps notes off stdout so --json stays parseable", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--role", "agent", "--json", "--limit", "0"]);
+
+				expect(() => JSON.parse(stdout())).not.toThrow();
+				expect(stderr()).toContain("Note:");
+			});
+		});
+
+		it("emits a stable envelope shape", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--json"]);
+
+				const result = JSON.parse(stdout());
+				expect(result.schemaVersion).toBe(1);
+				expect(Object.keys(result)).toEqual(
+					expect.arrayContaining([
+						"schemaVersion",
+						"generatedAt",
+						"query",
+						"scope",
+						"matches",
+						"stats",
+						"errors",
+						"notes",
+					]),
+				);
+			});
+		});
+	});
+
+	describe("clipboard and raw output", () => {
+		let writeSpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			clipboard.copied.length = 0;
+			clipboard.shouldFail = false;
+			writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		});
+
+		afterEach(() => {
+			writeSpy.mockRestore();
+		});
+
+		function written(): string {
+			return writeSpy.mock.calls.map(([value]) => String(value)).join("");
+		}
+
+		it("copies the newest match in full, newlines intact", async () => {
+			await withSearchHome(async (fixture) => {
+				const sessionFile = path.join(
+					fixture.homeDir,
+					".claude",
+					"projects",
+					slug(fixture.repoAlpha),
+					"multi.jsonl",
+				);
+				await writeFile(
+					sessionFile,
+					`${claudeUser("line one\nline two about zebras", "2026-08-09T10:00:00.000Z", fixture.repoAlpha, "sess-z")}\n`,
+				);
+				useFixture(fixture);
+				await search(["zebras", "--copy"]);
+
+				expect(clipboard.copied).toEqual(["line one\nline two about zebras"]);
+			});
+		});
+
+		it("copies the result at an explicit index", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--copy", "3", "--limit", "0"]);
+
+				expect(clipboard.copied).toEqual(["beta wants a merge conflict fix"]);
+			});
+		});
+
+		it("rejects an out-of-range index", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--copy", "99", "--limit", "0"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("out of range"));
+				expect(exitSpy).toHaveBeenCalledWith(2);
+				expect(clipboard.copied).toEqual([]);
+			});
+		});
+
+		// `--copy` placed before the query swallows a search term; that must fail loudly rather
+		// than silently copying the wrong result.
+		it("rejects a non-numeric index and names the fix", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["--copy", "merge", "conflict"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(
+					expect.stringContaining("Put the query before the flag"),
+				);
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("prints the text instead of losing it when the clipboard is unavailable", async () => {
+			await withSearchHome(async (fixture) => {
+				clipboard.shouldFail = true;
+				useFixture(fixture);
+				await search(["merge conflict", "--copy", "--limit", "0"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No clipboard helper"));
+				expect(written()).toContain("codex handles the merge conflict");
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			});
+		});
+
+		it("writes only the message text under --print", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--print", "--limit", "0"]);
+
+				expect(written()).toBe("codex handles the merge conflict\n");
+				// Nothing else may reach stdout, or a pipe would receive the listing too.
+				expect(stdout()).toBe("");
+			});
+		});
+
+		it("honours an explicit --print index", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--print", "2", "--limit", "0"]);
+
+				expect(written()).toBe("resolve the MERGE conflict on alpha\n");
+			});
+		});
+
+		it("numbers results so an index can be chosen without re-running", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--limit", "0"]);
+
+				expect(stdout()).toContain("[1]");
+				expect(stdout()).toContain("[3]");
+			});
+		});
+
+		it("prints complete text under --full", async () => {
+			await withSearchHome(async (fixture) => {
+				const sessionFile = path.join(
+					fixture.homeDir,
+					".claude",
+					"projects",
+					slug(fixture.repoAlpha),
+					"long.jsonl",
+				);
+				const long = `zebras ${"padding words ".repeat(40)}end of prompt`;
+				await writeFile(
+					sessionFile,
+					`${claudeUser(long, "2026-08-09T10:00:00.000Z", fixture.repoAlpha, "sess-l")}\n`,
+				);
+				useFixture(fixture);
+				await search(["zebras", "--full"]);
+
+				// The excerpt would have clamped this; --full must reach the final words.
+				expect(stdout()).toContain("end of prompt");
+			});
+		});
+
+		it("stays non-interactive when stdout is not a TTY", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["merge conflict", "--limit", "0"]);
+
+				// A picker would have produced no listing at all.
+				expect(stdout()).toContain("matches");
+				expect(clipboard.copied).toEqual([]);
+			});
+		});
+	});
+
+	describe("invalid usage", () => {
+		it("requires a query", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search([]);
+
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Provide a search query"));
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects an unknown role", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--role", "bogus"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--role must be one of"));
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects a negative limit", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--limit", "-1"]);
+
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects an unparseable --since", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--since", "notadate"]);
+
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects an inverted date range", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--since", "2026-08-06", "--until", "2026-08-01"]);
+
+				expect(errorSpy).toHaveBeenCalledWith("Error: --since must be before --until.");
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects an invalid regex", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["--regex", "("]);
+
+				expect(errorSpy).toHaveBeenCalledWith(
+					expect.stringContaining("--regex pattern is invalid"),
+				);
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("reports a bad flag value through the JSON envelope", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--role", "bogus", "--json"]);
+
+				const result = JSON.parse(stdout());
+				expect(result.errors[0].code).toBe("invalid_role");
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		// Regression for the KNOWN_COMMANDS registration in src/cli/index.ts: without it, a parse
+		// failure inside a registered command exits 2 instead of 1.
+		it("exits 1 (not 2) on an unknown flag", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--definitely-not-a-flag"]);
+
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			});
+		});
+	});
+});

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -635,6 +635,29 @@ describe.sequential("search command", () => {
 				);
 			});
 		});
+
+		it("sanitizes terminal controls in human output", async () => {
+			await withSearchHome(async (fixture) => {
+				const sessionFile = path.join(
+					fixture.homeDir,
+					".claude",
+					"projects",
+					slug(fixture.repoAlpha),
+					"unsafe.jsonl",
+				);
+				await writeFile(
+					sessionFile,
+					`${claudeUser("zebras before\x1b]52;c;YXR0YWNr\x07after", "2026-08-09T10:00:00.000Z", fixture.repoAlpha, "sess-unsafe")}\n`,
+				);
+				useFixture(fixture);
+				await search(["zebras", "--full"]);
+
+				expect(stdout()).not.toContain("\x1b");
+				expect(stdout()).not.toContain("\x07");
+				expect(stdout()).toContain("before");
+				expect(stdout()).toContain("after");
+			});
+		});
 	});
 
 	describe("clipboard and raw output", () => {
@@ -671,6 +694,27 @@ describe.sequential("search command", () => {
 				await search(["zebras", "--copy"]);
 
 				expect(clipboard.copied).toEqual(["line one\nline two about zebras"]);
+			});
+		});
+
+		it("does not truncate a copied message above 64 KiB", async () => {
+			await withSearchHome(async (fixture) => {
+				const sessionFile = path.join(
+					fixture.homeDir,
+					".claude",
+					"projects",
+					slug(fixture.repoAlpha),
+					"huge.jsonl",
+				);
+				const huge = `${"a".repeat(65_535)}🎉 zebras tail`;
+				await writeFile(
+					sessionFile,
+					`${claudeUser(huge, "2026-08-09T10:00:00.000Z", fixture.repoAlpha, "sess-huge")}\n`,
+				);
+				useFixture(fixture);
+				await search(["zebras tail", "--copy"]);
+
+				expect(clipboard.copied).toEqual([huge]);
 			});
 		});
 
@@ -759,7 +803,11 @@ describe.sequential("search command", () => {
 					slug(fixture.repoAlpha),
 					"long.jsonl",
 				);
-				const long = `zebras ${"padding words ".repeat(40)}end of prompt`;
+				const long = [
+					"zebras",
+					...Array.from({ length: 205 }, (_, index) => `line ${index}`),
+					"end of prompt",
+				].join("\n");
 				await writeFile(
 					sessionFile,
 					`${claudeUser(long, "2026-08-09T10:00:00.000Z", fixture.repoAlpha, "sess-l")}\n`,
@@ -767,8 +815,19 @@ describe.sequential("search command", () => {
 				useFixture(fixture);
 				await search(["zebras", "--full"]);
 
-				// The excerpt would have clamped this; --full must reach the final words.
+				// The excerpt and the former 200-line display cap would both have dropped this.
 				expect(stdout()).toContain("end of prompt");
+			});
+		});
+
+		it("exits 1 under --copy when an explicitly selected target has no history", async () => {
+			await withSearchHome(async (fixture) => {
+				await rm(path.join(fixture.homeDir, ".claude"), { recursive: true, force: true });
+				useFixture(fixture);
+				await search(["zebras", "--only", "claude", "--copy"]);
+
+				expect(exitSpy).toHaveBeenCalledWith(1);
+				expect(clipboard.copied).toEqual([]);
 			});
 		});
 
@@ -819,6 +878,16 @@ describe.sequential("search command", () => {
 				useFixture(fixture);
 				await search(["x", "--since", "notadate"]);
 
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects an out-of-range relative date through the JSON envelope", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--since", "999999999999999999999d", "--json"]);
+
+				expect(envelope().errors[0]?.code).toBe("invalid_since");
 				expect(exitSpy).toHaveBeenCalledWith(2);
 			});
 		});

--- a/tests/docs/readme.test.ts
+++ b/tests/docs/readme.test.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 const README_PATH = new URL("../../README.md", import.meta.url);
 const DOCS_INDEX_PATH = new URL("../../docs/README.md", import.meta.url);
 const TEMPLATING_PATH = new URL("../../docs/templating.md", import.meta.url);
+const REFERENCE_PATH = new URL("../../docs/reference.md", import.meta.url);
+const CUSTOM_TARGETS_PATH = new URL("../../docs/custom-targets.md", import.meta.url);
 const QUICKSTART_PATH = new URL(
 	"../../specs/017-dynamic-template-scripts/quickstart.md",
 	import.meta.url,
@@ -30,10 +32,29 @@ describe("README", () => {
 		expect(contents).toContain("my-personal-command.md");
 		expect(contents).toContain("<agents claude,codex>");
 		expect(contents).toMatch(/agent="\$\{1:-claude\}"/);
+		expect(contents).toContain("omniagent search");
 		expect(contents).toContain("## Contributing");
 		expect(contents).toContain("CONTRIBUTING.md");
 		expect(contents).not.toContain("## Validation");
 		expect(contents).not.toContain("docs/cli-shim-e2e.md");
+	});
+
+	it("documents the search command surface", async () => {
+		const reference = await readFile(REFERENCE_PATH, "utf8");
+		const customTargets = await readFile(CUSTOM_TARGETS_PATH, "utf8");
+
+		expect(reference).toContain("## Search");
+		expect(reference).toContain("--role");
+		expect(reference).toContain("--project");
+		// Copying a past prompt is the command's main purpose, and agents need the scriptable path.
+		expect(reference).toContain("--copy");
+		expect(reference).toContain("--print");
+		expect(reference).toContain("--no-interactive");
+		// Adding a searchable agent must stay a config-only change, so the capability is documented
+		// alongside the other target capabilities.
+		expect(customTargets).toContain("## Searchable history (`history`)");
+		expect(customTargets).toContain("scan");
+		expect(customTargets).toContain("normalize");
 	});
 
 	it("keeps advanced templating details in docs pages", async () => {

--- a/tests/lib/history/bounded-top-k.test.ts
+++ b/tests/lib/history/bounded-top-k.test.ts
@@ -1,0 +1,40 @@
+import { BoundedTopK } from "../../../src/lib/history/bounded-top-k.js";
+
+describe("BoundedTopK", () => {
+	it("retains only the best values and reports every capacity discard", () => {
+		const values = new BoundedTopK<number>(3, (a, b) => a - b);
+
+		expect(values.offer(5)).toEqual({ retained: true, discarded: false });
+		expect(values.offer(1)).toEqual({ retained: true, discarded: false });
+		expect(values.offer(3)).toEqual({ retained: true, discarded: false });
+		expect(values.offer(7)).toEqual({ retained: false, discarded: true });
+		expect(values.offer(2)).toEqual({ retained: true, discarded: true });
+		expect(values.offer(3)).toEqual({ retained: false, discarded: true });
+
+		expect(values.size).toBe(3);
+		expect(values.toSortedArray()).toEqual([1, 2, 3]);
+	});
+
+	it("rejects invalid capacities", () => {
+		expect(() => new BoundedTopK(0, (a: number, b: number) => a - b)).toThrow(RangeError);
+		expect(() => new BoundedTopK(1.5, (a: number, b: number) => a - b)).toThrow(RangeError);
+	});
+
+	it("scales by heap depth instead of repeatedly sorting the retained set", () => {
+		let comparisons = 0;
+		const values = new BoundedTopK<number>(10_000, (a, b) => {
+			comparisons += 1;
+			return a - b;
+		});
+
+		for (let value = 20_000; value > 0; value -= 1) {
+			values.offer(value);
+		}
+		const retained = values.toSortedArray();
+
+		expect(retained).toHaveLength(10_000);
+		expect(retained[0]).toBe(1);
+		expect(retained.at(-1)).toBe(10_000);
+		expect(comparisons).toBeLessThan(1_000_000);
+	});
+});

--- a/tests/lib/history/claude.test.ts
+++ b/tests/lib/history/claude.test.ts
@@ -1,0 +1,283 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	cleanClaudeText,
+	listClaudeFiles,
+	normalizeClaudeLine,
+	projectSlugMatches,
+	resumeClaudeSession,
+	slugifyProjectPath,
+} from "../../../src/lib/history/claude.js";
+import type {
+	HistoryContext,
+	HistoryFile,
+	HistoryRole,
+	SearchScope,
+} from "../../../src/lib/history/types.js";
+
+function context(overrides: Partial<HistoryContext> = {}): HistoryContext {
+	return {
+		targetId: "claude",
+		displayName: "Claude Code",
+		homeDir: "/home/test",
+		cwd: "/repo",
+		roles: new Set<HistoryRole>(["user", "assistant", "agent"]),
+		signal: new AbortController().signal,
+		...overrides,
+	};
+}
+
+function file(overrides: Partial<HistoryFile> = {}): HistoryFile {
+	return {
+		path: "/transcripts/session.jsonl",
+		projectPath: null,
+		sessionId: "session",
+		modifiedAt: null,
+		sizeBytes: null,
+		...overrides,
+	};
+}
+
+function scope(overrides: Partial<SearchScope> = {}): SearchScope {
+	return { projectPath: null, projectMatch: null, since: null, until: null, ...overrides };
+}
+
+const userRecord = (content: unknown, extra: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		type: "user",
+		sessionId: "session",
+		cwd: "/repo",
+		timestamp: "2026-08-01T10:00:00.000Z",
+		message: { role: "user", content },
+		...extra,
+	});
+
+describe("slugifyProjectPath", () => {
+	it("replaces every non-alphanumeric character with a hyphen", () => {
+		expect(slugifyProjectPath("/Users/joe/dev/my.project")).toBe("-Users-joe-dev-my-project");
+	});
+
+	it("matches a session started in a subdirectory of the project", () => {
+		expect(projectSlugMatches("-a-b-foo-src-nested", "/a/b/foo")).toBe(true);
+		expect(projectSlugMatches("-a-b-foo", "/a/b/foo")).toBe(true);
+	});
+
+	// Without the trailing-hyphen guard, `/a/b/foo` swallows every sibling sharing that prefix.
+	it("does not match a sibling project whose name extends the slug", () => {
+		expect(projectSlugMatches("-a-b-foobar", "/a/b/foo")).toBe(false);
+	});
+});
+
+describe("cleanClaudeText", () => {
+	it("strips system reminders", () => {
+		expect(cleanClaudeText("real prompt<system-reminder>noise\nmore</system-reminder>")).toBe(
+			"real prompt",
+		);
+	});
+
+	it("drops harness wrapper records", () => {
+		for (const tag of [
+			"task-notification",
+			"command-name",
+			"command-message",
+			"local-command-stdout",
+			"bash-input",
+		]) {
+			expect(cleanClaudeText(`<${tag}>payload</${tag}>`)).toBe("");
+		}
+		expect(cleanClaudeText("Caveat: the messages below were generated")).toBe("");
+	});
+
+	it("keeps ordinary prose that merely contains angle brackets", () => {
+		expect(cleanClaudeText("use <div> here")).toBe("use <div> here");
+	});
+});
+
+describe("normalizeClaudeLine", () => {
+	it("extracts a plain string user prompt", () => {
+		const record = normalizeClaudeLine(userRecord("fix the merge conflict"), file(), 3, context());
+
+		expect(record?.role).toBe("user");
+		expect(record?.text).toBe("fix the merge conflict");
+		expect(record?.sessionId).toBe("session");
+		expect(record?.cwd).toBe("/repo");
+		expect(record?.recordIndex).toBe(3);
+	});
+
+	it("extracts only text blocks from a block array", () => {
+		const record = normalizeClaudeLine(
+			userRecord([
+				{ type: "text", text: "first" },
+				{ type: "text", text: "second" },
+			]),
+			file(),
+			0,
+			context(),
+		);
+
+		expect(record?.text).toBe("first\nsecond");
+	});
+
+	// tool_result blocks ride on user-role records and outnumber real prompts ~20:1. Treating
+	// them as user messages is the single largest false-positive source.
+	it("ignores tool_result blocks entirely", () => {
+		const line = userRecord([
+			{ type: "tool_result", tool_use_id: "t1", content: "merge conflict in foo.ts" },
+		]);
+
+		expect(normalizeClaudeLine(line, file(), 0, context())).toBeNull();
+	});
+
+	it("ignores isMeta records", () => {
+		const line = userRecord("Base directory for this skill: /x", { isMeta: true });
+
+		expect(normalizeClaudeLine(line, file(), 0, context())).toBeNull();
+	});
+
+	// Sidechain user records are dispatch prompts written by the orchestrator, not the human.
+	it("classifies sidechain records as the agent role, never user", () => {
+		const line = userRecord("do a medium-breadth exploration", { isSidechain: true });
+
+		expect(normalizeClaudeLine(line, file(), 0, context())?.role).toBe("agent");
+		expect(
+			normalizeClaudeLine(line, file(), 0, context({ roles: new Set<HistoryRole>(["user"]) })),
+		).toBeNull();
+	});
+
+	it("extracts assistant text", () => {
+		const line = JSON.stringify({
+			type: "assistant",
+			sessionId: "session",
+			message: { role: "assistant", content: [{ type: "text", text: "here is the fix" }] },
+		});
+
+		expect(normalizeClaudeLine(line, file(), 0, context())?.role).toBe("assistant");
+	});
+
+	it("skips records whose role was not requested", () => {
+		const line = JSON.stringify({
+			type: "assistant",
+			message: { content: [{ type: "text", text: "hi" }] },
+		});
+
+		expect(
+			normalizeClaudeLine(line, file(), 0, context({ roles: new Set<HistoryRole>(["user"]) })),
+		).toBeNull();
+	});
+
+	it("returns null for malformed JSON instead of throwing", () => {
+		expect(normalizeClaudeLine('{"type":"user"', file(), 0, context())).toBeNull();
+	});
+
+	it("falls back to the file session id when the record omits one", () => {
+		const line = JSON.stringify({ type: "user", message: { content: "hello" } });
+
+		expect(
+			normalizeClaudeLine(line, file({ sessionId: "from-file" }), 0, context())?.sessionId,
+		).toBe("from-file");
+	});
+});
+
+describe("listClaudeFiles", () => {
+	async function withHome(fn: (homeDir: string) => Promise<void>): Promise<void> {
+		const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-claude-hist-"));
+		try {
+			const homeDir = path.join(root, "home");
+			const projects = path.join(homeDir, ".claude", "projects");
+			const projectA = path.join(projects, slugifyProjectPath("/repo/alpha"));
+			const projectB = path.join(projects, slugifyProjectPath("/repo/alphabet"));
+			await mkdir(path.join(projectA, "sess-1", "subagents"), { recursive: true });
+			await mkdir(projectB, { recursive: true });
+			await writeFile(path.join(projectA, "sess-1.jsonl"), "{}\n");
+			await writeFile(path.join(projectA, "sess-1", "subagents", "agent-aaa.jsonl"), "{}\n");
+			await writeFile(path.join(projectB, "sess-2.jsonl"), "{}\n");
+			await fn(homeDir);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+
+	async function collect(homeDir: string, s: SearchScope, roles: HistoryRole[]) {
+		const out: string[] = [];
+		for await (const found of listClaudeFiles(s, context({ homeDir, roles: new Set(roles) }))) {
+			out.push(found.path);
+		}
+		return out;
+	}
+
+	// 111 of 203 files on a real install live under subagents/. A one-level walk drops them all.
+	it("recurses into subagent transcripts", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope(), ["user", "assistant", "agent"]);
+
+			expect(found.some((p) => p.includes(`${path.sep}subagents${path.sep}`))).toBe(true);
+			expect(found).toHaveLength(3);
+		});
+	});
+
+	it("skips subagent transcripts when the agent role was not requested", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope(), ["user"]);
+
+			expect(found.some((p) => p.includes("subagents"))).toBe(false);
+			expect(found).toHaveLength(2);
+		});
+	});
+
+	it("reads only subagent transcripts when only the agent role was requested", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope(), ["agent"]);
+
+			expect(found).toHaveLength(1);
+			expect(found[0]).toContain("subagents");
+		});
+	});
+
+	it("prunes sibling projects that merely share a slug prefix", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope({ projectPath: "/repo/alpha" }), [
+				"user",
+				"agent",
+			]);
+
+			expect(found).toHaveLength(2);
+			expect(found.every((p) => !p.includes("alphabet"))).toBe(true);
+		});
+	});
+
+	it("matches a slugified substring filter", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope({ projectMatch: "repo/alphabet" }), ["user"]);
+
+			expect(found).toHaveLength(1);
+			expect(found[0]).toContain("alphabet");
+		});
+	});
+
+	it("yields nothing when the projects directory is absent", async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-claude-empty-"));
+		try {
+			expect(await collect(root, scope(), ["user"])).toEqual([]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resumeClaudeSession", () => {
+	it("reports the session cwd so the renderer can emit a cd prefix", () => {
+		const resume = resumeClaudeSession({
+			agentId: "claude",
+			role: "user",
+			timestamp: null,
+			text: "hi",
+			sessionId: "abc123",
+			cwd: "/repo/alpha",
+			sourcePath: "/x.jsonl",
+			recordIndex: 0,
+		});
+
+		expect(resume).toEqual({ command: "claude", args: ["--resume", "abc123"], cwd: "/repo/alpha" });
+	});
+});

--- a/tests/lib/history/clipboard.test.ts
+++ b/tests/lib/history/clipboard.test.ts
@@ -1,0 +1,98 @@
+import type { spawn as nodeSpawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import {
+	ClipboardError,
+	clipboardCandidates,
+	copyToClipboard,
+} from "../../../src/lib/history/clipboard.js";
+
+type Behavior = "ok" | "missing" | "fail";
+
+function fakeSpawn(behaviors: Record<string, Behavior>) {
+	const attempted: string[] = [];
+	const written: string[] = [];
+	const spawn = ((command: string) => {
+		attempted.push(command);
+		const child = new EventEmitter() as EventEmitter & { stdin: EventEmitter };
+		const stdin = new EventEmitter() as EventEmitter & { end: (value: string) => void };
+		stdin.end = (value: string) => {
+			written.push(value);
+		};
+		child.stdin = stdin;
+		queueMicrotask(() => {
+			const behavior = behaviors[command] ?? "missing";
+			if (behavior === "missing") {
+				child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+				return;
+			}
+			child.emit("close", behavior === "ok" ? 0 : 1);
+		});
+		return child;
+	}) as unknown as typeof nodeSpawn;
+	return { spawn, attempted, written };
+}
+
+describe("clipboardCandidates", () => {
+	it("uses pbcopy on macOS", () => {
+		expect(clipboardCandidates("darwin", {})).toEqual([{ command: "pbcopy", args: [] }]);
+	});
+
+	it("uses clip on Windows", () => {
+		expect(clipboardCandidates("win32", {})).toEqual([{ command: "clip", args: [] }]);
+	});
+
+	it("prefers wl-copy under Wayland and xclip otherwise", () => {
+		expect(clipboardCandidates("linux", { WAYLAND_DISPLAY: "wayland-0" })[0]?.command).toBe(
+			"wl-copy",
+		);
+		expect(clipboardCandidates("linux", {})[0]?.command).toBe("xclip");
+		// Every helper stays reachable regardless of the detected session type.
+		expect(clipboardCandidates("linux", {}).map((entry) => entry.command)).toContain("wl-copy");
+	});
+});
+
+describe("copyToClipboard", () => {
+	it("writes the text to the first working helper", async () => {
+		const { spawn, attempted, written } = fakeSpawn({ pbcopy: "ok" });
+
+		const used = await copyToClipboard("hello clipboard", { platform: "darwin", spawn });
+
+		expect(used.command).toBe("pbcopy");
+		expect(attempted).toEqual(["pbcopy"]);
+		expect(written).toEqual(["hello clipboard"]);
+	});
+
+	it("falls through to the next helper when one is missing", async () => {
+		const { spawn, attempted } = fakeSpawn({ xclip: "missing", xsel: "ok" });
+
+		const used = await copyToClipboard("text", { platform: "linux", env: {}, spawn });
+
+		expect(used.command).toBe("xsel");
+		expect(attempted).toEqual(["xclip", "xsel"]);
+	});
+
+	it("falls through when a helper exits non-zero", async () => {
+		const { spawn } = fakeSpawn({ xclip: "fail", xsel: "ok" });
+
+		expect((await copyToClipboard("text", { platform: "linux", env: {}, spawn })).command).toBe(
+			"xsel",
+		);
+	});
+
+	it("throws one actionable error when no helper works", async () => {
+		const { spawn, attempted } = fakeSpawn({});
+
+		await expect(copyToClipboard("text", { platform: "linux", env: {}, spawn })).rejects.toThrow(
+			ClipboardError,
+		);
+		expect(attempted).toEqual(["xclip", "xsel", "wl-copy"]);
+	});
+
+	it("names the install options in the failure message", async () => {
+		const { spawn } = fakeSpawn({});
+
+		await expect(copyToClipboard("text", { platform: "linux", env: {}, spawn })).rejects.toThrow(
+			/wl-clipboard, xclip, or xsel/,
+		);
+	});
+});

--- a/tests/lib/history/codex.test.ts
+++ b/tests/lib/history/codex.test.ts
@@ -62,6 +62,38 @@ const agentEvent = (message: string) =>
 		payload: { type: "agent_message", message, phase: "commentary" },
 	});
 
+/**
+ * Current shape (Codex from 2026-08-07): messages arrive as completed thread items rather than
+ * bespoke user_message / agent_message events.
+ */
+const itemCompletedUser = (text: string, timestamp = "2026-08-07T10:05:00.000Z") =>
+	JSON.stringify({
+		timestamp,
+		type: "event_msg",
+		payload: {
+			type: "item_completed",
+			item: { type: "UserMessage", id: "i1", content: [{ type: "text", text, text_elements: [] }] },
+		},
+	});
+
+/** Agent messages use a capitalised block type; the reader keys off the text field, not the label. */
+const itemCompletedAgent = (text: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-07T10:06:00.000Z",
+		type: "event_msg",
+		payload: {
+			type: "item_completed",
+			item: { type: "AgentMessage", id: "i2", content: [{ type: "Text", text }] },
+		},
+	});
+
+const itemCompletedOther = (itemType: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-07T10:07:00.000Z",
+		type: "event_msg",
+		payload: { type: "item_completed", item: { type: itemType, id: "i3", content: [] } },
+	});
+
 /** The polluted duplicate: same text, wrapped with injected harness context. */
 const responseItemUser = (text: string) =>
 	JSON.stringify({
@@ -132,6 +164,94 @@ describe("normalizeCodexLine", () => {
 
 	it("drops empty messages", () => {
 		expect(normalizeCodexLine(userEvent("   "), file(), 0, context())).toBeNull();
+	});
+});
+
+// Codex changed its transcript format on 2026-08-07: user_message / agent_message events were
+// replaced by item_completed thread items. Reading only the legacy shape silently returns
+// nothing for every recent session, which no snapshot of older transcripts can catch.
+describe("current item_completed format", () => {
+	it("extracts a user prompt from a completed UserMessage item", () => {
+		const record = normalizeCodexLine(itemCompletedUser("asdfadsf"), file(), 4, context());
+
+		expect(record?.role).toBe("user");
+		expect(record?.text).toBe("asdfadsf");
+		expect(record?.recordIndex).toBe(4);
+	});
+
+	it("extracts assistant text from a completed AgentMessage item", () => {
+		const record = normalizeCodexLine(itemCompletedAgent("here you go"), file(), 0, context());
+
+		expect(record?.role).toBe("assistant");
+		expect(record?.text).toBe("here you go");
+	});
+
+	it("ignores completed items that are not messages", () => {
+		for (const itemType of ["Reasoning", "CommandExecution", "FileChange", "Plan"]) {
+			expect(normalizeCodexLine(itemCompletedOther(itemType), file(), 0, context())).toBeNull();
+		}
+	});
+
+	it("still yields exactly one record when the turn is also stored as a response_item", () => {
+		const text = "asdfadsf";
+		const records = [responseItemUser(text), itemCompletedUser(text)]
+			.map((line, index) => normalizeCodexLine(line, file(), index, context()))
+			.filter((record) => record !== null);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.text).toBe(text);
+	});
+
+	it("honours role filtering", () => {
+		expect(
+			normalizeCodexLine(
+				itemCompletedAgent("hi"),
+				file(),
+				0,
+				context({ roles: new Set<HistoryRole>(["user"]) }),
+			),
+		).toBeNull();
+	});
+
+	it("joins multiple content blocks", () => {
+		const line = JSON.stringify({
+			timestamp: "2026-08-07T10:05:00.000Z",
+			type: "event_msg",
+			payload: {
+				type: "item_completed",
+				item: {
+					type: "UserMessage",
+					content: [
+						{ type: "text", text: "first " },
+						{ type: "text", text: "second" },
+					],
+				},
+			},
+		});
+
+		expect(normalizeCodexLine(line, file(), 0, context())?.text).toBe("first second");
+	});
+
+	it("drops an item with no text content", () => {
+		const line = JSON.stringify({
+			timestamp: "2026-08-07T10:05:00.000Z",
+			type: "event_msg",
+			payload: { type: "item_completed", item: { type: "UserMessage", content: [] } },
+		});
+
+		expect(normalizeCodexLine(line, file(), 0, context())).toBeNull();
+	});
+});
+
+// Both encodings must keep working: transcripts written before the change are still on disk.
+describe("legacy event format", () => {
+	it("still extracts user_message and agent_message events", () => {
+		expect(normalizeCodexLine(userEvent("legacy prompt"), file(), 0, context())?.text).toBe(
+			"legacy prompt",
+		);
+		expect(normalizeCodexLine(agentEvent("legacy reply"), file(), 0, context())?.role).toBe(
+			"assistant",
+		);
 	});
 });
 

--- a/tests/lib/history/codex.test.ts
+++ b/tests/lib/history/codex.test.ts
@@ -1,0 +1,268 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	listCodexFiles,
+	normalizeCodexLine,
+	readCodexSessionMeta,
+	resumeCodexSession,
+} from "../../../src/lib/history/codex.js";
+import type {
+	HistoryContext,
+	HistoryFile,
+	HistoryRole,
+	SearchScope,
+} from "../../../src/lib/history/types.js";
+
+function context(overrides: Partial<HistoryContext> = {}): HistoryContext {
+	return {
+		targetId: "codex",
+		displayName: "OpenAI Codex",
+		homeDir: "/home/test",
+		cwd: "/repo",
+		roles: new Set<HistoryRole>(["user", "assistant"]),
+		signal: new AbortController().signal,
+		...overrides,
+	};
+}
+
+function file(overrides: Partial<HistoryFile> = {}): HistoryFile {
+	return {
+		path: "/sessions/rollout.jsonl",
+		projectPath: "/repo",
+		sessionId: "rollout-id",
+		modifiedAt: null,
+		sizeBytes: null,
+		...overrides,
+	};
+}
+
+function scope(overrides: Partial<SearchScope> = {}): SearchScope {
+	return { projectPath: null, projectMatch: null, since: null, until: null, ...overrides };
+}
+
+const sessionMeta = (cwd: string, id = "rollout-id") =>
+	JSON.stringify({
+		timestamp: "2026-08-01T10:00:00.000Z",
+		type: "session_meta",
+		payload: { id, session_id: `${id}-forked`, cwd, model: "gpt-5", cli_version: "0.1.0" },
+	});
+
+const userEvent = (message: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-01T10:05:00.000Z",
+		type: "event_msg",
+		payload: { type: "user_message", message, images: [] },
+	});
+
+const agentEvent = (message: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-01T10:06:00.000Z",
+		type: "event_msg",
+		payload: { type: "agent_message", message, phase: "commentary" },
+	});
+
+/** The polluted duplicate: same text, wrapped with injected harness context. */
+const responseItemUser = (text: string) =>
+	JSON.stringify({
+		timestamp: "2026-08-01T10:05:00.000Z",
+		type: "response_item",
+		payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+	});
+
+describe("normalizeCodexLine", () => {
+	it("extracts a user prompt from an event_msg", () => {
+		const record = normalizeCodexLine(userEvent("fix the merge conflict"), file(), 2, context());
+
+		expect(record?.role).toBe("user");
+		expect(record?.text).toBe("fix the merge conflict");
+		expect(record?.sessionId).toBe("rollout-id");
+		expect(record?.cwd).toBe("/repo");
+		expect(record?.recordIndex).toBe(2);
+	});
+
+	it("extracts assistant text from agent_message", () => {
+		expect(normalizeCodexLine(agentEvent("here you go"), file(), 0, context())?.role).toBe(
+			"assistant",
+		);
+	});
+
+	// THE TRAP. response_item carries the same user text but with injected harness blocks.
+	// Widening the predicate to accept it silently doubles every result.
+	it("ignores response_item records that duplicate user text", () => {
+		expect(
+			normalizeCodexLine(responseItemUser("fix the merge conflict"), file(), 0, context()),
+		).toBeNull();
+	});
+
+	it("never surfaces injected environment_context", () => {
+		const line = responseItemUser("<environment_context><cwd>/repo</cwd></environment_context>");
+
+		expect(normalizeCodexLine(line, file(), 0, context())).toBeNull();
+	});
+
+	it("yields exactly one record when both encodings of the same turn are present", () => {
+		const text = "fix the merge conflict";
+		const lines = [userEvent(text), responseItemUser(text)];
+		const records = lines
+			.map((line, index) => normalizeCodexLine(line, file(), index, context()))
+			.filter((record) => record !== null);
+
+		expect(records).toHaveLength(1);
+		expect(records[0]?.text).toBe(text);
+	});
+
+	it("skips roles that were not requested", () => {
+		expect(
+			normalizeCodexLine(
+				agentEvent("hi"),
+				file(),
+				0,
+				context({ roles: new Set<HistoryRole>(["user"]) }),
+			),
+		).toBeNull();
+	});
+
+	it("ignores non-message events and malformed lines", () => {
+		const tokenCount = JSON.stringify({ type: "event_msg", payload: { type: "token_count" } });
+
+		expect(normalizeCodexLine(tokenCount, file(), 0, context())).toBeNull();
+		expect(normalizeCodexLine('{"type":"event_msg"', file(), 0, context())).toBeNull();
+	});
+
+	it("drops empty messages", () => {
+		expect(normalizeCodexLine(userEvent("   "), file(), 0, context())).toBeNull();
+	});
+});
+
+describe("readCodexSessionMeta", () => {
+	async function withFile(body: string, fn: (filePath: string) => Promise<void>): Promise<void> {
+		const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-meta-"));
+		try {
+			const filePath = path.join(root, "rollout.jsonl");
+			await writeFile(filePath, body);
+			await fn(filePath);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+
+	it("prefers the rollout id over the forked session_id", async () => {
+		await withFile(`${sessionMeta("/repo/alpha", "roll-1")}\n${userEvent("hi")}\n`, async (p) => {
+			const meta = await readCodexSessionMeta(p);
+
+			expect(meta?.sessionId).toBe("roll-1");
+			expect(meta?.cwd).toBe("/repo/alpha");
+		});
+	});
+
+	it("returns null when the first line is not session_meta", async () => {
+		await withFile(`${userEvent("hi")}\n`, async (p) => {
+			expect(await readCodexSessionMeta(p)).toBeNull();
+		});
+	});
+
+	it("returns null for a torn header rather than throwing", async () => {
+		await withFile('{"type":"session_meta","payload":{"cwd":"/re', async (p) => {
+			expect(await readCodexSessionMeta(p)).toBeNull();
+		});
+	});
+});
+
+describe("listCodexFiles", () => {
+	async function withHome(fn: (homeDir: string) => Promise<void>): Promise<void> {
+		const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-hist-"));
+		try {
+			const homeDir = path.join(root, "home");
+			const day = path.join(homeDir, ".codex", "sessions", "2026", "08", "01");
+			const otherDay = path.join(homeDir, ".codex", "sessions", "2026", "06", "15");
+			await mkdir(day, { recursive: true });
+			await mkdir(otherDay, { recursive: true });
+			await writeFile(
+				path.join(day, "rollout-alpha.jsonl"),
+				`${sessionMeta("/repo/alpha", "roll-alpha")}\n${userEvent("hi")}\n`,
+			);
+			await writeFile(
+				path.join(day, "rollout-beta.jsonl"),
+				`${sessionMeta("/repo/beta", "roll-beta")}\n${userEvent("hi")}\n`,
+			);
+			await writeFile(path.join(otherDay, "rollout-old.jsonl"), `${sessionMeta("/repo/alpha")}\n`);
+			await writeFile(path.join(day, "torn.jsonl"), '{"type":"session_meta","payl');
+			await fn(homeDir);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+
+	async function collect(homeDir: string, s: SearchScope) {
+		const out: HistoryFile[] = [];
+		for await (const found of listCodexFiles(s, context({ homeDir }))) {
+			out.push(found);
+		}
+		return out;
+	}
+
+	it("walks date shards and carries the header cwd and rollout id", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope());
+			const alpha = found.find((f) => f.path.endsWith("rollout-alpha.jsonl"));
+
+			expect(found).toHaveLength(4);
+			expect(alpha?.projectPath).toBe("/repo/alpha");
+			expect(alpha?.sessionId).toBe("roll-alpha");
+		});
+	});
+
+	it("prunes by project path using only the header", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope({ projectPath: "/repo/alpha" }));
+
+			// alpha from both shards, plus the torn file (fail-open); never beta.
+			expect(found.some((f) => f.path.includes("beta"))).toBe(false);
+			expect(found.some((f) => f.path.includes("alpha"))).toBe(true);
+		});
+	});
+
+	// A file whose header could not be read must still be scanned, then filtered per record.
+	it("fails open on an unreadable header", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope({ projectPath: "/repo/nowhere" }));
+
+			expect(found.map((f) => path.basename(f.path))).toEqual(["torn.jsonl"]);
+		});
+	});
+
+	it("prunes whole date shards outside the requested range", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collect(homeDir, scope({ since: new Date("2026-07-01T00:00:00Z") }));
+
+			expect(found.some((f) => f.path.includes(path.join("2026", "06")))).toBe(false);
+		});
+	});
+
+	it("yields nothing when the sessions directory is absent", async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-codex-empty-"));
+		try {
+			expect(await collect(root, scope())).toEqual([]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resumeCodexSession", () => {
+	it("reports the session cwd because codex resume is directory-scoped", () => {
+		const resume = resumeCodexSession({
+			agentId: "codex",
+			role: "user",
+			timestamp: null,
+			text: "hi",
+			sessionId: "roll-1",
+			cwd: "/repo/alpha",
+			sourcePath: "/x.jsonl",
+			recordIndex: 0,
+		});
+
+		expect(resume).toEqual({ command: "codex", args: ["resume", "roll-1"], cwd: "/repo/alpha" });
+	});
+});

--- a/tests/lib/history/extensibility.test.ts
+++ b/tests/lib/history/extensibility.test.ts
@@ -49,7 +49,9 @@ export default {
 						agentId: context.targetId,
 						role: "user",
 						timestamp,
-						text: rest.join("|"),
+						text: rest.join("|").startsWith("encoded:")
+							? Buffer.from(rest.join("|").slice("encoded:".length), "base64").toString("utf8")
+							: rest.join("|"),
 						sessionId: file.sessionId,
 						cwd: file.projectPath,
 						sourcePath: file.path,
@@ -128,6 +130,7 @@ async function withCustomAgent(fn: (fixture: Fixture) => Promise<void>): Promise
 				"2026-08-09T10:00:00.000Z|user|demo agent talks about zebras",
 				"2026-08-09T10:01:00.000Z|assistant|assistant mentions zebras",
 				"2026-08-09T09:00:00.000Z|user|an older zebras prompt",
+				`2026-08-09T08:00:00.000Z|user|encoded:${Buffer.from("decoded pangolin").toString("base64")}`,
 				"",
 			].join("\n"),
 		);
@@ -204,6 +207,15 @@ describe.sequential("history capability extensibility", () => {
 			]);
 			expect(result.matches[0]?.agentId).toBe("demo");
 			expect(result.matches[0]?.displayName).toBe("Demo Agent");
+		});
+	});
+
+	it("does not prefilter custom normalization unless the target opts in", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli(["node", "omniagent", "search", "decoded pangolin", "--only", "demo", "--json"]);
+
+			expect(envelope().matches.map((match) => match.text)).toEqual(["decoded pangolin"]);
 		});
 	});
 

--- a/tests/lib/history/extensibility.test.ts
+++ b/tests/lib/history/extensibility.test.ts
@@ -1,0 +1,329 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCli } from "../../../src/cli/index.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const HISTORY_DIR = path.resolve(HERE, "../../../src/lib/history");
+
+/**
+ * A whole agent defined in user config: its own directory layout, its own record format (pipe
+ * delimited, not JSON), its own resume verb. Nothing about it is known to the engine.
+ */
+function configSource(demoRoot: string, arrayRoot: string): string {
+	return `import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEMO_ROOT = ${JSON.stringify(demoRoot)};
+const ARRAY_ROOT = ${JSON.stringify(arrayRoot)};
+
+export default {
+	targets: [
+		{
+			id: "demo",
+			displayName: "Demo Agent",
+			history: {
+				roles: ["user"],
+				listFiles: async function* () {
+					const entries = await readdir(DEMO_ROOT, { withFileTypes: true });
+					for (const entry of entries) {
+						if (!entry.isFile() || !entry.name.endsWith(".log")) continue;
+						yield {
+							path: path.join(DEMO_ROOT, entry.name),
+							projectPath: "/demo/project",
+							sessionId: path.basename(entry.name, ".log"),
+							modifiedAt: "2026-08-09T00:00:00.000Z",
+							sizeBytes: null,
+						};
+					}
+				},
+				// Bespoke line format: TIMESTAMP|ROLE|TEXT. The engine only splits lines; every
+				// bit of parsing lives here.
+				normalize: (line, file, index, context) => {
+					const parts = line.split("|");
+					if (parts.length < 3) return null;
+					const [timestamp, role, ...rest] = parts;
+					if (role !== "user") return null;
+					return {
+						agentId: context.targetId,
+						role: "user",
+						timestamp,
+						text: rest.join("|"),
+						sessionId: file.sessionId,
+						cwd: file.projectPath,
+						sourcePath: file.path,
+						recordIndex: index,
+					};
+				},
+				resume: (record) => ({
+					command: "demo-cli",
+					args: ["--session", record.sessionId],
+					cwd: null,
+				}),
+			},
+		},
+		{
+			id: "arraystore",
+			displayName: "Array Store Agent",
+			history: {
+				roles: ["user"],
+				listFiles: async function* () {
+					yield {
+						path: path.join(ARRAY_ROOT, "store.json"),
+						projectPath: "/array/project",
+						sessionId: "arr-1",
+						modifiedAt: "2026-08-08T00:00:00.000Z",
+						sizeBytes: null,
+					};
+				},
+				// Not line-oriented at all: one JSON document holding every message.
+				scan: {
+					kind: "custom",
+					read: async function* (file, context) {
+						const rows = JSON.parse(await readFile(file.path, "utf8"));
+						let index = 0;
+						for (const row of rows) {
+							yield {
+								agentId: context.targetId,
+								role: "user",
+								timestamp: row.at,
+								text: row.text,
+								sessionId: file.sessionId,
+								cwd: file.projectPath,
+								sourcePath: file.path,
+								recordIndex: index++,
+							};
+						}
+					},
+				},
+			},
+		},
+	],
+};
+`;
+}
+
+type Fixture = { root: string; repoRoot: string; homeDir: string };
+
+async function withCustomAgent(fn: (fixture: Fixture) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-extensible-"));
+	try {
+		const repoRoot = path.join(root, "repo");
+		const homeDir = path.join(root, "home");
+		const demoRoot = path.join(root, "demo-history");
+		const arrayRoot = path.join(root, "array-history");
+		await mkdir(path.join(repoRoot, "agents"), { recursive: true });
+		await mkdir(demoRoot, { recursive: true });
+		await mkdir(arrayRoot, { recursive: true });
+		await mkdir(homeDir, { recursive: true });
+		await writeFile(path.join(repoRoot, "package.json"), "{}\n");
+		await writeFile(
+			path.join(repoRoot, "agents", "omniagent.config.mjs"),
+			configSource(demoRoot, arrayRoot),
+		);
+		await writeFile(
+			path.join(demoRoot, "sess-demo.log"),
+			[
+				"2026-08-09T10:00:00.000Z|user|demo agent talks about zebras",
+				"2026-08-09T10:01:00.000Z|assistant|assistant mentions zebras",
+				"2026-08-09T09:00:00.000Z|user|an older zebras prompt",
+				"",
+			].join("\n"),
+		);
+		await writeFile(
+			path.join(arrayRoot, "store.json"),
+			JSON.stringify([
+				{ at: "2026-08-08T10:00:00.000Z", text: "array store mentions zebras" },
+				{ at: "2026-08-08T09:00:00.000Z", text: "unrelated entry" },
+			]),
+		);
+		await fn({ root, repoRoot, homeDir });
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+describe.sequential("history capability extensibility", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let homeSpy: ReturnType<typeof vi.spyOn> | null = null;
+	let cwdSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		process.env.NO_COLOR = "1";
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		exitSpy.mockRestore();
+		homeSpy?.mockRestore();
+		cwdSpy?.mockRestore();
+		homeSpy = null;
+		cwdSpy = null;
+	});
+
+	function use(fixture: Fixture): void {
+		homeSpy = vi.spyOn(os, "homedir").mockReturnValue(fixture.homeDir);
+		cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(fixture.repoRoot);
+	}
+
+	function envelope(): {
+		matches: Array<Record<string, unknown>>;
+		stats: Record<string, number>;
+	} {
+		return JSON.parse(logSpy.mock.calls.map(([value]) => String(value)).join("\n"));
+	}
+
+	// The actual proof of the contract: a brand-new agent, defined only in user config, is fully
+	// searchable without a single line changing inside the search engine.
+	it("searches an agent defined entirely in omniagent.config, with zero engine changes", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"zebras",
+				"--only",
+				"demo",
+				"--json",
+				"--limit",
+				"0",
+			]);
+
+			const result = envelope();
+			expect(result.matches.map((match) => match.text)).toEqual([
+				"demo agent talks about zebras",
+				"an older zebras prompt",
+			]);
+			expect(result.matches[0]?.agentId).toBe("demo");
+			expect(result.matches[0]?.displayName).toBe("Demo Agent");
+		});
+	});
+
+	it("honours the custom agent's own role filtering", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"zebras",
+				"--only",
+				"demo",
+				"--json",
+				"--limit",
+				"0",
+			]);
+
+			// The reader drops the assistant line itself; the engine never sees it.
+			expect(envelope().matches.map((match) => match.text)).not.toContain(
+				"assistant mentions zebras",
+			);
+		});
+	});
+
+	it("renders the custom agent's own resume verb", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli(["node", "omniagent", "search", "zebras", "--only", "demo", "--json"]);
+
+			expect(envelope().matches[0]?.resumeCommand).toBe("demo-cli --session sess-demo");
+		});
+	});
+
+	// The escape hatch: an agent whose history is not line-oriented at all.
+	it("searches a custom scan target backed by a single JSON document", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"zebras",
+				"--only",
+				"arraystore",
+				"--json",
+				"--limit",
+				"0",
+			]);
+
+			expect(envelope().matches.map((match) => match.text)).toEqual([
+				"array store mentions zebras",
+			]);
+		});
+	});
+
+	it("orders results newest-first across built-in and custom agents alike", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"zebras",
+				"--only",
+				"demo,arraystore",
+				"--json",
+				"--limit",
+				"0",
+			]);
+
+			expect(envelope().matches.map((match) => match.timestamp)).toEqual([
+				"2026-08-09T10:00:00.000Z",
+				"2026-08-09T09:00:00.000Z",
+				"2026-08-08T10:00:00.000Z",
+			]);
+		});
+	});
+
+	it("rejects a history block that defines neither reader", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await writeFile(
+				path.join(fixture.repoRoot, "agents", "omniagent.config.mjs"),
+				`export default {
+	targets: [{ id: "broken", history: { roles: ["user"], listFiles: async function* () {} } }],
+};
+`,
+			);
+			await runCli(["node", "omniagent", "search", "zebras"]);
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("must define normalize (for JSONL) or scan.read"),
+			);
+			expect(exitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+
+	// A source-level guard, in the spirit of the existing tests/docs assertions: it fails loudly
+	// the first time someone reaches for a target-specific shortcut inside the engine.
+	it("keeps every engine module free of agent-specific knowledge", async () => {
+		const engineModules = [
+			"types.ts",
+			"query.ts",
+			"jsonl.ts",
+			"filters.ts",
+			"search.ts",
+			"format.ts",
+		];
+
+		for (const moduleName of engineModules) {
+			const source = await readFile(path.join(HISTORY_DIR, moduleName), "utf8");
+
+			expect(source, `${moduleName} must not name a specific agent`).not.toMatch(/claude|codex/i);
+			expect(source, `${moduleName} must not import an agent reader`).not.toMatch(
+				/from "\.\/(claude|codex)\.js"/,
+			);
+			expect(source, `${moduleName} must not branch on target id`).not.toMatch(
+				/targetId\s*===\s*["']/,
+			);
+		}
+	});
+});

--- a/tests/lib/history/extensibility.test.ts
+++ b/tests/lib/history/extensibility.test.ts
@@ -101,6 +101,55 @@ export default {
 				},
 			},
 		},
+		{
+			id: "malformed",
+			displayName: "Malformed Agent",
+			history: {
+				roles: ["user"],
+				listFiles: async function* () {
+					yield {
+						path: path.join(ARRAY_ROOT, "store.json"),
+						projectPath: null,
+						sessionId: null,
+						modifiedAt: null,
+						sizeBytes: null,
+					};
+				},
+				scan: {
+					kind: "custom",
+					read: async function* (file, context) {
+						const valid = {
+							agentId: context.targetId,
+							role: "user",
+							timestamp: null,
+							text: "runtime validation",
+							sessionId: "",
+							cwd: null,
+							gitBranch: null,
+							sourcePath: file.path,
+							recordIndex: 0,
+						};
+						const malformed = [
+							null,
+							{ ...valid, agentId: undefined },
+							{ ...valid, role: "system" },
+							{ ...valid, timestamp: 7 },
+							{ ...valid, text: "" },
+							{ ...valid, text: 7 },
+							{ ...valid, sessionId: undefined },
+							{ ...valid, cwd: undefined },
+							{ ...valid, gitBranch: 7 },
+							{ ...valid, sourcePath: undefined },
+							{ ...valid, recordIndex: -1 },
+							{ ...valid, recordIndex: 1.5 },
+							{ ...valid, recordIndex: NaN },
+						];
+						for (const record of malformed) yield record;
+						yield valid;
+					},
+				},
+			},
+		},
 	],
 };
 `;
@@ -272,6 +321,76 @@ describe.sequential("history capability extensibility", () => {
 		});
 	});
 
+	it("skips malformed custom scan records while retaining valid nullable fields", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"runtime validation",
+				"--only",
+				"malformed",
+				"--json",
+				"--limit",
+				"0",
+			]);
+
+			const result = envelope();
+			expect(result.matches).toHaveLength(1);
+			expect(result.matches[0]?.sessionId).toBe("");
+			expect(result.matches[0]?.timestamp).toBeNull();
+			expect(result.matches[0]?.cwd).toBeNull();
+			expect(result.stats.malformedRecords).toBe(13);
+			expect(result.stats.skippedFiles).toBe(0);
+		});
+	});
+
+	it("runtime-validates custom normalize results", async () => {
+		await withCustomAgent(async (fixture) => {
+			use(fixture);
+			await writeFile(
+				path.join(fixture.repoRoot, "agents", "omniagent.config.mjs"),
+				`export default {
+	targets: [{
+		id: "broken-normalize",
+		history: {
+			roles: ["user"],
+			listFiles: async function* () {
+				yield { path: ${JSON.stringify(path.join(fixture.root, "normalize.log"))}, projectPath: null, sessionId: null, modifiedAt: null, sizeBytes: null };
+			},
+			normalize: () => ({
+				agentId: "broken-normalize",
+				role: "user",
+				timestamp: null,
+				text: "malformed normalized record",
+				sessionId: "",
+				cwd: null,
+				recordIndex: 0,
+			}),
+		},
+	}],
+};
+`,
+			);
+			await writeFile(path.join(fixture.root, "normalize.log"), "one line\n");
+			await runCli([
+				"node",
+				"omniagent",
+				"search",
+				"malformed normalized",
+				"--only",
+				"broken-normalize",
+				"--json",
+			]);
+
+			const result = envelope();
+			expect(result.matches).toEqual([]);
+			expect(result.stats.malformedRecords).toBe(1);
+			expect(result.stats.skippedFiles).toBe(0);
+		});
+	});
+
 	it("orders results newest-first across built-in and custom agents alike", async () => {
 		await withCustomAgent(async (fixture) => {
 			use(fixture);
@@ -318,6 +437,7 @@ describe.sequential("history capability extensibility", () => {
 	// the first time someone reaches for a target-specific shortcut inside the engine.
 	it("keeps every engine module free of agent-specific knowledge", async () => {
 		const engineModules = [
+			"bounded-top-k.ts",
 			"types.ts",
 			"query.ts",
 			"jsonl.ts",

--- a/tests/lib/history/filters.test.ts
+++ b/tests/lib/history/filters.test.ts
@@ -1,0 +1,22 @@
+import { InvalidFilterError, parseWhen } from "../../../src/lib/history/filters.js";
+
+describe("parseWhen", () => {
+	it("rejects calendar dates that roll into another month", () => {
+		expect(() => parseWhen("2026-02-31", { flag: "--since" })).toThrow(InvalidFilterError);
+		expect(() => parseWhen("2026-13-01", { flag: "--until" })).toThrow(InvalidFilterError);
+	});
+
+	it("rejects relative durations outside the Date range", () => {
+		expect(() => parseWhen("999999999999999999999d", { flag: "--since" })).toThrow(
+			InvalidFilterError,
+		);
+	});
+
+	it("still accepts a valid leap day", () => {
+		const parsed = parseWhen("2028-02-29", { flag: "--since" });
+
+		expect(parsed.getFullYear()).toBe(2028);
+		expect(parsed.getMonth()).toBe(1);
+		expect(parsed.getDate()).toBe(29);
+	});
+});

--- a/tests/lib/history/format.test.ts
+++ b/tests/lib/history/format.test.ts
@@ -1,0 +1,71 @@
+import {
+	collapseText,
+	formatResumeCommand,
+	sanitizeTerminalText,
+} from "../../../src/lib/history/format.js";
+
+describe("terminal-safe formatting", () => {
+	it("removes VT and control sequences from displayed transcript text", () => {
+		const text = "before\x1b]52;c;YXR0YWNr\x07after\x1b[31mred\x1b[0m";
+		const sanitized = sanitizeTerminalText(text);
+
+		expect(sanitized).not.toContain("\x1b");
+		expect(sanitized).not.toContain("\x07");
+		expect(collapseText(text)).not.toContain("\x1b");
+	});
+
+	it("shell-quotes resume commands and project paths", () => {
+		expect(
+			formatResumeCommand(
+				{ command: "claude", args: ["--resume", "abc"], cwd: "/tmp/project with spaces" },
+				"/tmp/else",
+				"/Users/demo",
+			),
+		).toBe("cd '/tmp/project with spaces' && claude --resume abc");
+		expect(
+			formatResumeCommand(
+				{ command: "demo; touch /tmp/pwned", args: ["a'b"], cwd: null },
+				"/tmp/else",
+				"/Users/demo",
+			),
+		).toBe(`'demo; touch /tmp/pwned' 'a'"'"'b'`);
+		expect(
+			formatResumeCommand(
+				{ command: "X=1", args: ["touch", "/tmp/pwned"], cwd: null },
+				"/tmp/else",
+				"/Users/demo",
+			),
+		).toBe("'X=1' touch /tmp/pwned");
+	});
+
+	it("keeps home shortening valid when the path needs quotes", () => {
+		expect(
+			formatResumeCommand(
+				{
+					command: "codex",
+					args: ["resume", "abc"],
+					cwd: "/Users/demo/project with spaces",
+				},
+				"/tmp/else",
+				"/Users/demo",
+			),
+		).toBe("cd ~/'project with spaces' && codex resume abc");
+	});
+
+	it("renders a PowerShell-safe command on Windows", () => {
+		expect(
+			formatResumeCommand(
+				{
+					command: "demo agent",
+					args: ["resume", "a'b"],
+					cwd: "C:\\Project With Spaces",
+				},
+				"C:\\Elsewhere",
+				"C:\\Users\\demo",
+				"win32",
+			),
+		).toBe(
+			"Set-Location -LiteralPath 'C:\\Project With Spaces'; if ($?) { & 'demo agent' 'resume' 'a''b' }",
+		);
+	});
+});

--- a/tests/lib/history/format.test.ts
+++ b/tests/lib/history/format.test.ts
@@ -52,6 +52,16 @@ describe("terminal-safe formatting", () => {
 		).toBe("cd ~/'project with spaces' && codex resume abc");
 	});
 
+	it("leaves an exact home path unquoted so the shell expands it", () => {
+		expect(
+			formatResumeCommand(
+				{ command: "codex", args: ["resume", "abc"], cwd: "/Users/demo" },
+				"/tmp/else",
+				"/Users/demo",
+			),
+		).toBe("cd ~ && codex resume abc");
+	});
+
 	it("renders a PowerShell-safe command on Windows", () => {
 		expect(
 			formatResumeCommand(

--- a/tests/lib/history/jsonl.test.ts
+++ b/tests/lib/history/jsonl.test.ts
@@ -1,0 +1,162 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { type JsonlCounters, readJsonlLines } from "../../../src/lib/history/jsonl.js";
+
+async function withTempFile(
+	contents: string | Buffer,
+	fn: (filePath: string) => Promise<void>,
+): Promise<void> {
+	const root = await mkdtemp(path.join(os.tmpdir(), "omniagent-jsonl-"));
+	try {
+		const filePath = path.join(root, "transcript.jsonl");
+		await writeFile(filePath, contents);
+		await fn(filePath);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function collect(
+	filePath: string,
+	options: Parameters<typeof readJsonlLines>[1] = {},
+): Promise<string[]> {
+	const out: string[] = [];
+	for await (const line of readJsonlLines(filePath, options)) {
+		out.push(line.text);
+	}
+	return out;
+}
+
+function counters(): JsonlCounters {
+	return { scannedBytes: 0, oversizedLines: 0 };
+}
+
+describe("readJsonlLines", () => {
+	it("reads every record when lines straddle chunk boundaries", async () => {
+		const records = Array.from({ length: 40 }, (_, i) =>
+			JSON.stringify({ n: i, pad: "x".repeat(i) }),
+		);
+		await withTempFile(`${records.join("\n")}\n`, async (filePath) => {
+			// 16-byte chunks guarantee nearly every record spans several reads.
+			const lines = await collect(filePath, { highWaterMark: 16 });
+
+			expect(lines).toEqual(records);
+		});
+	});
+
+	it("yields a final line that has no trailing newline", async () => {
+		await withTempFile('{"a":1}\n{"b":2}', async (filePath) => {
+			expect(await collect(filePath, { highWaterMark: 4 })).toEqual(['{"a":1}', '{"b":2}']);
+		});
+	});
+
+	it("yields a torn final line so the caller can count it as malformed", async () => {
+		await withTempFile('{"a":1}\n{"b":', async (filePath) => {
+			const lines = await collect(filePath, { highWaterMark: 4 });
+
+			expect(lines).toEqual(['{"a":1}', '{"b":']);
+			expect(() => JSON.parse(lines[1] as string)).toThrow();
+		});
+	});
+
+	it("handles CRLF line endings", async () => {
+		await withTempFile('{"a":1}\r\n{"b":2}\r\n', async (filePath) => {
+			expect(await collect(filePath, { highWaterMark: 5 })).toEqual(['{"a":1}', '{"b":2}']);
+		});
+	});
+
+	it("skips blank lines and handles an empty file", async () => {
+		await withTempFile('\n\n{"a":1}\n\n', async (filePath) => {
+			expect(await collect(filePath)).toEqual(['{"a":1}']);
+		});
+		await withTempFile("", async (filePath) => {
+			expect(await collect(filePath)).toEqual([]);
+		});
+	});
+
+	it("drops an over-length line, counts it, and resyncs to the next record", async () => {
+		const huge = JSON.stringify({ big: "y".repeat(4000) });
+		await withTempFile(`{"a":1}\n${huge}\n{"b":2}\n`, async (filePath) => {
+			const stats = counters();
+			const lines = await collect(filePath, {
+				highWaterMark: 64,
+				maxLineBytes: 512,
+				counters: stats,
+			});
+
+			// The record after the oversized one must still come through — that is the resync.
+			expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+			expect(stats.oversizedLines).toBe(1);
+		});
+	});
+
+	it("keeps line indexes accurate across dropped and prefiltered lines", async () => {
+		const huge = JSON.stringify({ big: "y".repeat(4000) });
+		await withTempFile(`{"a":1}\n${huge}\n{"skip":1}\n{"b":2}\n`, async (filePath) => {
+			const seen: Array<{ text: string; index: number }> = [];
+			for await (const line of readJsonlLines(filePath, {
+				highWaterMark: 64,
+				maxLineBytes: 512,
+				prefilter: (text) => !text.includes("skip"),
+			})) {
+				seen.push({ text: line.text, index: line.index });
+			}
+
+			expect(seen).toEqual([
+				{ text: '{"a":1}', index: 0 },
+				{ text: '{"b":2}', index: 3 },
+			]);
+		});
+	});
+
+	it("applies the prefilter without parsing", async () => {
+		await withTempFile('{"a":1}\n{"b":2}\n{"a":3}\n', async (filePath) => {
+			expect(await collect(filePath, { prefilter: (text) => text.includes('"a"') })).toEqual([
+				'{"a":1}',
+				'{"a":3}',
+			]);
+		});
+	});
+
+	it("counts scanned bytes", async () => {
+		const body = '{"a":1}\n{"b":2}\n';
+		await withTempFile(body, async (filePath) => {
+			const stats = counters();
+			await collect(filePath, { counters: stats, highWaterMark: 4 });
+
+			expect(stats.scannedBytes).toBe(Buffer.byteLength(body));
+		});
+	});
+
+	it("stops early when the signal aborts", async () => {
+		const records = Array.from({ length: 200 }, (_, i) => JSON.stringify({ n: i }));
+		await withTempFile(`${records.join("\n")}\n`, async (filePath) => {
+			const controller = new AbortController();
+			const seen: string[] = [];
+			for await (const line of readJsonlLines(filePath, {
+				highWaterMark: 16,
+				signal: controller.signal,
+			})) {
+				seen.push(line.text);
+				if (seen.length === 3) {
+					controller.abort();
+				}
+			}
+
+			expect(seen.length).toBeLessThan(records.length);
+			expect(seen[0]).toBe(records[0]);
+		});
+	});
+
+	it("decodes multi-byte characters split across chunks", async () => {
+		const record = JSON.stringify({ text: "日本語 café 🎉 merge conflict" });
+		await withTempFile(`${record}\n`, async (filePath) => {
+			// 3-byte chunks slice straight through the multi-byte sequences.
+			const lines = await collect(filePath, { highWaterMark: 3 });
+
+			expect(lines).toEqual([record]);
+			expect(JSON.parse(lines[0] as string).text).toContain("日本語");
+		});
+	});
+});

--- a/tests/lib/history/picker.test.ts
+++ b/tests/lib/history/picker.test.ts
@@ -1,0 +1,250 @@
+import {
+	buildEntries,
+	createPickerState,
+	handleKey,
+	layout,
+	type PickerKey,
+	type PickerState,
+	renderPicker,
+	selectedMatch,
+} from "../../../src/lib/history/picker.js";
+import type { SearchMatch } from "../../../src/lib/history/types.js";
+
+function match(overrides: Partial<SearchMatch> = {}): SearchMatch {
+	return {
+		agentId: "claude",
+		displayName: "Claude Code",
+		role: "user",
+		timestamp: "2026-08-05T10:00:00.000Z",
+		sessionId: "sess",
+		cwd: "/repo/alpha",
+		project: "alpha",
+		gitBranch: null,
+		sourcePath: "/t.jsonl",
+		text: "resolve the merge conflict",
+		textTruncated: false,
+		excerpt: "resolve the merge conflict",
+		matchRanges: [],
+		resumeCommand: "claude --resume sess",
+		...overrides,
+	};
+}
+
+const MATCHES: SearchMatch[] = [
+	match({ text: "alpha prompt about migrations", project: "alpha", sessionId: "s1" }),
+	match({ text: "beta prompt about deploys", agentId: "codex", project: "beta", sessionId: "s2" }),
+	match({ text: "gamma prompt about migrations", project: "gamma", sessionId: "s3" }),
+	match({ text: "delta prompt about tests", agentId: "codex", project: "delta", sessionId: "s4" }),
+];
+
+function state(matches: SearchMatch[] = MATCHES): PickerState {
+	return createPickerState(buildEntries(matches));
+}
+
+function key(name: string, extra: Partial<PickerKey> = {}): PickerKey {
+	return { name, ...extra };
+}
+
+function typed(character: string): PickerKey {
+	return { sequence: character };
+}
+
+function press(initial: PickerState, keys: PickerKey[], listRows = 4): PickerState {
+	return keys.reduce((current, next) => handleKey(current, next, listRows), initial);
+}
+
+describe("picker navigation", () => {
+	it("starts on the newest result", () => {
+		expect(selectedMatch(state())?.sessionId).toBe("s1");
+	});
+
+	it("moves with arrows and with ctrl-n / ctrl-p", () => {
+		expect(selectedMatch(press(state(), [key("down")]))?.sessionId).toBe("s2");
+		expect(selectedMatch(press(state(), [key("n", { ctrl: true })]))?.sessionId).toBe("s2");
+		expect(
+			selectedMatch(press(state(), [key("down"), key("down"), key("p", { ctrl: true })]))
+				?.sessionId,
+		).toBe("s2");
+	});
+
+	it("clamps at both ends instead of wrapping", () => {
+		expect(selectedMatch(press(state(), [key("up"), key("up")]))?.sessionId).toBe("s1");
+		expect(
+			selectedMatch(press(state(), [key("down"), key("down"), key("down"), key("down")]))
+				?.sessionId,
+		).toBe("s4");
+	});
+
+	it("jumps with home, end, and page keys", () => {
+		expect(selectedMatch(press(state(), [key("end")]))?.sessionId).toBe("s4");
+		expect(selectedMatch(press(state(), [key("end"), key("home")]))?.sessionId).toBe("s1");
+		expect(selectedMatch(press(state(), [key("pagedown")], 2))?.sessionId).toBe("s3");
+	});
+
+	it("scrolls the viewport to keep the selection visible", () => {
+		const scrolled = press(state(), [key("down"), key("down"), key("down")], 2);
+
+		expect(scrolled.offset).toBe(2);
+		expect(selectedMatch(scrolled)?.sessionId).toBe("s4");
+	});
+});
+
+describe("picker filtering", () => {
+	it("narrows as characters are typed", () => {
+		const filtered = press(state(), [typed("m"), typed("i"), typed("g")]);
+
+		expect(filtered.filter).toBe("mig");
+		expect(filtered.visible).toHaveLength(2);
+		expect(selectedMatch(filtered)?.sessionId).toBe("s1");
+	});
+
+	it("ANDs filter terms", () => {
+		const filtered = press(state(), [..."gamma mig".split("").map(typed)]);
+
+		expect(filtered.visible).toHaveLength(1);
+		expect(selectedMatch(filtered)?.sessionId).toBe("s3");
+	});
+
+	it("matches on agent id and project as well as text", () => {
+		expect(press(state(), [..."codex".split("").map(typed)]).visible).toHaveLength(2);
+		expect(press(state(), [..."delta".split("").map(typed)]).visible).toHaveLength(1);
+	});
+
+	it("removes characters on backspace", () => {
+		const filtered = press(state(), [typed("m"), typed("i"), typed("g"), key("backspace")]);
+
+		expect(filtered.filter).toBe("mi");
+	});
+
+	it("resets the selection when the filter changes", () => {
+		const filtered = press(state(), [key("down"), key("down"), typed("m")]);
+
+		expect(filtered.selected).toBe(0);
+	});
+
+	it("survives a filter that matches nothing", () => {
+		const filtered = press(state(), [..."zzzz".split("").map(typed)]);
+
+		expect(filtered.visible).toEqual([]);
+		expect(selectedMatch(filtered)).toBeNull();
+		expect(filtered.outcome.type).toBe("active");
+	});
+
+	it("ignores control sequences as filter input", () => {
+		expect(press(state(), [{ sequence: "r", ctrl: true, name: "r" }]).filter).toBe("");
+	});
+});
+
+describe("picker actions", () => {
+	it("copies the selected message on enter", () => {
+		const outcome = press(state(), [key("down"), key("return")]).outcome;
+
+		expect(outcome.type).toBe("copy-text");
+		expect(outcome.type === "copy-text" && outcome.match.sessionId).toBe("s2");
+	});
+
+	it("copies the resume command on ctrl-r", () => {
+		const outcome = press(state(), [key("r", { ctrl: true })]).outcome;
+
+		expect(outcome.type).toBe("copy-resume");
+	});
+
+	it("quits on ctrl-c and ctrl-d", () => {
+		expect(press(state(), [key("c", { ctrl: true })]).outcome.type).toBe("quit");
+		expect(press(state(), [key("d", { ctrl: true })]).outcome.type).toBe("quit");
+	});
+
+	// Escape is overloaded on purpose: it should undo the filter before it abandons the search.
+	it("clears the filter on escape, and quits only once it is empty", () => {
+		const filtered = press(state(), [typed("m"), typed("i")]);
+		const cleared = handleKey(filtered, key("escape"), 4);
+
+		expect(cleared.filter).toBe("");
+		expect(cleared.outcome.type).toBe("active");
+		expect(handleKey(cleared, key("escape"), 4).outcome.type).toBe("quit");
+	});
+
+	it("does nothing on enter when the filter matches nothing", () => {
+		const empty = press(state(), [..."zzzz".split("").map(typed)]);
+
+		expect(handleKey(empty, key("return"), 4).outcome.type).toBe("active");
+	});
+});
+
+describe("picker rendering", () => {
+	const dimensions = { rows: 24, columns: 80 };
+
+	it("renders a frame that fits the terminal", () => {
+		const frame = renderPicker(state(), dimensions, { query: "prompt", useColor: false });
+
+		expect(frame.length).toBeLessThanOrEqual(dimensions.rows);
+		for (const line of frame) {
+			expect(line.length).toBeLessThanOrEqual(dimensions.columns);
+		}
+	});
+
+	it("shows the query, the count, and every result number", () => {
+		const frame = renderPicker(state(), dimensions, { query: "prompt", useColor: false }).join(
+			"\n",
+		);
+
+		expect(frame).toContain("prompt · 4 matches");
+		expect(frame).toContain("[1]");
+		expect(frame).toContain("[4]");
+	});
+
+	it("marks the selected row and previews its full text", () => {
+		const moved = press(state(), [key("down")]);
+		const frame = renderPicker(moved, dimensions, { query: "prompt", useColor: false }).join("\n");
+
+		expect(frame).toContain("▸ [2]");
+		expect(frame).toContain("beta prompt about deploys");
+	});
+
+	it("keeps original result numbers stable while filtering", () => {
+		const filtered = press(state(), [..."gamma".split("").map(typed)]);
+		const frame = renderPicker(filtered, dimensions, { query: "prompt", useColor: false }).join(
+			"\n",
+		);
+
+		// gamma is the third result overall, so it stays [3] even as the only visible row.
+		expect(frame).toContain("[3]");
+		expect(frame).toContain("1 of 4");
+	});
+
+	it("reports an empty filter result without crashing", () => {
+		const empty = press(state(), [..."zzzz".split("").map(typed)]);
+		const frame = renderPicker(empty, dimensions, { query: "prompt", useColor: false }).join("\n");
+
+		expect(frame).toContain("no matches for this filter");
+	});
+
+	it("emits no ANSI when color is disabled", () => {
+		const frame = renderPicker(state(), dimensions, { query: "prompt", useColor: false }).join(
+			"\n",
+		);
+
+		expect(frame.includes(String.fromCharCode(27))).toBe(false);
+	});
+});
+
+describe("picker layout", () => {
+	it("splits the viewport between list and preview", () => {
+		const { listRows, previewRows } = layout({ rows: 24, columns: 80 }, 20);
+
+		expect(listRows).toBeGreaterThan(0);
+		expect(previewRows).toBeGreaterThan(0);
+		expect(listRows + previewRows).toBeLessThanOrEqual(24);
+	});
+
+	it("stays usable in a very short terminal", () => {
+		const { listRows, previewRows } = layout({ rows: 6, columns: 40 }, 20);
+
+		expect(listRows).toBeGreaterThanOrEqual(1);
+		expect(previewRows).toBeGreaterThanOrEqual(1);
+	});
+
+	it("never reserves more list rows than there are results", () => {
+		expect(layout({ rows: 40, columns: 80 }, 2).listRows).toBe(2);
+	});
+});

--- a/tests/lib/history/picker.test.ts
+++ b/tests/lib/history/picker.test.ts
@@ -226,6 +226,16 @@ describe("picker rendering", () => {
 
 		expect(frame.includes(String.fromCharCode(27))).toBe(false);
 	});
+
+	it("sanitizes terminal controls embedded in transcript text", () => {
+		const unsafe = state([
+			match({ text: "before\x1b]52;c;YXR0YWNr\x07after", sessionId: "unsafe" }),
+		]);
+		const frame = renderPicker(unsafe, dimensions, { query: "before", useColor: false }).join("\n");
+
+		expect(frame).not.toContain("\x1b");
+		expect(frame).not.toContain("\x07");
+	});
 });
 
 describe("picker layout", () => {
@@ -238,10 +248,13 @@ describe("picker layout", () => {
 	});
 
 	it("stays usable in a very short terminal", () => {
-		const { listRows, previewRows } = layout({ rows: 6, columns: 40 }, 20);
+		const dimensions = { rows: 6, columns: 40 };
+		const { listRows, previewRows } = layout(dimensions, 20);
+		const frame = renderPicker(state(), dimensions, { query: "prompt", useColor: false });
 
 		expect(listRows).toBeGreaterThanOrEqual(1);
-		expect(previewRows).toBeGreaterThanOrEqual(1);
+		expect(previewRows).toBeGreaterThanOrEqual(0);
+		expect(frame.length).toBeLessThanOrEqual(dimensions.rows);
 	});
 
 	it("never reserves more list rows than there are results", () => {

--- a/tests/lib/history/picker.test.ts
+++ b/tests/lib/history/picker.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import {
 	buildEntries,
 	createPickerState,
@@ -6,9 +7,11 @@ import {
 	type PickerKey,
 	type PickerState,
 	renderPicker,
+	runPicker,
 	selectedMatch,
 } from "../../../src/lib/history/picker.js";
 import type { SearchMatch } from "../../../src/lib/history/types.js";
+import { createHeadlessTerminal, readScreen } from "../../../src/lib/usage/pty.js";
 
 function match(overrides: Partial<SearchMatch> = {}): SearchMatch {
 	return {
@@ -235,6 +238,57 @@ describe("picker rendering", () => {
 
 		expect(frame).not.toContain("\x1b");
 		expect(frame).not.toContain("\x07");
+	});
+});
+
+describe("picker terminal repaint", () => {
+	it("preserves the terminal line before the picker across repaint and cleanup", async () => {
+		const input = new EventEmitter() as EventEmitter &
+			Pick<NodeJS.ReadStream, "isTTY" | "pause" | "resume" | "setRawMode">;
+		input.isTTY = false;
+		input.pause = vi.fn(() => input as NodeJS.ReadStream);
+		input.resume = vi.fn(() => input as NodeJS.ReadStream);
+		input.setRawMode = vi.fn(() => input as NodeJS.ReadStream);
+
+		const writes: string[] = [];
+		const output = new EventEmitter() as EventEmitter &
+			Pick<NodeJS.WriteStream, "columns" | "rows" | "write">;
+		output.columns = 80;
+		output.rows = 12;
+		output.write = vi.fn((value: string | Uint8Array) => {
+			writes.push(String(value));
+			return true;
+		});
+
+		const outcome = runPicker(
+			MATCHES,
+			{
+				input: input as NodeJS.ReadStream,
+				output: output as NodeJS.WriteStream,
+				useColor: false,
+			},
+			{ query: "prompt" },
+		);
+		input.emit("keypress", undefined, key("down"));
+		input.emit("keypress", undefined, key("escape"));
+
+		await expect(outcome).resolves.toEqual({ type: "quit" });
+		const terminal = createHeadlessTerminal(80, 24);
+		try {
+			await new Promise<void>((resolve) => {
+				// A real TTY's output processing expands LF to CRLF. Headless xterm consumes raw
+				// bytes, so mirror that line discipline before replaying the captured writes.
+				const ttyOutput = writes.join("").replaceAll("\n", "\r\n");
+				terminal.write(`sentinel before picker\r\n${ttyOutput}`, resolve);
+			});
+			const nonEmptyLines = readScreen(terminal)
+				.split("\n")
+				.filter((line) => line.length > 0);
+
+			expect(nonEmptyLines).toEqual(["sentinel before picker"]);
+		} finally {
+			terminal.dispose();
+		}
 	});
 });
 

--- a/tests/lib/history/query.test.ts
+++ b/tests/lib/history/query.test.ts
@@ -3,6 +3,7 @@ import {
 	findRanges,
 	InvalidQueryError,
 	matchesText,
+	prefilterJsonLine,
 	prefilterLine,
 } from "../../../src/lib/history/query.js";
 
@@ -149,6 +150,29 @@ describe("prefilter", () => {
 		expect(line).toContain('\\"hello\\"');
 		expect(matchesText(query, text)).toBe(true);
 		expect(prefilterLine(query, line)).toBe(true);
+	});
+
+	it("admits JSON lines whose matching text is unicode escaped", () => {
+		const query = compileQuery(["merge"]);
+		const line = '{"message":"\\u006d\\u0065\\u0072\\u0067\\u0065"}';
+
+		expect(prefilterLine(query, line)).toBe(false);
+		expect(prefilterJsonLine(query, line)).toBe(true);
+	});
+
+	it("admits multiple text fields that normalization may join", () => {
+		const query = compileQuery(["merge"]);
+		const line = '{"content":[{"text":"mer"},{"text":"ge"}]}';
+
+		expect(prefilterLine(query, line)).toBe(false);
+		expect(prefilterJsonLine(query, line)).toBe(true);
+	});
+
+	it("still rejects an unrelated JSON line with one text field", () => {
+		const query = compileQuery(["merge"]);
+		const line = '{"content":[{"type":"text","text":"unrelated"}]}';
+
+		expect(prefilterJsonLine(query, line)).toBe(false);
 	});
 });
 

--- a/tests/lib/history/query.test.ts
+++ b/tests/lib/history/query.test.ts
@@ -1,0 +1,180 @@
+import {
+	compileQuery,
+	findRanges,
+	InvalidQueryError,
+	matchesText,
+	prefilterLine,
+} from "../../../src/lib/history/query.js";
+
+describe("compileQuery", () => {
+	it("treats each positional as its own term, ANDed", () => {
+		const query = compileQuery(["merge", "conflict"]);
+
+		expect(query.terms).toEqual(["merge", "conflict"]);
+		// Order-independent: this is the whole point of AND over phrase.
+		expect(matchesText(query, "hit a conflict during the merge")).toBe(true);
+		expect(matchesText(query, "just a merge")).toBe(false);
+	});
+
+	it("treats a quoted positional as a phrase", () => {
+		const query = compileQuery(["merge conflict"]);
+
+		expect(query.terms).toEqual(["merge conflict"]);
+		expect(matchesText(query, "resolve the merge conflict now")).toBe(true);
+		expect(matchesText(query, "hit a conflict during the merge")).toBe(false);
+	});
+
+	it("is case-insensitive by default and exact under caseSensitive", () => {
+		expect(matchesText(compileQuery(["MeRgE"]), "a merge happened")).toBe(true);
+		expect(matchesText(compileQuery(["MeRgE"], { caseSensitive: true }), "a merge happened")).toBe(
+			false,
+		);
+		expect(matchesText(compileQuery(["merge"], { caseSensitive: true }), "a merge happened")).toBe(
+			true,
+		);
+	});
+
+	it("coerces non-string positionals without throwing", () => {
+		// yargs hands back numbers for a bare `search 123` unless the positional is typed.
+		const query = compileQuery([123 as unknown as string]);
+
+		expect(matchesText(query, "error code 123 returned")).toBe(true);
+	});
+
+	it("rejects a multi-positional regex query", () => {
+		expect(() => compileQuery(["a", "b"], { regex: true })).toThrow(InvalidQueryError);
+		try {
+			compileQuery(["a", "b"], { regex: true });
+		} catch (error) {
+			expect((error as InvalidQueryError).code).toBe("invalid_regex_query");
+		}
+	});
+
+	it("rejects an invalid regex pattern", () => {
+		try {
+			compileQuery(["("], { regex: true });
+			expect.unreachable("should have thrown");
+		} catch (error) {
+			expect((error as InvalidQueryError).code).toBe("invalid_regex");
+		}
+	});
+
+	it("matches in regex mode", () => {
+		const query = compileQuery(["merge\\s+conflicts?"], { regex: true });
+
+		expect(matchesText(query, "the merge   conflict is bad")).toBe(true);
+		expect(matchesText(query, "mergeconflict")).toBe(false);
+	});
+
+	it("uses no prefilter in regex mode", () => {
+		expect(compileQuery(["anything"], { regex: true }).prefilter).toBeNull();
+	});
+});
+
+describe("prefilter", () => {
+	it("derives a needle from the longest escape-safe run", () => {
+		expect(compileQuery(['"hello"']).prefilter).toBe("hello");
+		expect(compileQuery(["merge conflict"]).prefilter).toBe("conflict");
+		expect(compileQuery(["ab", "conflict"]).prefilter).toBe("conflict");
+	});
+
+	it("declines a needle when no safe run is long enough", () => {
+		expect(compileQuery(['a"b']).prefilter).toBeNull();
+		expect(compileQuery(["a b"]).prefilter).toBeNull();
+	});
+
+	it("passes every line when there is no needle", () => {
+		const query = compileQuery(['a"b']);
+
+		expect(query.prefilter).toBeNull();
+		expect(prefilterLine(query, "totally unrelated line")).toBe(true);
+	});
+
+	// The invariant the whole fast path rests on: the prefilter may over-admit lines, but it must
+	// never reject a line whose record would have matched. Anything that breaks this silently
+	// drops real results.
+	it("never produces a false negative against a JSON-encoded line", () => {
+		const texts = [
+			'say "hello" to the parser',
+			'a backslash \\ and a quote " together',
+			"multi\nline\nprompt about merge conflicts",
+			"tabs\tand\tspaces",
+			"unicode: café — naïve — 日本語 — 🎉",
+			"control  char",
+			"plain simple prompt",
+			'nested "quotes \\"deeper\\"" here',
+			"trailing backslash \\",
+		];
+		const needles = [
+			'"hello"',
+			"hello",
+			"backslash",
+			"merge conflicts",
+			"conflicts",
+			"tabs",
+			"café",
+			"日本語",
+			"🎉",
+			"control",
+			"simple",
+			'"quotes',
+			"deeper",
+			"trailing",
+			"\\",
+		];
+
+		for (const text of texts) {
+			// Mirrors how both agents actually persist a record: JSON on one line.
+			const line = JSON.stringify({ type: "user", message: { content: text } });
+			for (const needle of needles) {
+				for (const caseSensitive of [false, true]) {
+					const query = compileQuery([needle], { caseSensitive });
+					if (!matchesText(query, text)) {
+						continue;
+					}
+					expect(
+						prefilterLine(query, line),
+						`prefilter dropped a real match: needle=${JSON.stringify(needle)} text=${JSON.stringify(text)} prefilter=${JSON.stringify(query.prefilter)}`,
+					).toBe(true);
+				}
+			}
+		}
+	});
+
+	it("still admits lines when the needle only appears escaped", () => {
+		const text = 'say "hello" to the parser';
+		const line = JSON.stringify({ message: { content: text } });
+		const query = compileQuery(['"hello"']);
+
+		expect(line).toContain('\\"hello\\"');
+		expect(matchesText(query, text)).toBe(true);
+		expect(prefilterLine(query, line)).toBe(true);
+	});
+});
+
+describe("findRanges", () => {
+	it("returns merged, sorted ranges for literal terms", () => {
+		const query = compileQuery(["merge", "conflict"]);
+
+		expect(findRanges(query, "merge conflict")).toEqual([
+			[0, 5],
+			[6, 14],
+		]);
+	});
+
+	it("finds every occurrence of a term", () => {
+		expect(findRanges(compileQuery(["ab"]), "ab-ab-ab")).toEqual([
+			[0, 2],
+			[3, 5],
+			[6, 8],
+		]);
+	});
+
+	it("merges overlapping ranges from different terms", () => {
+		expect(findRanges(compileQuery(["abc", "bcd"]), "abcd")).toEqual([[0, 4]]);
+	});
+
+	it("returns regex match ranges without hanging on zero-width matches", () => {
+		expect(findRanges(compileQuery(["a*"], { regex: true }), "aa b")).toEqual([[0, 2]]);
+	});
+});

--- a/tests/lib/history/search.test.ts
+++ b/tests/lib/history/search.test.ts
@@ -1,0 +1,116 @@
+import { compileQuery } from "../../../src/lib/history/query.js";
+import { searchHistory } from "../../../src/lib/history/search.js";
+import type { SearchRecord } from "../../../src/lib/history/types.js";
+import type { ResolvedTarget } from "../../../src/lib/targets/config-types.js";
+
+function record(index: number, overrides: Partial<SearchRecord> = {}): SearchRecord {
+	return {
+		agentId: "demo",
+		role: "user",
+		timestamp: new Date(Date.UTC(2026, 0, 1) + index).toISOString(),
+		text: `matching record ${index}`,
+		sessionId: `session-${index}`,
+		cwd: "/repo",
+		sourcePath: "/history.json",
+		recordIndex: index,
+		...overrides,
+	};
+}
+
+function target(records: SearchRecord[], id = "demo"): ResolvedTarget {
+	return {
+		id,
+		displayName: id,
+		aliases: [],
+		outputs: {},
+		isBuiltIn: false,
+		isCustomized: true,
+		history: {
+			roles: ["user"],
+			listFiles: async function* () {
+				yield {
+					path: "/history.json",
+					projectPath: "/repo",
+					sessionId: "session",
+					modifiedAt: "2026-01-01T00:00:00.000Z",
+					sizeBytes: null,
+				};
+			},
+			scan: {
+				kind: "custom",
+				read: async function* () {
+					yield* records;
+				},
+			},
+		},
+	};
+}
+
+async function search(records: SearchRecord[], limit: number) {
+	return searchHistory({
+		targets: [target(records)],
+		query: compileQuery(["matching"]),
+		scope: { projectPath: null, projectMatch: null, since: null, until: null },
+		roles: new Set(["user"]),
+		limit,
+		homeDir: "/home/demo",
+		cwd: "/repo",
+		signal: new AbortController().signal,
+	});
+}
+
+describe("bounded history search", () => {
+	it("keeps the newest 10,000 matches under the unlimited safety cap", async () => {
+		const records = Array.from({ length: 10_005 }, (_, index) => record(index));
+
+		const result = await search(records, 0);
+
+		expect(result.hits).toHaveLength(10_000);
+		expect(result.hits[0]?.record.recordIndex).toBe(10_004);
+		expect(result.hits.at(-1)?.record.recordIndex).toBe(5);
+		expect(result.stats.matchedRecords).toBe(10_005);
+		expect(result.stats.returnedMatches).toBe(10_000);
+		expect(result.stats.truncated).toBe(true);
+	});
+
+	it("uses a finite requested limit as the heap capacity", async () => {
+		const records = [record(2), record(0), record(4), record(1), record(3)];
+
+		const result = await search(records, 3);
+
+		expect(result.hits.map((hit) => hit.record.recordIndex)).toEqual([4, 3, 2]);
+		expect(result.stats.matchedRecords).toBe(5);
+		expect(result.stats.returnedMatches).toBe(3);
+		expect(result.stats.truncated).toBe(true);
+	});
+
+	it("preserves deterministic tie-breaks and sorts unknown timestamps last", async () => {
+		const timestamp = "2026-01-01T00:00:00.000Z";
+		const records = [
+			record(4, { agentId: "beta", sessionId: "s1", timestamp, recordIndex: 0 }),
+			record(3, { agentId: "alpha", sessionId: "s2", timestamp, recordIndex: 0 }),
+			record(2, { agentId: "alpha", sessionId: "s1", timestamp, recordIndex: 1 }),
+			record(1, { agentId: "alpha", sessionId: "s1", timestamp, recordIndex: 0 }),
+			record(5, { agentId: "unknown-b", timestamp: "not-a-date", recordIndex: 0 }),
+			record(6, { agentId: "unknown-a", timestamp: null, recordIndex: 0 }),
+		];
+
+		const result = await search(records, 0);
+
+		expect(
+			result.hits.map(({ record: hit }) => [
+				hit.agentId,
+				hit.sessionId,
+				hit.recordIndex,
+				hit.timestamp,
+			]),
+		).toEqual([
+			["alpha", "s1", 0, timestamp],
+			["alpha", "s1", 1, timestamp],
+			["alpha", "s2", 0, timestamp],
+			["beta", "s1", 0, timestamp],
+			["unknown-a", "session-6", 0, null],
+			["unknown-b", "session-5", 0, "not-a-date"],
+		]);
+	});
+});

--- a/tests/lib/history/search.test.ts
+++ b/tests/lib/history/search.test.ts
@@ -113,4 +113,29 @@ describe("bounded history search", () => {
 			["unknown-b", "session-5", 0, "not-a-date"],
 		]);
 	});
+
+	it("uses source paths to resolve otherwise identical ordering ties", async () => {
+		const timestamp = "2026-01-01T00:00:00.000Z";
+		const records = [
+			record(1, {
+				timestamp,
+				sessionId: "shared-session",
+				sourcePath: "/z-history.json",
+				recordIndex: 0,
+			}),
+			record(0, {
+				timestamp,
+				sessionId: "shared-session",
+				sourcePath: "/a-history.json",
+				recordIndex: 0,
+			}),
+		];
+
+		const result = await search(records, 0);
+
+		expect(result.hits.map((hit) => hit.record.sourcePath)).toEqual([
+			"/a-history.json",
+			"/z-history.json",
+		]);
+	});
 });

--- a/tests/lib/targets/config.test.ts
+++ b/tests/lib/targets/config.test.ts
@@ -455,6 +455,29 @@ describe("target config validation", () => {
 			]),
 		);
 	});
+
+	it("rejects a non-function history prefilter", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "searchable",
+					history: {
+						roles: ["user"],
+						listFiles: async function* () {},
+						normalize: () => null,
+						prefilter: "nope",
+					},
+				} as unknown as TargetDefinition,
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toContain(
+			"targets[0].history.prefilter must be a function when provided.",
+		);
+	});
 });
 
 describe("target resolution", () => {


### PR DESCRIPTION
Claude Code and Codex both persist full conversation transcripts as JSONL, but there's no way to find a prompt you wrote before and use it again. `omniagent search` reads those transcripts directly and puts a past message on your clipboard. No agent CLI is launched, nothing is written, and no network request is made — so an agent you've since uninstalled is still searchable.

```
omniagent search merge conflict
```

## Picking a result

Interactive by default: result list on top, full text of the highlighted match below.

```
review · 20 matches

▸ [ 1] 2026-08-07 16:18  claude  omniagent
  [ 2] 2026-08-07 13:40  codex   BAL-2085-scout-oversized-turn-failure-feedback
  [ 3] 2026-08-07 11:58  claude  BAL-1946-Align-Request-activity-feed-authorization…
────────────────────────────────────────────────────────────────────────────────────
this is a good start! one thing, here is an example output:
…full text of the highlighted match, nothing clamped…

↑↓ move · type to filter · enter copy · ctrl-r resume cmd · esc/ctrl-c quit
```

Typing filters the loaded results in memory — no re-scan. Result numbers stay pinned to the unfiltered list, so a number seen while filtering is the one `--copy` takes.

## Non-interactive

The picker is skipped outside a TTY and whenever `--json`, `--copy`, or `--print` is passed, so scripts and agents never hit a prompt.

```bash
omniagent search deploy --copy       # newest match → clipboard
omniagent search deploy --copy 3     # third result
omniagent search deploy --print 2    # only the text, to stdout — pipeable
omniagent search deploy --full       # complete text for every match
omniagent search deploy --json | jq -r '.matches[0].text'
```

Also `--role user|assistant|agent|all`, `--project` (a path scopes to the repo containing it, so `--project .` means "this repo"; anything else is a substring), `--only`/`--skip`, `--since`/`--until`, `--limit`, `--case-sensitive`, `--regex`.

Multiple terms are ANDed, so `search merge conflict` also finds "conflict during the merge". Quoting is the phrase operator, no extra flag.

## Searchability is a target capability

Targets declare a `history` block — `roles`, `listFiles`, `normalize` or `scan.read`, `resume` — alongside the existing `usage` block. A new agent becomes searchable through config alone; the engine is untouched.

That's enforced rather than asserted:

- A test defines a whole synthetic agent in an `omniagent.config` fixture — own directory layout, pipe-delimited records, own resume verb — and searches it end to end.
- A second fixture covers an agent whose history isn't line-oriented at all, via `scan.read`.
- A source check fails if `search.ts`, `query.ts`, `filters.ts`, or `format.ts` ever names a specific agent.

`normalize` exists because the engine owns the file loop, which is what lets it prefilter raw lines before `JSON.parse`. `scan.kind: "custom"` is the escape hatch so that optimization doesn't quietly restrict which agents are expressible.

## Transcript quirks, and where they live

All of this sits in the per-agent readers, never in the engine:

- Claude subagent transcripts live a directory level deeper (`<session>/subagents/agent-*.jsonl`) — the majority of files on a busy install. Their user-role records are orchestrator dispatch prompts, not human typing, so they're classified `agent` rather than polluting `--role user`.
- `tool_result` blocks ride on user-role records and outnumber real prompts roughly 20:1. Dropped, along with `isMeta` skill payloads and harness wrappers (`task-notification`, `command-name`, `local-command-stdout`, …). The wrapper list was derived by scanning a real corpus, not guessed.
- Codex stores each turn twice; only one copy is clean. It also changed format on 2026-08-07 (`user_message` → `item_completed`), so both encodings are read — see the second commit.

## Performance

Streams line by line and applies an escape-safe substring prefilter before `JSON.parse`, so roughly 132 of 765k lines are ever parsed. A full 1.6 GB corpus scans in ~2s; a path-scoped `--project` is ~150ms. Two counterintuitive results are pinned in comments with the measurements, because both look like obvious optimizations and are ~3x slower: hand-rolled byte-level case folding, and chunk-level prefiltering.

No cache. A stale index would silently return wrong recall results — you'd conclude you never wrote something and rewrite it — which is the one failure this command can't afford. `--json` reports scan stats so the call can be revisited with data.

## Testing

108 new tests. Beyond the usual coverage, each known trap is a named regression test: the Codex duplicate encoding, `tool_result`-is-not-a-prompt, the subagent directory walk, slug prefix collisions (`/a/b/foo` must not swallow `/a/b/foobar`), prefilter escape safety, and `KNOWN_COMMANDS` registration (an unknown flag must exit 1, not 2).

The picker's logic is a pure state machine, unit-tested without a terminal. The parts that can't reach — raw mode, key sequences, frame painting — were driven through a real pty via `node-pty` against actual history.

Gates: `check`, `typecheck`, `test`, `build` all clean. 870 tests pass, up from 769 on master.

## Not included

No `specs/018-search-agent-history/` directory. Every user-facing feature here has one and the branch name is aligned for it, but nothing in CI enforces it — happy to add before merge if you want the convention kept intact.