### PR TITLE
Fix CLI shim passthrough collisions

### DIFF
--- a/docs/cli-shim.md
+++ b/docs/cli-shim.md
@@ -110,9 +110,15 @@ Rules:
 - `--` passthrough is only valid after `--agent`.
 - Unsupported shared flags are ignored with a warning.
 - Output is passed through unmodified, except for `--output-schema` runs (see above).
-- Passthrough args after `--` are not checked for collisions with shim-generated flags such as
-  `--output-schema` or fallback-injected flags (copilot's `--silent`); the agent CLI's own
-  duplicate-flag error surfaces instead.
+- For target-declared native options, an explicit passthrough value suppresses the corresponding
+  shim default. This is silent in normal output and visible in `--trace-translate` through
+  `shimArgs` and `passthroughArgs`.
+- Passthrough cannot override an explicit shared flag, a policy derived from one (such as
+  `--yolo` selecting its sandbox), prompt delivery, or structured-output arguments. These
+  conflicts exit with code 2 before the target starts and identify both inputs.
+- Undeclared native options and duplicates wholly within passthrough remain the target CLI's
+  responsibility. Value-sensitive declarations keep repeatable flags such as
+  `--disable <feature>` independent.
 - Some approval values are agent-specific.
 - Some output formats are one-shot only for specific CLIs.
 - Copilot exposes JSONL via `--output-format json`, so `--output json` and `--output stream-json` both map to that flag in one-shot mode.

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -242,6 +242,8 @@ cli: {
 		collisions: [
 			// Matches both `--sandbox read-only` and `--sandbox=read-only`.
 			{ option: "--sandbox", sources: ["sandbox"] },
+			// Short value options can opt into matching attached forms such as `-sread-only`.
+			{ option: "-s", allowAttachedValue: true, sources: ["sandbox"] },
 			// Match a single value of a repeatable option without affecting other values.
 			{ option: "--disable", value: "web", sources: ["web"] },
 			{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
@@ -254,11 +256,17 @@ cli: {
 `structuredOutput`. Rules without `modes` apply to both interactive and one-shot invocations.
 Declare aliases as separate rules. When `value` is present, both `--flag value` and
 `--flag=value` match only that exact value; this is appropriate for repeatable keyed options.
+Set `allowAttachedValue: true` only for a single-character short option that accepts attached
+values, such as `-sread-only`. A target-native `--` ends collision scanning, so later positional
+arguments are never mistaken for options.
 
 Collision metadata is optional. Undeclared native options pass through unchanged, and duplicate
 options supplied entirely after `--` remain the target CLI's responsibility. Targets with a
 custom `cli.translate` function cannot declare these rules because the translator owns argument
-provenance and collision behavior itself.
+provenance and collision behavior itself. Custom translators receive resolved shared values in
+`invocation.requests` and can distinguish defaults from explicit requests through
+`approvalExplicit`, `sandboxExplicit`, `outputExplicit`, `modelExplicit`, and `webExplicit` on
+`invocation.session`.
 
 ## Structured output (`cli.flags.structuredOutput`)
 

--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -224,6 +224,42 @@ history: {
   filter to each surviving record, so pruning too little is slow but never wrong; pruning too much
   silently loses results.
 
+## Passthrough collisions (`cli.passthrough.collisions`)
+
+The default CLI translator can identify target-native options that overlap with shim-generated
+arguments. A matching passthrough option suppresses an implicit shim default. If the associated
+source was explicitly requested or is required for the invocation, omniagent exits with code 2
+instead of sending duplicate or contradictory options to the target.
+
+```ts
+cli: {
+	modes: {
+		interactive: { command: "acme" },
+		oneShot: { command: "acme", args: ["run"] },
+	},
+	passthrough: {
+		position: "before-prompt",
+		collisions: [
+			// Matches both `--sandbox read-only` and `--sandbox=read-only`.
+			{ option: "--sandbox", sources: ["sandbox"] },
+			// Match a single value of a repeatable option without affecting other values.
+			{ option: "--disable", value: "web", sources: ["web"] },
+			{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+		],
+	},
+}
+```
+
+`sources` accepts `mode`, `prompt`, `approval`, `sandbox`, `output`, `model`, `web`, and
+`structuredOutput`. Rules without `modes` apply to both interactive and one-shot invocations.
+Declare aliases as separate rules. When `value` is present, both `--flag value` and
+`--flag=value` match only that exact value; this is appropriate for repeatable keyed options.
+
+Collision metadata is optional. Undeclared native options pass through unchanged, and duplicate
+options supplied entirely after `--` remain the target CLI's responsibility. Targets with a
+custom `cli.translate` function cannot declare these rules because the translator owns argument
+provenance and collision behavior itself.
+
 ## Structured output (`cli.flags.structuredOutput`)
 
 Custom targets whose CLI supports schema-constrained responses can declare a

--- a/src/cli/shim/translate.ts
+++ b/src/cli/shim/translate.ts
@@ -1,13 +1,22 @@
 import type {
 	FlagMap,
 	InvocationMode,
+	PassthroughCollisionRule,
+	PassthroughCollisionSource,
 	TargetCliDefinition,
 	TranslationResult,
 } from "../../lib/targets/config-types.js";
+import { InvalidUsageError } from "./errors.js";
 import type { ResolvedInvocation } from "./types.js";
 
 type TranslateOptions = {
 	includePassthrough?: boolean;
+};
+
+type CollisionSourceState = {
+	active: boolean;
+	explicit: boolean;
+	label: string;
 };
 
 function formatWarning(agentId: string, flag: string, value?: string): string {
@@ -38,6 +47,60 @@ function modeAllowed(modes: InvocationMode[] | undefined, mode: InvocationMode):
 		return true;
 	}
 	return modes.includes(mode);
+}
+
+function matchesPassthroughRule(args: string[], rule: PassthroughCollisionRule): boolean {
+	const equalsPrefix = `${rule.option}=`;
+	for (const [index, arg] of args.entries()) {
+		if (arg.startsWith(equalsPrefix)) {
+			if (rule.value === undefined || arg.slice(equalsPrefix.length) === rule.value) {
+				return true;
+			}
+			continue;
+		}
+		if (arg !== rule.option) {
+			continue;
+		}
+		if (rule.value === undefined || args[index + 1] === rule.value) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function formatCollisionOption(rule: PassthroughCollisionRule): string {
+	return rule.value === undefined ? rule.option : `${rule.option} ${rule.value}`;
+}
+
+function resolvePassthroughSuppression(
+	invocation: ResolvedInvocation,
+	cli: TargetCliDefinition,
+	sources: Record<PassthroughCollisionSource, CollisionSourceState>,
+): Set<PassthroughCollisionSource> {
+	const suppressed = new Set<PassthroughCollisionSource>();
+	for (const rule of cli.passthrough?.collisions ?? []) {
+		if (rule.modes && !rule.modes.includes(invocation.mode)) {
+			continue;
+		}
+		if (!matchesPassthroughRule(invocation.passthrough.args, rule)) {
+			continue;
+		}
+
+		const activeSources = rule.sources.filter((source) => sources[source].active);
+		if (activeSources.length === 0) {
+			continue;
+		}
+		const explicitSource = activeSources.find((source) => sources[source].explicit);
+		if (explicitSource) {
+			throw new InvalidUsageError(
+				`Passthrough option ${formatCollisionOption(rule)} conflicts with ${sources[explicitSource].label}. Remove one of the conflicting options.`,
+			);
+		}
+		for (const source of activeSources) {
+			suppressed.add(source);
+		}
+	}
+	return suppressed;
 }
 
 function buildPromptArgs(
@@ -77,63 +140,114 @@ export function translateInvocation(
 	const { requests } = invocation;
 	const { approvalExplicit, modelExplicit, outputExplicit, sandboxExplicit, webExplicit } =
 		invocation.session;
-	const sandboxWarnExplicit = sandboxExplicit || (approvalExplicit && requests.approval === "yolo");
+	const sandboxDerivedExplicit = approvalExplicit && requests.approval === "yolo";
+	const sandboxWarnExplicit = sandboxExplicit || sandboxDerivedExplicit;
 	const flags = cli.flags;
 
 	const mappedApproval = resolveFlagMapValue(flags?.approval, mode, requests.approval);
+	const mappedSandbox = resolveFlagMapValue(flags?.sandbox, mode, requests.sandbox);
+	const mappedOutput = resolveFlagMapValue(flags?.output, mode, requests.output);
+	const modelSupported = Boolean(
+		requests.model && flags?.model && modeAllowed(flags.model.modes, mode),
+	);
+	const modeAllowedForWeb = modeAllowed(flags?.web?.modes, mode);
+	const mappedWeb =
+		flags?.web && modeAllowedForWeb ? (requests.web ? flags.web.on : flags.web.off) : undefined;
+	const { promptArgs, position } = buildPromptArgs(invocation, cli, warnings);
+	const suppressed = resolvePassthroughSuppression(invocation, cli, {
+		mode: {
+			active: (base.args?.length ?? 0) > 0,
+			explicit: true,
+			label: "required target mode arguments",
+		},
+		prompt: {
+			active: promptArgs.length > 0,
+			explicit: true,
+			label: "required one-shot prompt delivery",
+		},
+		approval: {
+			active: mappedApproval !== undefined && mappedApproval !== null,
+			explicit: approvalExplicit,
+			label: "explicit shared --approval policy",
+		},
+		sandbox: {
+			active: mappedSandbox !== undefined && mappedSandbox !== null,
+			explicit: sandboxExplicit || sandboxDerivedExplicit,
+			label: sandboxDerivedExplicit
+				? "the sandbox policy derived from explicit --yolo"
+				: "explicit shared --sandbox policy",
+		},
+		output: {
+			active: mappedOutput !== undefined && mappedOutput !== null,
+			explicit: outputExplicit,
+			label: "explicit shared --output format",
+		},
+		model: {
+			active: modelSupported,
+			explicit: modelExplicit,
+			label: "explicit shared --model selection",
+		},
+		web: {
+			active: mappedWeb !== undefined && mappedWeb !== null,
+			explicit: webExplicit,
+			label: "explicit shared --web setting",
+		},
+		structuredOutput: {
+			active: (invocation.structuredOutput?.args.length ?? 0) > 0,
+			explicit: true,
+			label: "required shared --output-schema arguments",
+		},
+	});
+
 	if (mappedApproval === undefined || mappedApproval === null) {
 		if (approvalExplicit) {
 			warnings.push(formatWarning(invocation.agent.id, "--approval", requests.approval));
 		}
-	} else {
+	} else if (!suppressed.has("approval")) {
 		args.push(...mappedApproval);
 	}
 
-	const mappedSandbox = resolveFlagMapValue(flags?.sandbox, mode, requests.sandbox);
 	if (mappedSandbox === undefined || mappedSandbox === null) {
 		if (sandboxWarnExplicit) {
 			warnings.push(formatWarning(invocation.agent.id, "--sandbox", requests.sandbox));
 		}
-	} else {
+	} else if (!suppressed.has("sandbox")) {
 		args.push(...mappedSandbox);
 	}
 
-	const mappedOutput = resolveFlagMapValue(flags?.output, mode, requests.output);
 	if (mappedOutput === undefined || mappedOutput === null) {
 		if (outputExplicit) {
 			warnings.push(formatWarning(invocation.agent.id, "--output", requests.output));
 		}
-	} else {
+	} else if (!suppressed.has("output")) {
 		args.push(...mappedOutput);
 	}
 
 	if (requests.model) {
-		if (!flags?.model || !modeAllowed(flags.model.modes, mode)) {
+		if (!modelSupported || !flags?.model) {
 			if (modelExplicit) {
 				warnings.push(formatWarning(invocation.agent.id, "--model", requests.model));
 			}
-		} else {
+		} else if (!suppressed.has("model")) {
 			args.push(...flags.model.flag, requests.model);
 		}
 	}
 
-	const modeAllowedForWeb = modeAllowed(flags?.web?.modes, mode);
 	if (!flags?.web || !modeAllowedForWeb) {
 		if (webExplicit) {
 			warnings.push(formatWarning(invocation.agent.id, "--web", requests.web ? "on" : "off"));
 		}
 	} else {
-		const mapped = requests.web ? flags.web.on : flags.web.off;
-		if (mapped === undefined || mapped === null) {
+		if (mappedWeb === undefined || mappedWeb === null) {
 			if (webExplicit) {
 				warnings.push(formatWarning(invocation.agent.id, "--web", requests.web ? "on" : "off"));
 			}
-		} else {
-			args.push(...mapped);
+		} else if (!suppressed.has("web")) {
+			args.push(...mappedWeb);
 		}
 	}
 
-	if (invocation.structuredOutput) {
+	if (invocation.structuredOutput && !suppressed.has("structuredOutput")) {
 		args.push(...invocation.structuredOutput.args);
 	}
 
@@ -145,7 +259,6 @@ export function translateInvocation(
 		}
 	}
 
-	const { promptArgs, position } = buildPromptArgs(invocation, cli, warnings);
 	const passthroughArgs = includePassthrough ? invocation.passthrough.args : [];
 
 	if (promptArgs.length === 0) {

--- a/src/cli/shim/translate.ts
+++ b/src/cli/shim/translate.ts
@@ -52,8 +52,17 @@ function modeAllowed(modes: InvocationMode[] | undefined, mode: InvocationMode):
 function matchesPassthroughRule(args: string[], rule: PassthroughCollisionRule): boolean {
 	const equalsPrefix = `${rule.option}=`;
 	for (const [index, arg] of args.entries()) {
+		if (arg === "--") {
+			break;
+		}
 		if (arg.startsWith(equalsPrefix)) {
 			if (rule.value === undefined || arg.slice(equalsPrefix.length) === rule.value) {
+				return true;
+			}
+			continue;
+		}
+		if (rule.allowAttachedValue && arg.startsWith(rule.option) && arg.length > rule.option.length) {
+			if (rule.value === undefined || arg.slice(rule.option.length) === rule.value) {
 				return true;
 			}
 			continue;

--- a/src/cli/shim/translate.ts
+++ b/src/cli/shim/translate.ts
@@ -149,7 +149,8 @@ export function translateInvocation(
 	const { requests } = invocation;
 	const { approvalExplicit, modelExplicit, outputExplicit, sandboxExplicit, webExplicit } =
 		invocation.session;
-	const sandboxDerivedExplicit = approvalExplicit && requests.approval === "yolo";
+	const sandboxDerivedExplicit =
+		approvalExplicit && requests.approval === "yolo" && !sandboxExplicit;
 	const sandboxWarnExplicit = sandboxExplicit || sandboxDerivedExplicit;
 	const flags = cli.flags;
 

--- a/src/lib/targets/builtins/antigravity-cli/target.ts
+++ b/src/lib/targets/builtins/antigravity-cli/target.ts
@@ -14,7 +14,12 @@ export const agyTarget: TargetDefinition = {
 		prompt: { type: "flag", flag: ["-p"] },
 		passthrough: {
 			collisions: [
-				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{
+					option: "-p",
+					allowAttachedValue: true,
+					sources: ["prompt"],
+					modes: ["one-shot"],
+				},
 				{
 					option: "--dangerously-skip-permissions",
 					sources: ["approval", "sandbox"],

--- a/src/lib/targets/builtins/antigravity-cli/target.ts
+++ b/src/lib/targets/builtins/antigravity-cli/target.ts
@@ -12,6 +12,17 @@ export const agyTarget: TargetDefinition = {
 		// agy requires the prompt as -p's argument; the shim always passes the
 		// (possibly stdin-derived) prompt inline, so piped stdin works.
 		prompt: { type: "flag", flag: ["-p"] },
+		passthrough: {
+			collisions: [
+				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{
+					option: "--dangerously-skip-permissions",
+					sources: ["approval", "sandbox"],
+				},
+				{ option: "--sandbox", sources: ["sandbox"] },
+				{ option: "--model", sources: ["model"] },
+			],
+		},
 		flags: {
 			approval: {
 				values: {

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -17,7 +17,12 @@ export const claudeTarget: TargetDefinition = {
 		prompt: { type: "flag", flag: ["-p"] },
 		passthrough: {
 			collisions: [
-				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{
+					option: "-p",
+					allowAttachedValue: true,
+					sources: ["prompt"],
+					modes: ["one-shot"],
+				},
 				{ option: "--print", sources: ["prompt"], modes: ["one-shot"] },
 				{ option: "--dangerously-skip-permissions", sources: ["approval"] },
 				{ option: "--model", sources: ["model"] },

--- a/src/lib/targets/builtins/claude-code/target.ts
+++ b/src/lib/targets/builtins/claude-code/target.ts
@@ -15,6 +15,20 @@ export const claudeTarget: TargetDefinition = {
 			oneShot: { command: "claude" },
 		},
 		prompt: { type: "flag", flag: ["-p"] },
+		passthrough: {
+			collisions: [
+				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{ option: "--print", sources: ["prompt"], modes: ["one-shot"] },
+				{ option: "--dangerously-skip-permissions", sources: ["approval"] },
+				{ option: "--model", sources: ["model"] },
+				{ option: "--output-format", sources: ["output", "structuredOutput"] },
+				{
+					option: "--json-schema",
+					sources: ["structuredOutput"],
+					modes: ["one-shot"],
+				},
+			],
+		},
 		flags: {
 			approval: {
 				values: {

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -19,14 +19,14 @@ export const codexTarget: TargetDefinition = {
 			position: "before-prompt",
 			collisions: [
 				{ option: "--ask-for-approval", sources: ["approval"] },
-				{ option: "-a", sources: ["approval"] },
+				{ option: "-a", allowAttachedValue: true, sources: ["approval"] },
 				{ option: "--full-auto", sources: ["approval"] },
 				{ option: "--yolo", sources: ["approval", "sandbox"] },
 				{ option: "--sandbox", sources: ["sandbox"] },
-				{ option: "-s", sources: ["sandbox"] },
+				{ option: "-s", allowAttachedValue: true, sources: ["sandbox"] },
 				{ option: "--json", sources: ["output"], modes: ["one-shot"] },
 				{ option: "--model", sources: ["model"] },
-				{ option: "-m", sources: ["model"] },
+				{ option: "-m", allowAttachedValue: true, sources: ["model"] },
 				{ option: "--search", sources: ["web"] },
 				{ option: "--disable", value: "web_search_request", sources: ["web"] },
 				{
@@ -39,7 +39,12 @@ export const codexTarget: TargetDefinition = {
 					sources: ["structuredOutput"],
 					modes: ["one-shot"],
 				},
-				{ option: "-o", sources: ["structuredOutput"], modes: ["one-shot"] },
+				{
+					option: "-o",
+					allowAttachedValue: true,
+					sources: ["structuredOutput"],
+					modes: ["one-shot"],
+				},
 			],
 		},
 		flags: {

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -20,11 +20,16 @@ export const codexTarget: TargetDefinition = {
 			collisions: [
 				{ option: "--ask-for-approval", sources: ["approval"] },
 				{ option: "-a", allowAttachedValue: true, sources: ["approval"] },
-				{ option: "--full-auto", sources: ["approval"] },
+				{ option: "--full-auto", sources: ["approval", "sandbox"] },
 				{ option: "--yolo", sources: ["approval", "sandbox"] },
+				{
+					option: "--dangerously-bypass-approvals-and-sandbox",
+					sources: ["approval", "sandbox"],
+				},
 				{ option: "--sandbox", sources: ["sandbox"] },
 				{ option: "-s", allowAttachedValue: true, sources: ["sandbox"] },
 				{ option: "--json", sources: ["output"], modes: ["one-shot"] },
+				{ option: "--experimental-json", sources: ["output"], modes: ["one-shot"] },
 				{ option: "--model", sources: ["model"] },
 				{ option: "-m", allowAttachedValue: true, sources: ["model"] },
 				{ option: "--search", sources: ["web"] },

--- a/src/lib/targets/builtins/codex/target.ts
+++ b/src/lib/targets/builtins/codex/target.ts
@@ -15,7 +15,33 @@ export const codexTarget: TargetDefinition = {
 			oneShot: { command: "codex", args: ["exec"] },
 		},
 		prompt: { type: "positional", position: "last" },
-		passthrough: { position: "before-prompt" },
+		passthrough: {
+			position: "before-prompt",
+			collisions: [
+				{ option: "--ask-for-approval", sources: ["approval"] },
+				{ option: "-a", sources: ["approval"] },
+				{ option: "--full-auto", sources: ["approval"] },
+				{ option: "--yolo", sources: ["approval", "sandbox"] },
+				{ option: "--sandbox", sources: ["sandbox"] },
+				{ option: "-s", sources: ["sandbox"] },
+				{ option: "--json", sources: ["output"], modes: ["one-shot"] },
+				{ option: "--model", sources: ["model"] },
+				{ option: "-m", sources: ["model"] },
+				{ option: "--search", sources: ["web"] },
+				{ option: "--disable", value: "web_search_request", sources: ["web"] },
+				{
+					option: "--output-schema",
+					sources: ["structuredOutput"],
+					modes: ["one-shot"],
+				},
+				{
+					option: "--output-last-message",
+					sources: ["structuredOutput"],
+					modes: ["one-shot"],
+				},
+				{ option: "-o", sources: ["structuredOutput"], modes: ["one-shot"] },
+			],
+		},
 		flags: {
 			approval: {
 				byMode: {

--- a/src/lib/targets/builtins/copilot-cli/target.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.ts
@@ -29,6 +29,15 @@ export const copilotTarget: TargetDefinition = {
 			oneShot: { command: "copilot" },
 		},
 		prompt: { type: "flag", flag: ["-p"] },
+		passthrough: {
+			collisions: [
+				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{ option: "--allow-all-tools", sources: ["approval"] },
+				{ option: "--output-format", sources: ["output"] },
+				{ option: "--model", sources: ["model"] },
+				{ option: "--silent", sources: ["structuredOutput"], modes: ["one-shot"] },
+			],
+		},
 		flags: {
 			approval: {
 				values: {

--- a/src/lib/targets/builtins/copilot-cli/target.ts
+++ b/src/lib/targets/builtins/copilot-cli/target.ts
@@ -31,7 +31,12 @@ export const copilotTarget: TargetDefinition = {
 		prompt: { type: "flag", flag: ["-p"] },
 		passthrough: {
 			collisions: [
-				{ option: "-p", sources: ["prompt"], modes: ["one-shot"] },
+				{
+					option: "-p",
+					allowAttachedValue: true,
+					sources: ["prompt"],
+					modes: ["one-shot"],
+				},
 				{ option: "--allow-all-tools", sources: ["approval"] },
 				{ option: "--output-format", sources: ["output"] },
 				{ option: "--model", sources: ["model"] },

--- a/src/lib/targets/config-types.ts
+++ b/src/lib/targets/config-types.ts
@@ -16,6 +16,25 @@ export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
 export type InvocationMode = "interactive" | "one-shot";
 
+export const PASSTHROUGH_COLLISION_SOURCES = [
+	"mode",
+	"prompt",
+	"approval",
+	"sandbox",
+	"output",
+	"model",
+	"web",
+	"structuredOutput",
+] as const;
+export type PassthroughCollisionSource = (typeof PASSTHROUGH_COLLISION_SOURCES)[number];
+
+export type PassthroughCollisionRule = {
+	option: string;
+	value?: string;
+	sources: PassthroughCollisionSource[];
+	modes?: InvocationMode[];
+};
+
 export type CommandLocation = "project" | "user";
 export type OutputType = "skills" | "commands" | "subagents" | "instructions";
 
@@ -197,7 +216,10 @@ export type TargetCliDefinition = {
 		structuredOutput?: StructuredOutputSpec;
 		structuredOutputFallback?: StructuredOutputFallbackSpec;
 	};
-	passthrough?: { position?: "after" | "before-prompt" };
+	passthrough?: {
+		position?: "after" | "before-prompt";
+		collisions?: PassthroughCollisionRule[];
+	};
 	translate?: (invocation: TranslationInvocation) => TranslationResult;
 };
 

--- a/src/lib/targets/config-types.ts
+++ b/src/lib/targets/config-types.ts
@@ -31,6 +31,7 @@ export type PassthroughCollisionSource = (typeof PASSTHROUGH_COLLISION_SOURCES)[
 export type PassthroughCollisionRule = {
 	option: string;
 	value?: string;
+	allowAttachedValue?: boolean;
 	sources: PassthroughCollisionSource[];
 	modes?: InvocationMode[];
 };
@@ -238,14 +239,18 @@ export type TranslationInvocation = {
 		outputFormat: OutputFormat;
 		model: string | null;
 		webEnabled: boolean;
+		approvalExplicit: boolean;
 		sandboxExplicit: boolean;
+		outputExplicit: boolean;
+		modelExplicit: boolean;
+		webExplicit: boolean;
 	};
 	requests: {
-		approval?: ApprovalPolicy;
-		sandbox?: SandboxMode;
-		output?: OutputFormat;
+		approval: ApprovalPolicy;
+		sandbox: SandboxMode;
+		output: OutputFormat;
 		model?: string;
-		web?: boolean;
+		web: boolean;
 	};
 	passthrough: {
 		hasDelimiter: boolean;

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -12,7 +12,12 @@ import type {
 	TargetOutputs,
 	TargetUsageDefinition,
 } from "./config-types.js";
-import { APPROVAL_POLICIES, OUTPUT_FORMATS, SANDBOX_MODES } from "./config-types.js";
+import {
+	APPROVAL_POLICIES,
+	OUTPUT_FORMATS,
+	PASSTHROUGH_COLLISION_SOURCES,
+	SANDBOX_MODES,
+} from "./config-types.js";
 import { type PlaceholderKey, validatePlaceholders } from "./placeholders.js";
 
 export type ConfigValidationResult = {
@@ -211,6 +216,55 @@ function validatePromptSpec(value: unknown, label: string, errors: string[]): vo
 	errors.push(`${label}.type must be "flag" or "positional".`);
 }
 
+function validatePassthroughCollisions(value: unknown, label: string, errors: string[]): void {
+	if (!Array.isArray(value)) {
+		errors.push(`${label} must be an array.`);
+		return;
+	}
+	for (const [index, entry] of value.entries()) {
+		const entryLabel = `${label}[${index}]`;
+		if (!isPlainObject(entry)) {
+			errors.push(`${entryLabel} must be an object.`);
+			continue;
+		}
+		const option = normalizeString(entry.option);
+		if (!option || !option.startsWith("-")) {
+			errors.push(`${entryLabel}.option must be a non-empty option beginning with "-".`);
+		}
+		if (entry.value !== undefined && normalizeString(entry.value) === null) {
+			errors.push(`${entryLabel}.value must be a non-empty string when provided.`);
+		}
+
+		validateStringArray(entry.sources, `${entryLabel}.sources`, errors);
+		if (Array.isArray(entry.sources)) {
+			for (const source of entry.sources) {
+				if (
+					typeof source === "string" &&
+					!PASSTHROUGH_COLLISION_SOURCES.includes(
+						source as (typeof PASSTHROUGH_COLLISION_SOURCES)[number],
+					)
+				) {
+					errors.push(`${entryLabel}.sources has unsupported source "${source}".`);
+				}
+			}
+		}
+
+		if (entry.modes !== undefined) {
+			validateStringArray(entry.modes, `${entryLabel}.modes`, errors);
+			if (Array.isArray(entry.modes)) {
+				for (const mode of entry.modes) {
+					if (
+						typeof mode === "string" &&
+						!INVOCATION_MODES.includes(mode as (typeof INVOCATION_MODES)[number])
+					) {
+						errors.push(`${entryLabel}.modes has unsupported mode "${mode}".`);
+					}
+				}
+			}
+		}
+	}
+}
+
 function validateCliDefinition(
 	cli: TargetCliDefinition | undefined,
 	label: string,
@@ -304,12 +358,26 @@ function validateCliDefinition(
 	if (cli.passthrough !== undefined) {
 		if (!isPlainObject(cli.passthrough)) {
 			errors.push(`${label}.passthrough must be an object.`);
-		} else if (
-			cli.passthrough.position !== undefined &&
-			cli.passthrough.position !== "after" &&
-			cli.passthrough.position !== "before-prompt"
-		) {
-			errors.push(`${label}.passthrough.position must be "after" or "before-prompt".`);
+		} else {
+			if (
+				cli.passthrough.position !== undefined &&
+				cli.passthrough.position !== "after" &&
+				cli.passthrough.position !== "before-prompt"
+			) {
+				errors.push(`${label}.passthrough.position must be "after" or "before-prompt".`);
+			}
+			if (cli.passthrough.collisions !== undefined) {
+				validatePassthroughCollisions(
+					cli.passthrough.collisions,
+					`${label}.passthrough.collisions`,
+					errors,
+				);
+				if (cli.translate !== undefined) {
+					errors.push(
+						`${label}.passthrough.collisions cannot be combined with ${label}.translate.`,
+					);
+				}
+			}
 		}
 	}
 	if (cli.translate !== undefined && typeof cli.translate !== "function") {

--- a/src/lib/targets/config-validate.ts
+++ b/src/lib/targets/config-validate.ts
@@ -234,6 +234,17 @@ function validatePassthroughCollisions(value: unknown, label: string, errors: st
 		if (entry.value !== undefined && normalizeString(entry.value) === null) {
 			errors.push(`${entryLabel}.value must be a non-empty string when provided.`);
 		}
+		if (entry.allowAttachedValue !== undefined && typeof entry.allowAttachedValue !== "boolean") {
+			errors.push(`${entryLabel}.allowAttachedValue must be a boolean when provided.`);
+		}
+		if (
+			entry.allowAttachedValue === true &&
+			(!option || !option.startsWith("-") || option.startsWith("--") || option.length !== 2)
+		) {
+			errors.push(
+				`${entryLabel}.allowAttachedValue can only be enabled for a single-character short option.`,
+			);
+		}
 
 		validateStringArray(entry.sources, `${entryLabel}.sources`, errors);
 		if (Array.isArray(entry.sources)) {

--- a/tests/commands/cli-shim-flags.test.ts
+++ b/tests/commands/cli-shim-flags.test.ts
@@ -9,6 +9,7 @@ import {
 	resolveInvocationFromFlags,
 	runShim,
 } from "../../src/cli/shim/index.js";
+import type { TargetCliDefinition } from "../../src/lib/targets/config-types.js";
 
 type InvocationOptions = {
 	stdinIsTTY?: boolean;
@@ -294,6 +295,56 @@ describe("CLI shim flag parsing", () => {
 			"workspace-write",
 			"--search",
 		]);
+	});
+
+	it("keeps suppressed defaults out of shimArgs while preserving passthroughArgs", async () => {
+		const invocation = await buildInvocation(["--agent", "codex", "--", "--sandbox=read-only"]);
+		const result = buildAgentArgs(invocation);
+
+		expect(result.shimArgs).toEqual([
+			"--ask-for-approval",
+			"on-request",
+			"--disable",
+			"web_search_request",
+		]);
+		expect(result.passthroughArgs).toEqual(["--sandbox=read-only"]);
+		expect(result.args).toEqual([...result.shimArgs, "--sandbox=read-only"]);
+	});
+
+	it("applies declared collision rules to custom targets using the default translator", async () => {
+		const invocation = await buildInvocation([
+			"--agent",
+			"codex",
+			"--",
+			"--native-sandbox",
+			"read-only",
+		]);
+		const customCli: TargetCliDefinition = {
+			modes: {
+				interactive: { command: "custom" },
+				oneShot: { command: "custom", args: ["run"] },
+			},
+			flags: {
+				sandbox: {
+					values: {
+						"workspace-write": ["--native-sandbox", "workspace"],
+						off: ["--native-sandbox", "none"],
+					},
+				},
+			},
+			passthrough: {
+				collisions: [{ option: "--native-sandbox", sources: ["sandbox"] }],
+			},
+		};
+		const result = buildAgentArgs({
+			...invocation,
+			agent: { ...invocation.agent, id: "custom" },
+			target: { ...invocation.target, id: "custom", cli: customCli },
+		});
+
+		expect(result.shimArgs).toEqual([]);
+		expect(result.passthroughArgs).toEqual(["--native-sandbox", "read-only"]);
+		expect(result.args).toEqual(["--native-sandbox", "read-only"]);
 	});
 
 	it("resolves mode/output for common flag combinations", async () => {

--- a/tests/commands/cli-shim-passthrough.test.ts
+++ b/tests/commands/cli-shim-passthrough.test.ts
@@ -147,6 +147,16 @@ describe("CLI shim passthrough", () => {
 				"-sread-only",
 			],
 		},
+		{
+			name: "interactive full-auto preset",
+			argv: ["--agent", "codex", "--", "--full-auto"],
+			expected: ["--disable", "web_search_request", "--full-auto"],
+		},
+		{
+			name: "interactive canonical yolo alias",
+			argv: ["--agent", "codex", "--", "--dangerously-bypass-approvals-and-sandbox"],
+			expected: ["--disable", "web_search_request", "--dangerously-bypass-approvals-and-sandbox"],
+		},
 	])("lets passthrough replace a shim default in $name mode", async ({ argv, expected }) => {
 		const spawn = createSpawnStub(0);
 		const exitCode = await runShim(argv, { stdinIsTTY: true, spawn });
@@ -160,14 +170,59 @@ describe("CLI shim passthrough", () => {
 		{
 			name: "explicit shared sandbox",
 			argv: ["--agent", "codex", "--sandbox", "workspace-write", "--", "--sandbox", "read-only"],
+			expectedOption: "--sandbox",
 			expectedOrigin: "explicit shared --sandbox policy",
 		},
 		{
 			name: "sandbox derived from yolo",
 			argv: ["--agent", "codex", "--yolo", "--", "--sandbox=read-only"],
+			expectedOption: "--sandbox",
 			expectedOrigin: "sandbox policy derived from explicit --yolo",
 		},
-	])("rejects a passthrough collision with $name", async ({ argv, expectedOrigin }) => {
+		{
+			name: "explicit sandbox plus canonical yolo alias",
+			argv: [
+				"--agent",
+				"codex",
+				"--sandbox",
+				"workspace-write",
+				"--",
+				"--dangerously-bypass-approvals-and-sandbox",
+			],
+			expectedOption: "--dangerously-bypass-approvals-and-sandbox",
+			expectedOrigin: "explicit shared --sandbox policy",
+		},
+		{
+			name: "explicit output plus experimental JSON alias",
+			argv: ["--agent", "codex", "--output", "text", "-p", "Hello", "--", "--experimental-json"],
+			expectedOption: "--experimental-json",
+			expectedOrigin: "explicit shared --output format",
+		},
+		{
+			name: "explicit sandbox plus full-auto preset",
+			argv: ["--agent", "codex", "--sandbox", "off", "--", "--full-auto"],
+			expectedOption: "--full-auto",
+			expectedOrigin: "explicit shared --sandbox policy",
+		},
+		{
+			name: "explicit sandbox taking precedence over yolo derivation",
+			argv: [
+				"--agent",
+				"codex",
+				"--yolo",
+				"--sandbox",
+				"workspace-write",
+				"--",
+				"--sandbox=read-only",
+			],
+			expectedOption: "--sandbox",
+			expectedOrigin: "explicit shared --sandbox policy",
+		},
+	])("rejects a passthrough collision with $name", async ({
+		argv,
+		expectedOption,
+		expectedOrigin,
+	}) => {
 		const spawn = createSpawnStub(0);
 		const stderrWrites: string[] = [];
 		const stderr = {
@@ -182,7 +237,7 @@ describe("CLI shim passthrough", () => {
 		expect(exitCode).toBe(2);
 		expect(spawn).not.toHaveBeenCalled();
 		const output = stderrWrites.join("");
-		expect(output).toContain("Passthrough option --sandbox");
+		expect(output).toContain(`Passthrough option ${expectedOption}`);
 		expect(output).toContain(expectedOrigin);
 		expect(output).toContain("Remove one of the conflicting options.");
 	});

--- a/tests/commands/cli-shim-passthrough.test.ts
+++ b/tests/commands/cli-shim-passthrough.test.ts
@@ -115,4 +115,165 @@ describe("CLI shim passthrough", () => {
 			"Hello",
 		]);
 	});
+
+	it.each([
+		{
+			name: "interactive --flag value",
+			argv: ["--agent", "codex", "-m", "gpt-5.3-codex-spark", "--", "--sandbox", "read-only"],
+			expected: [
+				"--ask-for-approval",
+				"on-request",
+				"-m",
+				"gpt-5.3-codex-spark",
+				"--disable",
+				"web_search_request",
+				"--sandbox",
+				"read-only",
+			],
+		},
+		{
+			name: "one-shot --flag=value",
+			argv: ["--agent", "codex", "-p", "Hello", "--", "--sandbox=read-only"],
+			expected: ["exec", "--disable", "web_search_request", "--sandbox=read-only", "Hello"],
+		},
+	])("lets passthrough replace a shim default in $name mode", async ({ argv, expected }) => {
+		const spawn = createSpawnStub(0);
+		const exitCode = await runShim(argv, { stdinIsTTY: true, spawn });
+
+		expect(exitCode).toBe(0);
+		const [, args] = spawn.mock.calls[0] as SpawnCall;
+		expect(args).toEqual(expected);
+	});
+
+	it.each([
+		{
+			name: "explicit shared sandbox",
+			argv: ["--agent", "codex", "--sandbox", "workspace-write", "--", "--sandbox", "read-only"],
+			expectedOrigin: "explicit shared --sandbox policy",
+		},
+		{
+			name: "sandbox derived from yolo",
+			argv: ["--agent", "codex", "--yolo", "--", "--sandbox=read-only"],
+			expectedOrigin: "sandbox policy derived from explicit --yolo",
+		},
+	])("rejects a passthrough collision with $name", async ({ argv, expectedOrigin }) => {
+		const spawn = createSpawnStub(0);
+		const stderrWrites: string[] = [];
+		const stderr = {
+			write: (chunk: string) => {
+				stderrWrites.push(String(chunk));
+				return true;
+			},
+		} as NodeJS.WriteStream;
+
+		const exitCode = await runShim(argv, { stdinIsTTY: true, spawn, stderr });
+
+		expect(exitCode).toBe(2);
+		expect(spawn).not.toHaveBeenCalled();
+		const output = stderrWrites.join("");
+		expect(output).toContain("Passthrough option --sandbox");
+		expect(output).toContain(expectedOrigin);
+		expect(output).toContain("Remove one of the conflicting options.");
+	});
+
+	it("matches repeatable native options by value without suppressing unrelated values", async () => {
+		const unrelatedSpawn = createSpawnStub(0);
+		await runShim(["--agent", "codex", "--", "--disable", "apps"], {
+			stdinIsTTY: true,
+			spawn: unrelatedSpawn,
+		});
+		const [, unrelatedArgs] = unrelatedSpawn.mock.calls[0] as SpawnCall;
+		expect(unrelatedArgs).toEqual([
+			"--ask-for-approval",
+			"on-request",
+			"--sandbox",
+			"workspace-write",
+			"--disable",
+			"web_search_request",
+			"--disable",
+			"apps",
+		]);
+
+		const matchingSpawn = createSpawnStub(0);
+		await runShim(["--agent", "codex", "--", "--disable=web_search_request"], {
+			stdinIsTTY: true,
+			spawn: matchingSpawn,
+		});
+		const [, matchingArgs] = matchingSpawn.mock.calls[0] as SpawnCall;
+		expect(matchingArgs).toEqual([
+			"--ask-for-approval",
+			"on-request",
+			"--sandbox",
+			"workspace-write",
+			"--disable=web_search_request",
+		]);
+
+		const mixedSpawn = createSpawnStub(0);
+		await runShim(
+			["--agent", "codex", "--", "--disable", "apps", "--disable", "web_search_request"],
+			{ stdinIsTTY: true, spawn: mixedSpawn },
+		);
+		const [, mixedArgs] = mixedSpawn.mock.calls[0] as SpawnCall;
+		expect(mixedArgs).toEqual([
+			"--ask-for-approval",
+			"on-request",
+			"--sandbox",
+			"workspace-write",
+			"--disable",
+			"apps",
+			"--disable",
+			"web_search_request",
+		]);
+	});
+
+	it.each([
+		{
+			name: "prompt delivery",
+			argv: ["--agent", "claude", "-p", "Hello", "--", "-p", "Other"],
+			expectedOrigin: "required one-shot prompt delivery",
+		},
+		{
+			name: "structured output",
+			argv: [
+				"--agent",
+				"claude",
+				"-p",
+				"Hello",
+				"--output-schema",
+				'{"type":"object"}',
+				"--",
+				"--output-format=json",
+			],
+			expectedOrigin: "required shared --output-schema arguments",
+		},
+		{
+			name: "structured-output fallback",
+			argv: [
+				"--agent",
+				"copilot",
+				"-p",
+				"Hello",
+				"--output-schema",
+				'{"type":"object"}',
+				"--",
+				"--silent",
+			],
+			expectedOrigin: "required shared --output-schema arguments",
+		},
+	])("rejects collisions with required $name arguments", async ({ argv, expectedOrigin }) => {
+		const spawn = createSpawnStub(0);
+		const stderrWrites: string[] = [];
+		const stderr = {
+			write: (chunk: string) => {
+				stderrWrites.push(String(chunk));
+				return true;
+			},
+		} as NodeJS.WriteStream;
+
+		const exitCode = await runShim(argv, { stdinIsTTY: true, spawn, stderr });
+
+		expect(exitCode).toBe(2);
+		expect(spawn).not.toHaveBeenCalled();
+		expect(stderrWrites.join("")).toContain(expectedOrigin);
+	});
 });

--- a/tests/commands/cli-shim-passthrough.test.ts
+++ b/tests/commands/cli-shim-passthrough.test.ts
@@ -136,6 +136,17 @@ describe("CLI shim passthrough", () => {
 			argv: ["--agent", "codex", "-p", "Hello", "--", "--sandbox=read-only"],
 			expected: ["exec", "--disable", "web_search_request", "--sandbox=read-only", "Hello"],
 		},
+		{
+			name: "interactive attached short-option value",
+			argv: ["--agent", "codex", "--", "-sread-only"],
+			expected: [
+				"--ask-for-approval",
+				"on-request",
+				"--disable",
+				"web_search_request",
+				"-sread-only",
+			],
+		},
 	])("lets passthrough replace a shim default in $name mode", async ({ argv, expected }) => {
 		const spawn = createSpawnStub(0);
 		const exitCode = await runShim(argv, { stdinIsTTY: true, spawn });
@@ -174,6 +185,28 @@ describe("CLI shim passthrough", () => {
 		expect(output).toContain("Passthrough option --sandbox");
 		expect(output).toContain(expectedOrigin);
 		expect(output).toContain("Remove one of the conflicting options.");
+	});
+
+	it("stops collision matching at the target-native end-of-options delimiter", async () => {
+		const spawn = createSpawnStub(0);
+		const exitCode = await runShim(
+			["--agent", "codex", "--sandbox", "workspace-write", "--", "--version", "--", "--sandbox"],
+			{ stdinIsTTY: true, spawn },
+		);
+
+		expect(exitCode).toBe(0);
+		const [, args] = spawn.mock.calls[0] as SpawnCall;
+		expect(args).toEqual([
+			"--ask-for-approval",
+			"on-request",
+			"--sandbox",
+			"workspace-write",
+			"--disable",
+			"web_search_request",
+			"--version",
+			"--",
+			"--sandbox",
+		]);
 	});
 
 	it("matches repeatable native options by value without suppressing unrelated values", async () => {

--- a/tests/lib/targets/config.test.ts
+++ b/tests/lib/targets/config.test.ts
@@ -273,6 +273,107 @@ describe("target config validation", () => {
 		expect(validation.errors).toEqual([]);
 	});
 
+	it("allows target-aware passthrough collision rules", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom", args: ["run"] },
+						},
+						passthrough: {
+							collisions: [
+								{ option: "--sandbox", sources: ["sandbox"] },
+								{
+									option: "--disable",
+									value: "web",
+									sources: ["web"],
+									modes: ["one-shot"],
+								},
+							],
+						},
+					},
+				},
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(true);
+		expect(validation.errors).toEqual([]);
+	});
+
+	it("rejects invalid passthrough collision rules", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						passthrough: {
+							collisions: [
+								{
+									option: "sandbox",
+									value: " ",
+									sources: ["telepathy"],
+									modes: ["batch"],
+								},
+							],
+						},
+					},
+				} as unknown as TargetDefinition,
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toEqual(
+			expect.arrayContaining([
+				'targets[0].cli.passthrough.collisions[0].option must be a non-empty option beginning with "-".',
+				"targets[0].cli.passthrough.collisions[0].value must be a non-empty string when provided.",
+				'targets[0].cli.passthrough.collisions[0].sources has unsupported source "telepathy".',
+				'targets[0].cli.passthrough.collisions[0].modes has unsupported mode "batch".',
+			]),
+		);
+	});
+
+	it("leaves collision handling to custom translators", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						passthrough: {
+							collisions: [{ option: "--sandbox", sources: ["sandbox"] }],
+						},
+						translate: (invocation) => ({
+							command: "custom",
+							args: invocation.passthrough.args,
+							warnings: [],
+						}),
+					},
+				},
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(false);
+		expect(validation.errors).toContain(
+			"targets[0].cli.passthrough.collisions cannot be combined with targets[0].cli.translate.",
+		);
+	});
+
 	it("rejects invalid structured output specs", () => {
 		const config: OmniagentConfig = {
 			targets: [

--- a/tests/lib/targets/config.test.ts
+++ b/tests/lib/targets/config.test.ts
@@ -287,6 +287,11 @@ describe("target config validation", () => {
 							collisions: [
 								{ option: "--sandbox", sources: ["sandbox"] },
 								{
+									option: "-s",
+									allowAttachedValue: true,
+									sources: ["sandbox"],
+								},
+								{
 									option: "--disable",
 									value: "web",
 									sources: ["web"],
@@ -320,8 +325,14 @@ describe("target config validation", () => {
 								{
 									option: "sandbox",
 									value: " ",
+									allowAttachedValue: "yes",
 									sources: ["telepathy"],
 									modes: ["batch"],
+								},
+								{
+									option: "--model",
+									allowAttachedValue: true,
+									sources: ["model"],
 								},
 							],
 						},
@@ -337,10 +348,48 @@ describe("target config validation", () => {
 			expect.arrayContaining([
 				'targets[0].cli.passthrough.collisions[0].option must be a non-empty option beginning with "-".',
 				"targets[0].cli.passthrough.collisions[0].value must be a non-empty string when provided.",
+				"targets[0].cli.passthrough.collisions[0].allowAttachedValue must be a boolean when provided.",
 				'targets[0].cli.passthrough.collisions[0].sources has unsupported source "telepathy".',
 				'targets[0].cli.passthrough.collisions[0].modes has unsupported mode "batch".',
+				"targets[0].cli.passthrough.collisions[1].allowAttachedValue can only be enabled for a single-character short option.",
 			]),
 		);
+	});
+
+	it("exposes shared-option provenance to custom translators", () => {
+		const config: OmniagentConfig = {
+			targets: [
+				{
+					id: "custom-agent",
+					cli: {
+						modes: {
+							interactive: { command: "custom" },
+							oneShot: { command: "custom" },
+						},
+						translate: (invocation) => ({
+							command: "custom",
+							args: [
+								String(invocation.session.approvalExplicit),
+								String(invocation.session.sandboxExplicit),
+								String(invocation.session.outputExplicit),
+								String(invocation.session.modelExplicit),
+								String(invocation.session.webExplicit),
+								invocation.requests.approval,
+								invocation.requests.sandbox,
+								invocation.requests.output,
+								String(invocation.requests.web),
+							],
+							warnings: [],
+						}),
+					},
+				},
+			],
+		};
+
+		const validation = validateTargetConfig({ config, builtIns: BUILTIN_TARGETS });
+
+		expect(validation.valid).toBe(true);
+		expect(validation.errors).toEqual([]);
 	});
 
 	it("leaves collision handling to custom translators", () => {


### PR DESCRIPTION
## Summary

- add target-aware metadata for native options that can collide with shim-generated arguments
- let passthrough options silently replace implicit shim defaults while rejecting conflicts with explicit shared flags and required generated arguments
- cover built-in targets, value-sensitive repeatable options, structured-output injections, custom-target validation, and translation tracing
- document precedence and the custom translator contract

## Why

The shim translated its shared defaults before appending native passthrough arguments. For non-repeatable target options, this could produce invalid duplicate arguments. In particular, Codex always received `--sandbox workspace-write`, so passing `--sandbox read-only` after `--` caused Codex to exit before starting.

Collision behavior must distinguish implicit defaults from explicit shared requests without incorrectly deduplicating repeatable options such as `--disable <feature>`.

## Impact

Codex native read-only sessions now work through passthrough in both interactive and one-shot modes. Passthrough overrides of declared defaults are silent and visible in `--trace-translate`. Contradictory explicit inputs fail early with an actionable exit-code-2 error.

Custom targets using the default translator can opt into the same behavior declaratively. Custom `cli.translate` functions continue to own argument provenance and collisions.

## Validation

- `npm run check`
- `npm run typecheck`
- `npm test` — 944 tests passed; 3 optional E2E suites skipped
- `npm run build`
- built-CLI smoke test confirmed the generated Codex workspace-write sandbox is suppressed in favor of native `--sandbox read-only`

Closes #55
