### PR TITLE
Add adaptive history cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ omniagent search "merge conflict"
 omniagent search --project . migration
 omniagent search --role agent exploration
 omniagent search --only codex --since 7d deploy
+omniagent search deploy --all-history       # exhaustive scan; may be slow
 
 # Non-interactive, for scripts and agents
 omniagent search merge conflict --copy      # copy the newest match
@@ -102,6 +103,10 @@ omniagent search --limit 50 --json refactor
 omniagent --agent codex
 omniagent -p "Summarize this repo" --agent codex --output json
 ```
+
+Large unbounded searches may automatically use a metadata-derived `--since` cutoff. The effective
+range is displayed; pass an explicit `--since`/`--until`, or use `--all-history` for an exhaustive
+scan. No index or cache is created.
 
 `usage` supports Codex, Claude, and Antigravity (`agy`; `gemini` works as an alias). Copilot
 is not supported for usage extraction yet. Usage extraction may launch agent TUIs and may incur

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -205,6 +205,10 @@ history: {
 
 - `roles` must be a non-empty subset of `user`, `assistant`, `agent`.
 - `listFiles` is required.
+- Return accurate `modifiedAt` and `sizeBytes` metadata whenever available. `null` is supported:
+  unknown sizes still count as files but not bytes, and unknown or invalid modification times fail
+  open during automatic pruning. An incorrectly old `modifiedAt` can hide records from automatic or
+  explicit `--since` searches.
 - `prefilter(line, query)` is optional and must never reject a line whose normalized record could
   match; omit it unless the raw encoding makes that guarantee possible.
 - Define exactly one reader: `normalize` for the line-oriented fast path, or `scan.read` for a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -125,6 +125,7 @@ npx omniagent@latest search --project bt-monorepo rls
 npx omniagent@latest search --role assistant flaky test
 npx omniagent@latest search --role agent exploration
 npx omniagent@latest search --only codex --since 7d deploy
+npx omniagent@latest search deploy --all-history
 npx omniagent@latest search --skip codex refactor
 npx omniagent@latest search --regex "TODO\(\w+\)"
 npx omniagent@latest search --limit 50 --json refactor
@@ -134,6 +135,12 @@ Searches the conversation transcripts agent CLIs already write to disk so you ca
 you wrote before and reuse it. The primary path is copying a past message to the clipboard.
 Nothing is launched, nothing is written, and no network request is made — unlike `usage`, no agent
 CLI needs to be installed for its past sessions to be searchable.
+
+Large searches with no date range may receive an automatic `--since` cutoff based on transcript
+file counts and sizes. The effective range is always displayed. An explicit `--since` or `--until`
+bypasses adaptation; `--all-history` disables it and scans every candidate transcript, which may be
+slow. This does not remove the 10,000-result safety cap. Discovery still walks filesystem metadata,
+but old transcript contents are not read. No persistent index or cache is created.
 
 ### Picking a result
 
@@ -170,7 +177,7 @@ passed, so scripts and agents never hit a prompt. `--no-interactive` forces the 
   a search term as the index; that case is rejected with a message naming the fix.
 
 - Command surface: `search [query..]` with `--role`, `--project`, `--only`, `--skip`, `--since`,
-  `--until`, `--limit`, `--case-sensitive`, `--regex`, `--full`, `--copy`, `--print`,
+  `--until`, `--all-history`, `--limit`, `--case-sensitive`, `--regex`, `--full`, `--copy`, `--print`,
   `--no-interactive`, `--agentsDir`, and `--json`.
 - Query behavior: matching is case-insensitive by default. Each argument is a separate term and
   all terms must match, so `search merge conflict` also finds "conflict during the merge". Quote a

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -47,6 +47,7 @@ type SearchArgs = {
 	skip?: string | string[];
 	since?: string;
 	until?: string;
+	allHistory?: boolean;
 	limit?: number;
 	caseSensitive?: boolean;
 	regex?: boolean;
@@ -106,7 +107,10 @@ function printError(options: {
 function emitNotes(notes: SearchNote[]): void {
 	const useColor = shouldUseColor();
 	for (const note of notes) {
-		const line = `Note: ${sanitizeTerminalText(note.message)}`;
+		const line =
+			note.code === "automatic_since"
+				? sanitizeTerminalText(note.message)
+				: `Note: ${sanitizeTerminalText(note.message)}`;
 		console.error(useColor ? `\x1b[2m${line}\x1b[0m` : line);
 	}
 }
@@ -221,6 +225,15 @@ async function runSearchCommand(argv: SearchArgs): Promise<void> {
 			json: jsonOutput,
 			code: "invalid_limit",
 			message: "--limit must be a non-negative integer. Use 0 for the 10,000-result cap.",
+			exitCode: 2,
+		});
+		return;
+	}
+	if (argv.allHistory && (argv.since !== undefined || argv.until !== undefined)) {
+		printError({
+			json: jsonOutput,
+			code: "conflicting_history_scope",
+			message: "Use either --all-history or --since/--until, not both.",
 			exitCode: 2,
 		});
 		return;
@@ -382,6 +395,7 @@ async function runSearchCommand(argv: SearchArgs): Promise<void> {
 			homeDir,
 			cwd: startDir,
 			signal: controller.signal,
+			automaticSince: argv.allHistory !== true && since === null && until === null,
 		});
 	} finally {
 		process.removeListener("SIGINT", onInterrupt);
@@ -413,10 +427,10 @@ async function runSearchCommand(argv: SearchArgs): Promise<void> {
 		query,
 		roles,
 		targets: selected.map((target) => target.id),
-		projectPath: scope.projectPath,
-		projectMatch: scope.projectMatch,
-		since,
-		until,
+		projectPath: result.effectiveScope.projectPath,
+		projectMatch: result.effectiveScope.projectMatch,
+		since: result.effectiveScope.since,
+		until: result.effectiveScope.until,
 		cwd: startDir,
 		homeDir,
 		generatedAt: new Date().toISOString(),
@@ -521,6 +535,7 @@ export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
 			.usage(
 				"omniagent search <query..> [--role <role>] [--project <path|substring>] " +
 					"[--only <targets>] [--skip <targets>] [--since <when>] [--until <when>] " +
+					"[--all-history] " +
 					"[--limit <n>] [--case-sensitive] [--regex] [--full] [--copy [n]] [--print [n]] " +
 					"[--no-interactive] [--agentsDir <path>] [--json]",
 			)
@@ -557,6 +572,11 @@ export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
 				type: "string",
 				describe:
 					"Only match messages at or before this time (YYYY-MM-DD, ISO timestamp, or 7d/24h/30m)",
+			})
+			.option("all-history", {
+				type: "boolean",
+				default: false,
+				describe: "Disable the automatic history cutoff (may be slow)",
 			})
 			.option("limit", {
 				type: "number",
@@ -614,6 +634,7 @@ export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
 			.epilog(
 				"Reads agent transcripts directly from disk. No agent CLI is launched, nothing is " +
 					"written, and no network request is made.\n" +
+					"Large unbounded histories may use an automatic --since cutoff; --all-history disables it.\n" +
 					"Multiple terms are ANDed; quote a phrase to match it exactly.\n" +
 					"Transcripts may contain secrets you pasted; --json prints full message text.",
 			)
@@ -628,6 +649,7 @@ export const searchCommand: CommandModule<Record<string, never>, SearchArgs> = {
 			.example("omniagent search --role assistant flaky test", "Search agent replies, not prompts")
 			.example("omniagent search --role agent exploration", "Search subagent transcripts")
 			.example("omniagent search --only codex --since 7d deploy", "One agent, last week only")
+			.example("omniagent search deploy --all-history", "Search every transcript (may be slow)")
 			.example('omniagent search --regex "TODO\\(\\w+\\)"', "Match with a regular expression")
 			.example("omniagent search --limit 50 --json refactor", "Emit machine-readable results"),
 	handler: async (argv) => {

--- a/src/lib/history/auto-since.ts
+++ b/src/lib/history/auto-since.ts
@@ -13,6 +13,9 @@ export type AutomaticSinceDecision = {
 	since: Date;
 };
 
+const ISO_TIMESTAMP =
+	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
 function knownSizeBytes(file: HistoryFile): number {
 	return typeof file.sizeBytes === "number" &&
 		Number.isFinite(file.sizeBytes) &&
@@ -21,10 +24,38 @@ function knownSizeBytes(file: HistoryFile): number {
 		: 0;
 }
 
+function parseKnownModifiedAt(value: unknown): number | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+	const match = ISO_TIMESTAMP.exec(value);
+	if (!match) {
+		return null;
+	}
+
+	const [year, month, day, hour, minute, second] = match.slice(1, 7).map((part) => Number(part));
+	const calendar = new Date(0);
+	calendar.setUTCFullYear(year as number, (month as number) - 1, day);
+	calendar.setUTCHours(hour as number, minute, second, 0);
+	if (
+		calendar.getUTCFullYear() !== year ||
+		calendar.getUTCMonth() !== (month as number) - 1 ||
+		calendar.getUTCDate() !== day ||
+		calendar.getUTCHours() !== hour ||
+		calendar.getUTCMinutes() !== minute ||
+		calendar.getUTCSeconds() !== second
+	) {
+		return null;
+	}
+
+	const timestamp = Date.parse(value);
+	return Number.isFinite(timestamp) ? timestamp : null;
+}
+
 /** Missing or invalid mtimes fail open so uncertain metadata never hides a transcript. */
 export function historyFileMatchesSince(file: HistoryFile, since: Date): boolean {
-	const modifiedAt = file.modifiedAt === null ? Number.NaN : Date.parse(file.modifiedAt);
-	return !Number.isFinite(modifiedAt) || modifiedAt >= since.getTime();
+	const modifiedAt = parseKnownModifiedAt(file.modifiedAt);
+	return modifiedAt === null || modifiedAt >= since.getTime();
 }
 
 /** Selects a responsive search window using only metadata gathered during normal discovery. */

--- a/src/lib/history/auto-since.ts
+++ b/src/lib/history/auto-since.ts
@@ -1,0 +1,67 @@
+import { parseWhen } from "./filters.js";
+import type { HistoryFile } from "./types.js";
+
+export const LARGE_HISTORY_BYTES = 2 * 1024 * 1024 * 1024;
+export const LARGE_HISTORY_FILES = 20_000;
+export const TARGET_HISTORY_BYTES = 512 * 1024 * 1024;
+export const TARGET_HISTORY_FILES = 5_000;
+
+export const AUTO_SINCE_WINDOWS = ["365d", "180d", "90d", "30d", "7d"] as const;
+
+export type AutomaticSinceDecision = {
+	argument: (typeof AUTO_SINCE_WINDOWS)[number];
+	since: Date;
+};
+
+function knownSizeBytes(file: HistoryFile): number {
+	return typeof file.sizeBytes === "number" &&
+		Number.isFinite(file.sizeBytes) &&
+		file.sizeBytes >= 0
+		? file.sizeBytes
+		: 0;
+}
+
+/** Missing or invalid mtimes fail open so uncertain metadata never hides a transcript. */
+export function historyFileMatchesSince(file: HistoryFile, since: Date): boolean {
+	const modifiedAt = file.modifiedAt === null ? Number.NaN : Date.parse(file.modifiedAt);
+	return !Number.isFinite(modifiedAt) || modifiedAt >= since.getTime();
+}
+
+/** Selects a responsive search window using only metadata gathered during normal discovery. */
+export function chooseAutomaticSince(
+	files: readonly HistoryFile[],
+	now: Date = new Date(),
+): AutomaticSinceDecision | null {
+	const knownBytes = files.reduce((total, file) => total + knownSizeBytes(file), 0);
+	if (knownBytes <= LARGE_HISTORY_BYTES && files.length <= LARGE_HISTORY_FILES) {
+		return null;
+	}
+
+	let fallback: AutomaticSinceDecision | null = null;
+	for (const argument of AUTO_SINCE_WINDOWS) {
+		const decision = {
+			argument,
+			since: parseWhen(argument, { flag: "--since", now }),
+		} satisfies AutomaticSinceDecision;
+		fallback = decision;
+
+		let recentBytes = 0;
+		let recentFiles = 0;
+		for (const file of files) {
+			if (!historyFileMatchesSince(file, decision.since)) {
+				continue;
+			}
+			recentFiles += 1;
+			recentBytes += knownSizeBytes(file);
+			if (recentBytes > TARGET_HISTORY_BYTES || recentFiles > TARGET_HISTORY_FILES) {
+				break;
+			}
+		}
+
+		if (recentBytes <= TARGET_HISTORY_BYTES && recentFiles <= TARGET_HISTORY_FILES) {
+			return decision;
+		}
+	}
+
+	return fallback;
+}

--- a/src/lib/history/search.ts
+++ b/src/lib/history/search.ts
@@ -1,4 +1,5 @@
 import type { ResolvedTarget } from "../targets/config-types.js";
+import { chooseAutomaticSince, historyFileMatchesSince } from "./auto-since.js";
 import { BoundedTopK } from "./bounded-top-k.js";
 import { recordMatchesScope } from "./filters.js";
 import { type JsonlCounters, readJsonlLines } from "./jsonl.js";
@@ -33,6 +34,7 @@ export type SearchOptions = {
 	cwd: string;
 	signal: AbortSignal;
 	concurrency?: number;
+	automaticSince?: boolean;
 };
 
 export type SearchResult = {
@@ -40,6 +42,7 @@ export type SearchResult = {
 	stats: SearchStats;
 	errors: SearchNote[];
 	notes: SearchNote[];
+	effectiveScope: SearchScope;
 };
 
 type QueuedFile = {
@@ -149,11 +152,12 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 	};
 	const errors: SearchNote[] = [];
 	const notes: SearchNote[] = [];
+	const effectiveScope = { ...options.scope };
 	const hitCapacity =
 		options.limit > 0 ? Math.min(options.limit, MAX_BUFFERED_HITS) : MAX_BUFFERED_HITS;
 	const hits = new BoundedTopK<SearchHit>(hitCapacity, compareHits);
 
-	const queue: QueuedFile[] = [];
+	let queue: QueuedFile[] = [];
 	for (const target of options.targets) {
 		const history = target.history;
 		if (!history) {
@@ -206,6 +210,22 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 		}
 	}
 
+	if (options.automaticSince && !options.scope.since && !options.scope.until) {
+		const decision = chooseAutomaticSince(queue.map((entry) => entry.file));
+		if (decision) {
+			effectiveScope.since = decision.since;
+			notes.push({
+				targetId: "",
+				displayName: "",
+				code: "automatic_since",
+				message:
+					`Large history detected: using \`--since ${decision.argument}\`. ` +
+					"Use `--all-history` for everything.",
+			});
+			queue = queue.filter((entry) => historyFileMatchesSince(entry.file, decision.since));
+		}
+	}
+
 	// Process recent transcripts first for predictable scan behavior. The bounded heap and its
 	// comparator determine which hits survive regardless of file or worker completion order.
 	queue.sort((a, b) => (b.file.modifiedAt ?? "").localeCompare(a.file.modifiedAt ?? ""));
@@ -216,7 +236,7 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 		if (!options.roles.has(record.role)) {
 			return;
 		}
-		if (!recordMatchesScope(record, options.scope)) {
+		if (!recordMatchesScope(record, effectiveScope)) {
 			return;
 		}
 		if (!matchesText(options.query, record.text)) {
@@ -293,5 +313,5 @@ export async function searchHistory(options: SearchOptions): Promise<SearchResul
 	stats.returnedMatches = retained.length;
 	stats.elapsedMs = Date.now() - startedAt;
 
-	return { hits: retained, stats, errors, notes };
+	return { hits: retained, stats, errors, notes, effectiveScope };
 }

--- a/src/lib/history/types.ts
+++ b/src/lib/history/types.ts
@@ -38,8 +38,12 @@ export type HistoryFile = {
 	projectPath: string | null;
 	/** Session id when derivable from the path or header; else null. */
 	sessionId: string | null;
-	/** ISO 8601. Drives newest-first file ordering so `--limit` short-circuits sensibly. */
+	/**
+	 * ISO 8601. Enables safe cutoff pruning and newest-first ordering. Null or invalid values fail
+	 * open and leave the file eligible for scanning.
+	 */
 	modifiedAt: string | null;
+	/** Contributes to adaptive cutoff selection. Null or invalid values are ignored. */
 	sizeBytes: number | null;
 	/** Free-form payload carried from `listFiles` through to `normalize`. */
 	meta?: Record<string, unknown>;

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -6,6 +6,7 @@ import { runCli } from "../../src/cli/index.js";
 // The clipboard is stubbed so the suite never writes to the developer's real clipboard, and so
 // the copy paths behave identically on a CI box with no clipboard helper installed.
 const clipboard = vi.hoisted(() => ({ copied: [] as string[], shouldFail: false }));
+const automaticSince = vi.hoisted(() => ({ argument: null as "90d" | null }));
 vi.mock("../../src/lib/history/clipboard.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../src/lib/history/clipboard.js")>();
 	return {
@@ -17,6 +18,21 @@ vi.mock("../../src/lib/history/clipboard.js", async (importOriginal) => {
 			clipboard.copied.push(text);
 			return { command: "stub", args: [] };
 		}),
+	};
+});
+vi.mock("../../src/lib/history/auto-since.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/lib/history/auto-since.js")>();
+	return {
+		...actual,
+		chooseAutomaticSince(files: Parameters<typeof actual.chooseAutomaticSince>[0], now?: Date) {
+			if (automaticSince.argument === null) {
+				return actual.chooseAutomaticSince(files, now);
+			}
+			return {
+				argument: automaticSince.argument,
+				since: new Date("2026-05-11T12:00:00.000Z"),
+			};
+		},
 	};
 });
 
@@ -189,6 +205,7 @@ describe.sequential("search command", () => {
 		originalNoColor = process.env.NO_COLOR;
 		process.env.NO_COLOR = "1";
 		process.exitCode = undefined;
+		automaticSince.argument = null;
 	});
 
 	afterEach(() => {
@@ -436,6 +453,134 @@ describe.sequential("search command", () => {
 				expect(envelope().matches.map((match) => match.text)).toEqual([
 					"beta wants a merge conflict fix",
 				]);
+			});
+		});
+	});
+
+	describe("adaptive cutoff", () => {
+		it("prints the locked notice to stderr and exposes the effective JSON scope", async () => {
+			await withSearchHome(async (fixture) => {
+				automaticSince.argument = "90d";
+				useFixture(fixture);
+				await search(["merge conflict", "--json", "--limit", "0"]);
+
+				const result = envelope();
+				const message =
+					"Large history detected: using `--since 90d`. Use `--all-history` for everything.";
+				expect(() => JSON.parse(stdout())).not.toThrow();
+				expect(stderr()).toBe(message);
+				expect(stderr()).not.toContain("Note:");
+				expect(result.scope.since).toBe("2026-05-11T12:00:00.000Z");
+				expect(result.notes).toContainEqual({
+					targetId: "",
+					displayName: "",
+					code: "automatic_since",
+					message,
+				});
+			});
+		});
+
+		it("accepts --all-history and disables the automatic cutoff", async () => {
+			await withSearchHome(async (fixture) => {
+				automaticSince.argument = "90d";
+				useFixture(fixture);
+				await search(["merge conflict", "--all-history", "--json", "--limit", "0"]);
+
+				const result = envelope();
+				expect(result.matches).toHaveLength(3);
+				expect(result.scope.since).toBeNull();
+				expect(result.notes).not.toContainEqual(
+					expect.objectContaining({ code: "automatic_since" }),
+				);
+				expect(stderr()).toBe("");
+			});
+		});
+
+		it("lets an explicit --since bypass adaptation", async () => {
+			await withSearchHome(async (fixture) => {
+				automaticSince.argument = "90d";
+				useFixture(fixture);
+				await search(["merge conflict", "--since", "7d", "--json", "--limit", "0"]);
+
+				expect(envelope().notes).not.toContainEqual(
+					expect.objectContaining({ code: "automatic_since" }),
+				);
+				expect(stderr()).not.toContain("Large history detected");
+			});
+		});
+
+		it("rejects --all-history with --since", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--all-history", "--since", "7d"]);
+
+				expect(errorSpy).toHaveBeenCalledWith(
+					"Error: Use either --all-history or --since/--until, not both.",
+				);
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("rejects --all-history with --until through the JSON-aware error path", async () => {
+			await withSearchHome(async (fixture) => {
+				useFixture(fixture);
+				await search(["x", "--all-history", "--until", "7d", "--json"]);
+
+				expect(envelope().errors[0]?.code).toBe("conflicting_history_scope");
+				expect(exitSpy).toHaveBeenCalledWith(2);
+			});
+		});
+
+		it("keeps the 10,000-result cap under --all-history", async () => {
+			await withSearchHome(async (fixture) => {
+				const agentsDir = path.join(fixture.repoAlpha, "agents");
+				await mkdir(agentsDir, { recursive: true });
+				await writeFile(
+					path.join(agentsDir, "omniagent.config.mjs"),
+					`export default {
+	targets: [{
+		id: "bulk",
+		displayName: "Bulk Agent",
+		history: {
+			roles: ["user"],
+			listFiles: async function* () {
+				yield {
+					path: "/virtual/bulk.json",
+					projectPath: "/repo",
+					sessionId: "bulk",
+					modifiedAt: "2026-08-09T00:00:00.000Z",
+					sizeBytes: 1,
+				};
+			},
+			scan: {
+				kind: "custom",
+				read: async function* (file, context) {
+					for (let index = 0; index < 10005; index += 1) {
+						yield {
+							agentId: context.targetId,
+							role: "user",
+							timestamp: new Date(Date.UTC(2026, 7, 1) + index).toISOString(),
+							text: \`matching record \${index}\`,
+							sessionId: "bulk",
+							cwd: "/repo",
+							sourcePath: file.path,
+							recordIndex: index,
+						};
+					}
+				},
+			},
+		},
+	}],
+};
+`,
+				);
+				useFixture(fixture);
+				await search(["matching", "--only", "bulk", "--all-history", "--limit", "0", "--json"]);
+
+				const result = envelope();
+				expect(result.matches).toHaveLength(10_000);
+				expect(result.stats.matchedRecords).toBe(10_005);
+				expect(result.stats.truncated).toBe(true);
 			});
 		});
 	});

--- a/tests/lib/history/auto-since.test.ts
+++ b/tests/lib/history/auto-since.test.ts
@@ -1,0 +1,131 @@
+import {
+	AUTO_SINCE_WINDOWS,
+	chooseAutomaticSince,
+	LARGE_HISTORY_BYTES,
+	LARGE_HISTORY_FILES,
+	TARGET_HISTORY_BYTES,
+	TARGET_HISTORY_FILES,
+} from "../../../src/lib/history/auto-since.js";
+import { parseWhen } from "../../../src/lib/history/filters.js";
+import type { HistoryFile } from "../../../src/lib/history/types.js";
+
+const NOW = new Date("2026-08-09T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+let fileIndex = 0;
+
+function daysAgo(days: number): string {
+	return new Date(NOW.getTime() - days * DAY_MS).toISOString();
+}
+
+function file(overrides: Partial<HistoryFile> = {}): HistoryFile {
+	return {
+		path: `/history/${fileIndex++}.jsonl`,
+		projectPath: null,
+		sessionId: null,
+		modifiedAt: daysAgo(1),
+		sizeBytes: 1,
+		...overrides,
+	};
+}
+
+function oldTrigger(): HistoryFile {
+	return file({ modifiedAt: daysAgo(400), sizeBytes: LARGE_HISTORY_BYTES + 1 });
+}
+
+function corpusSelecting(argument: (typeof AUTO_SINCE_WINDOWS)[number]): HistoryFile[] {
+	const overloadAges: Record<(typeof AUTO_SINCE_WINDOWS)[number], number[]> = {
+		"365d": [],
+		"180d": [300],
+		"90d": [300, 120],
+		"30d": [300, 120, 60],
+		"7d": [300, 120, 60, 20],
+	};
+	return [
+		oldTrigger(),
+		...overloadAges[argument].map((age) =>
+			file({ modifiedAt: daysAgo(age), sizeBytes: TARGET_HISTORY_BYTES + 1 }),
+		),
+	];
+}
+
+describe("chooseAutomaticSince", () => {
+	it("keeps corpora below both large-history triggers unbounded", () => {
+		expect(
+			chooseAutomaticSince([file({ sizeBytes: LARGE_HISTORY_BYTES }), file({ sizeBytes: 0 })], NOW),
+		).toBeNull();
+	});
+
+	it("triggers when known transcript data exceeds 2 GiB", () => {
+		expect(chooseAutomaticSince([oldTrigger()], NOW)?.argument).toBe("365d");
+	});
+
+	it("triggers when the corpus contains more than 20,000 small files", () => {
+		const files = Array.from({ length: LARGE_HISTORY_FILES + 1 }, () =>
+			file({ modifiedAt: daysAgo(400), sizeBytes: 1 }),
+		);
+
+		expect(chooseAutomaticSince(files, NOW)?.argument).toBe("365d");
+	});
+
+	it.each(AUTO_SINCE_WINDOWS)("selects the least restrictive qualifying %s window", (argument) => {
+		expect(chooseAutomaticSince(corpusSelecting(argument), NOW)?.argument).toBe(argument);
+	});
+
+	it("uses 7d when even the tightest window exceeds the responsive target", () => {
+		const files = [
+			...corpusSelecting("7d"),
+			file({ modifiedAt: daysAgo(3), sizeBytes: TARGET_HISTORY_BYTES + 1 }),
+		];
+
+		expect(chooseAutomaticSince(files, NOW)?.argument).toBe("7d");
+	});
+
+	it("counts missing and invalid modification times as recent in every window", () => {
+		const uncertain = Array.from({ length: TARGET_HISTORY_FILES + 1 }, (_, index) =>
+			file({ modifiedAt: index % 2 === 0 ? null : "not-a-date", sizeBytes: 0 }),
+		);
+
+		expect(chooseAutomaticSince([oldTrigger(), ...uncertain], NOW)?.argument).toBe("7d");
+	});
+
+	it("counts unknown-size files toward the file trigger but not the byte estimate", () => {
+		const files = Array.from({ length: LARGE_HISTORY_FILES + 1 }, () =>
+			file({ modifiedAt: daysAgo(400), sizeBytes: null }),
+		);
+
+		expect(chooseAutomaticSince(files, NOW)?.argument).toBe("365d");
+	});
+
+	it("ignores negative and non-finite sizes", () => {
+		const files = [
+			file({ sizeBytes: -1 }),
+			file({ sizeBytes: Number.NaN }),
+			file({ sizeBytes: Number.POSITIVE_INFINITY }),
+		];
+
+		expect(chooseAutomaticSince(files, NOW)).toBeNull();
+	});
+
+	it("uses strict large-history triggers and inclusive responsive targets", () => {
+		const atLargeBoundaries = [
+			file({ sizeBytes: LARGE_HISTORY_BYTES }),
+			...Array.from({ length: LARGE_HISTORY_FILES - 1 }, () =>
+				file({ modifiedAt: daysAgo(400), sizeBytes: 0 }),
+			),
+		];
+		expect(chooseAutomaticSince(atLargeBoundaries, NOW)).toBeNull();
+
+		const atResponsiveBoundaries = [
+			oldTrigger(),
+			file({ sizeBytes: TARGET_HISTORY_BYTES }),
+			...Array.from({ length: TARGET_HISTORY_FILES - 1 }, () => file({ sizeBytes: 0 })),
+		];
+		expect(chooseAutomaticSince(atResponsiveBoundaries, NOW)?.argument).toBe("365d");
+	});
+
+	it("returns the same exact cutoff as parseWhen for an injected clock", () => {
+		const decision = chooseAutomaticSince(corpusSelecting("90d"), NOW);
+
+		expect(decision?.since).toEqual(parseWhen("90d", { flag: "--since", now: NOW }));
+	});
+});

--- a/tests/lib/history/auto-since.test.ts
+++ b/tests/lib/history/auto-since.test.ts
@@ -1,6 +1,7 @@
 import {
 	AUTO_SINCE_WINDOWS,
 	chooseAutomaticSince,
+	historyFileMatchesSince,
 	LARGE_HISTORY_BYTES,
 	LARGE_HISTORY_FILES,
 	TARGET_HISTORY_BYTES,
@@ -127,5 +128,29 @@ describe("chooseAutomaticSince", () => {
 		const decision = chooseAutomaticSince(corpusSelecting("90d"), NOW);
 
 		expect(decision?.since).toEqual(parseWhen("90d", { flag: "--since", now: NOW }));
+	});
+});
+
+describe("historyFileMatchesSince", () => {
+	const since = new Date("2026-01-01T00:00:00.000Z");
+
+	it.each([
+		"0",
+		"2026/08/01",
+		"2026-02-30T00:00:00.000Z",
+	])("fails open for invalid timestamp %s", (modifiedAt) => {
+		expect(historyFileMatchesSince(file({ modifiedAt }), since)).toBe(true);
+	});
+
+	it("fails open for a non-string value from a JavaScript custom target", () => {
+		const modifiedAt = Symbol("invalid") as unknown as string;
+
+		expect(historyFileMatchesSince(file({ modifiedAt }), since)).toBe(true);
+	});
+
+	it("still excludes files with a valid ISO timestamp before the cutoff", () => {
+		expect(historyFileMatchesSince(file({ modifiedAt: "2025-12-31T18:00:00-05:00" }), since)).toBe(
+			false,
+		);
 	});
 });

--- a/tests/lib/history/claude.test.ts
+++ b/tests/lib/history/claude.test.ts
@@ -198,12 +198,16 @@ describe("listClaudeFiles", () => {
 		}
 	}
 
-	async function collect(homeDir: string, s: SearchScope, roles: HistoryRole[]) {
-		const out: string[] = [];
+	async function collectFiles(homeDir: string, s: SearchScope, roles: HistoryRole[]) {
+		const out: HistoryFile[] = [];
 		for await (const found of listClaudeFiles(s, context({ homeDir, roles: new Set(roles) }))) {
-			out.push(found.path);
+			out.push(found);
 		}
 		return out;
+	}
+
+	async function collect(homeDir: string, s: SearchScope, roles: HistoryRole[]) {
+		return (await collectFiles(homeDir, s, roles)).map((found) => found.path);
 	}
 
 	// 111 of 203 files on a real install live under subagents/. A one-level walk drops them all.
@@ -213,6 +217,16 @@ describe("listClaudeFiles", () => {
 
 			expect(found.some((p) => p.includes(`${path.sep}subagents${path.sep}`))).toBe(true);
 			expect(found).toHaveLength(3);
+		});
+	});
+
+	it("returns filesystem modification time and size metadata", async () => {
+		await withHome(async (homeDir) => {
+			const found = await collectFiles(homeDir, scope(), ["user"]);
+
+			expect(found.every((candidate) => candidate.modifiedAt !== null)).toBe(true);
+			expect(found.every((candidate) => Date.parse(candidate.modifiedAt as string) > 0)).toBe(true);
+			expect(found.every((candidate) => candidate.sizeBytes === 3)).toBe(true);
 		});
 	});
 

--- a/tests/lib/history/codex.test.ts
+++ b/tests/lib/history/codex.test.ts
@@ -330,6 +330,8 @@ describe("listCodexFiles", () => {
 			expect(found).toHaveLength(4);
 			expect(alpha?.projectPath).toBe("/repo/alpha");
 			expect(alpha?.sessionId).toBe("roll-alpha");
+			expect(Date.parse(alpha?.modifiedAt as string)).toBeGreaterThan(0);
+			expect(alpha?.sizeBytes).toBeGreaterThan(0);
 		});
 	});
 

--- a/tests/lib/history/extensibility.test.ts
+++ b/tests/lib/history/extensibility.test.ts
@@ -437,6 +437,7 @@ describe.sequential("history capability extensibility", () => {
 	// the first time someone reaches for a target-specific shortcut inside the engine.
 	it("keeps every engine module free of agent-specific knowledge", async () => {
 		const engineModules = [
+			"auto-since.ts",
 			"bounded-top-k.ts",
 			"types.ts",
 			"query.ts",

--- a/tests/lib/history/search.test.ts
+++ b/tests/lib/history/search.test.ts
@@ -1,6 +1,7 @@
+import { LARGE_HISTORY_BYTES } from "../../../src/lib/history/auto-since.js";
 import { compileQuery } from "../../../src/lib/history/query.js";
 import { searchHistory } from "../../../src/lib/history/search.js";
-import type { SearchRecord } from "../../../src/lib/history/types.js";
+import type { HistoryFile, SearchRecord, SearchScope } from "../../../src/lib/history/types.js";
 import type { ResolvedTarget } from "../../../src/lib/targets/config-types.js";
 
 function record(index: number, overrides: Partial<SearchRecord> = {}): SearchRecord {
@@ -137,5 +138,233 @@ describe("bounded history search", () => {
 			"/a-history.json",
 			"/z-history.json",
 		]);
+	});
+});
+
+type FileFixture = {
+	file: HistoryFile;
+	records: SearchRecord[];
+};
+
+function historyFile(name: string, overrides: Partial<HistoryFile> = {}): HistoryFile {
+	return {
+		path: `/history/${name}.jsonl`,
+		projectPath: "/repo",
+		sessionId: name,
+		modifiedAt: "2026-08-01T00:00:00.000Z",
+		sizeBytes: 1,
+		...overrides,
+	};
+}
+
+function targetWithFiles(fixtures: FileFixture[], scanned: string[]): ResolvedTarget {
+	return {
+		id: "adaptive",
+		displayName: "Adaptive Agent",
+		aliases: [],
+		outputs: {},
+		isBuiltIn: false,
+		isCustomized: true,
+		history: {
+			roles: ["user"],
+			listFiles: async function* () {
+				for (const fixture of fixtures) {
+					yield fixture.file;
+				}
+			},
+			scan: {
+				kind: "custom",
+				read: async function* (file) {
+					scanned.push(file.path);
+					const fixture = fixtures.find((candidate) => candidate.file.path === file.path);
+					if (fixture) {
+						yield* fixture.records;
+					}
+				},
+			},
+		},
+	};
+}
+
+async function adaptiveSearch(
+	fixtures: FileFixture[],
+	options: { automaticSince?: boolean; scope?: Partial<SearchScope>; limit?: number } = {},
+) {
+	const scanned: string[] = [];
+	const scope: SearchScope = {
+		projectPath: null,
+		projectMatch: null,
+		since: null,
+		until: null,
+		...options.scope,
+	};
+	const result = await searchHistory({
+		targets: [targetWithFiles(fixtures, scanned)],
+		query: compileQuery(["matching"]),
+		scope,
+		roles: new Set(["user"]),
+		limit: options.limit ?? 0,
+		homeDir: "/home/demo",
+		cwd: "/repo",
+		signal: new AbortController().signal,
+		automaticSince: options.automaticSince,
+	});
+	return { result, scanned };
+}
+
+describe("adaptive history cutoff", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-09T12:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("derives an effective scope and prunes old files before reading them", async () => {
+		const old = historyFile("old", {
+			modifiedAt: "2024-01-01T00:00:00.000Z",
+			sizeBytes: LARGE_HISTORY_BYTES + 1,
+		});
+		const recent = historyFile("recent");
+		const { result, scanned } = await adaptiveSearch(
+			[
+				{ file: old, records: [record(0)] },
+				{ file: recent, records: [record(1, { timestamp: "2026-08-01T00:00:00.000Z" })] },
+			],
+			{ automaticSince: true },
+		);
+
+		expect(result.effectiveScope.since).toEqual(new Date("2025-08-09T12:00:00.000Z"));
+		expect(result.notes).toContainEqual({
+			targetId: "",
+			displayName: "",
+			code: "automatic_since",
+			message: "Large history detected: using `--since 365d`. Use `--all-history` for everything.",
+		});
+		expect(scanned).toEqual([recent.path]);
+	});
+
+	it("still filters old records inside recent files and scans unknown-mtime files", async () => {
+		const trigger = historyFile("trigger", {
+			modifiedAt: "2024-01-01T00:00:00.000Z",
+			sizeBytes: LARGE_HISTORY_BYTES + 1,
+		});
+		const mixed = historyFile("mixed");
+		const unknown = historyFile("unknown", { modifiedAt: null });
+		const { result, scanned } = await adaptiveSearch(
+			[
+				{ file: trigger, records: [] },
+				{ file: mixed, records: [record(0, { timestamp: "2024-06-01T00:00:00.000Z" })] },
+				{
+					file: unknown,
+					records: [record(1, { timestamp: "2026-08-02T00:00:00.000Z" })],
+				},
+			],
+			{ automaticSince: true },
+		);
+
+		expect(scanned).toEqual(expect.arrayContaining([mixed.path, unknown.path]));
+		expect(scanned).not.toContain(trigger.path);
+		expect(result.hits.map((hit) => hit.record.sourcePath)).toEqual(["/history.json"]);
+		expect(result.hits[0]?.record.recordIndex).toBe(1);
+	});
+
+	it("scans every file when automatic cutoff is disabled", async () => {
+		const old = historyFile("old", {
+			modifiedAt: "2024-01-01T00:00:00.000Z",
+			sizeBytes: LARGE_HISTORY_BYTES + 1,
+		});
+		const recent = historyFile("recent");
+		const { result, scanned } = await adaptiveSearch(
+			[
+				{ file: old, records: [record(0, { timestamp: "2024-01-01T00:00:00.000Z" })] },
+				{ file: recent, records: [record(1, { timestamp: "2026-08-01T00:00:00.000Z" })] },
+			],
+			{ automaticSince: false },
+		);
+
+		expect(scanned).toHaveLength(2);
+		expect(result.hits).toHaveLength(2);
+		expect(result.effectiveScope.since).toBeNull();
+		expect(result.notes).not.toContainEqual(expect.objectContaining({ code: "automatic_since" }));
+	});
+
+	it("preserves an explicit since without adding an automatic note", async () => {
+		const since = new Date("2026-07-01T00:00:00.000Z");
+		const { result } = await adaptiveSearch(
+			[
+				{
+					file: historyFile("large", { sizeBytes: LARGE_HISTORY_BYTES + 1 }),
+					records: [record(0, { timestamp: "2026-08-01T00:00:00.000Z" })],
+				},
+			],
+			{ automaticSince: true, scope: { since } },
+		);
+
+		expect(result.effectiveScope.since).toBe(since);
+		expect(result.notes).not.toContainEqual(expect.objectContaining({ code: "automatic_since" }));
+	});
+
+	it("preserves an explicit until without adding an automatic note", async () => {
+		const until = new Date("2026-08-10T00:00:00.000Z");
+		const { result } = await adaptiveSearch(
+			[
+				{
+					file: historyFile("large", { sizeBytes: LARGE_HISTORY_BYTES + 1 }),
+					records: [record(0, { timestamp: "2026-08-01T00:00:00.000Z" })],
+				},
+			],
+			{ automaticSince: true, scope: { until } },
+		);
+
+		expect(result.effectiveScope.until).toBe(until);
+		expect(result.notes).not.toContainEqual(expect.objectContaining({ code: "automatic_since" }));
+	});
+
+	it("leaves small histories unbounded and keeps normal ordering, limits, and stats", async () => {
+		const { result } = await adaptiveSearch(
+			[
+				{
+					file: historyFile("small"),
+					records: [
+						record(0, { timestamp: "2026-08-01T00:00:00.000Z" }),
+						record(1, { timestamp: "2026-08-02T00:00:00.000Z" }),
+					],
+				},
+			],
+			{ automaticSince: true, limit: 1 },
+		);
+
+		expect(result.effectiveScope.since).toBeNull();
+		expect(result.notes).not.toContainEqual(expect.objectContaining({ code: "automatic_since" }));
+		expect(result.hits[0]?.record.recordIndex).toBe(1);
+		expect(result.stats).toMatchObject({
+			scannedFiles: 1,
+			matchedRecords: 2,
+			returnedMatches: 1,
+			truncated: true,
+		});
+	});
+
+	it("does not report discovered history as unavailable after automatic pruning", async () => {
+		const { result } = await adaptiveSearch(
+			[
+				{
+					file: historyFile("old", {
+						modifiedAt: "2024-01-01T00:00:00.000Z",
+						sizeBytes: LARGE_HISTORY_BYTES + 1,
+					}),
+					records: [],
+				},
+			],
+			{ automaticSince: true },
+		);
+
+		expect(result.stats.scannedFiles).toBe(0);
+		expect(result.notes).not.toContainEqual(
+			expect.objectContaining({ code: "history_unavailable" }),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- Detect clearly large history corpora from file metadata already collected during discovery.
- Select the least restrictive responsive `--since` window and prune old transcripts before reading their contents.
- Add `--all-history` as an explicit exhaustive-search escape hatch, including scope conflict validation.
- Expose the effective cutoff through the exact stderr notice, structured notes, and JSON scope.
- Document custom-target metadata behavior and add decision, engine, CLI, provider, and extensibility coverage.

## Why

Unbounded searches can take a very long time on machines with years of Claude or Codex history. The search engine already discovers file modification times and sizes, so it can choose a conservative cutoff without a content pre-scan, persistent index, cache, network request, or agent invocation.

Small histories and explicit date ranges retain their existing behavior. Users who need every transcript can pass `--all-history`; the existing 10,000-result safety cap still applies.

## Validation

- `npm run format`
- `npm run fix`
- `npm test` — 926 tests passed
- `npm run build`
- `npm run typecheck`
- `git diff --check`
- Built CLI help and JSON conflict smoke tests
