### PR TITLE
Remove usage column from usage table

### DIFF
--- a/docs/custom-targets.md
+++ b/docs/custom-targets.md
@@ -98,6 +98,10 @@ Limits that report an absolute balance instead of percentages can set
 `percentUsed`/`percentRemaining` to `null` and provide `remainingText` (for example `"1,234"`),
 which the human table renders in the Left column.
 
+The human table's Left column prefers `percentRemaining`, falls back to `remainingText`, and
+otherwise derives the remainder from `percentUsed`. Extractors that report only `percentUsed` still
+render correctly; `--json` always carries both fields as returned.
+
 Extractors can return `notes: string[]` for informational, nonfatal conditions. Notes appear as
 `Note:` lines in human output and are promoted to the top-level JSON envelope. Notes do not change
 the exit code; use `errors` when the condition should make `omniagent usage` exit with code 1.

--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -67,7 +67,6 @@ type TargetExtractionOutcome =
 			debug: NormalizedUsageDebugArtifact[];
 	  };
 
-const USAGE_BAR_WIDTH = 12;
 const ANSI = {
 	reset: "\x1b[0m",
 	bold: "\x1b[1m",
@@ -99,7 +98,6 @@ type UsageDisplayRow =
 type UsageTableWidths = {
 	agent: number;
 	limit: number;
-	usage: number;
 	left: number;
 	reset: number;
 };
@@ -711,15 +709,6 @@ function percentText(value: number | null): string {
 	return value == null ? "unknown" : `${Math.round(value)}%`;
 }
 
-function usageBar(percentUsed: number | null): string {
-	if (percentUsed == null) {
-		return `[${"?".repeat(USAGE_BAR_WIDTH)}]`;
-	}
-	const clamped = Math.max(0, Math.min(100, percentUsed));
-	const filled = clamped === 0 ? 0 : Math.max(1, Math.round((clamped / 100) * USAGE_BAR_WIDTH));
-	return `[${"#".repeat(filled)}${"-".repeat(USAGE_BAR_WIDTH - filled)}]`;
-}
-
 function formatResetValue(limit: NormalizedUsageLimit, now: Date): string {
 	const resetAt = parseDate(limit.resetAt);
 	if (resetAt != null) {
@@ -900,7 +889,6 @@ function renderUsageTable(rows: UsageDisplayRow[], useColor: boolean): string {
 			"Limit",
 			rows.map((row) => row.limitLabel),
 		),
-		usage: maxWidth("Usage", rows.map(usageCellText)),
 		left: maxWidth("Left", rows.map(leftCellText)),
 		reset: maxWidth("Reset", rows.map(resetCellText)),
 	};
@@ -908,7 +896,6 @@ function renderUsageTable(rows: UsageDisplayRow[], useColor: boolean): string {
 		pad("Agent", widths.agent),
 		pad("Limit", widths.limit),
 		pad("Left", widths.left),
-		pad("Usage", widths.usage),
 		pad("Reset", widths.reset),
 	]
 		.join("  ")
@@ -917,7 +904,6 @@ function renderUsageTable(rows: UsageDisplayRow[], useColor: boolean): string {
 		"-".repeat(widths.agent),
 		"-".repeat(widths.limit),
 		"-".repeat(widths.left),
-		"-".repeat(widths.usage),
 		"-".repeat(widths.reset),
 	]
 		.join("  ")
@@ -935,18 +921,10 @@ function renderUsageRow(row: UsageDisplayRow, widths: UsageTableWidths, useColor
 		pad(row.agent, widths.agent),
 		pad(row.limitLabel, widths.limit),
 		renderLeftCell(row, widths.left, useColor),
-		renderUsageCell(row, widths.usage, useColor),
 		renderResetCell(row, widths.reset, useColor),
 	]
 		.join("  ")
 		.trimEnd();
-}
-
-function usageCellText(row: UsageDisplayRow): string {
-	if (row.status === "error") {
-		return "failed";
-	}
-	return `${usageBar(row.limit.percentUsed)} ${percentText(row.limit.percentUsed).padStart(4)} used`;
 }
 
 function leftCellText(row: UsageDisplayRow): string {
@@ -966,22 +944,6 @@ function resetCellText(row: UsageDisplayRow): string {
 	return row.reset;
 }
 
-function renderUsageCell(row: UsageDisplayRow, width: number, useColor: boolean): string {
-	const text = usageCellText(row);
-	const padding = " ".repeat(Math.max(0, width - text.length));
-	if (row.status === "error") {
-		return `${color(text, "red", useColor)}${padding}`;
-	}
-
-	const severity = usageSeverity(row.limit.percentUsed);
-	const used = percentText(row.limit.percentUsed).padStart(4);
-	return `${color(usageBar(row.limit.percentUsed), severity, useColor)} ${color(
-		used,
-		severity,
-		useColor,
-	)} used${padding}`;
-}
-
 function renderLeftCell(row: UsageDisplayRow, width: number, useColor: boolean): string {
 	const text = leftCellText(row);
 	const padding = " ".repeat(Math.max(0, width - text.length));
@@ -996,22 +958,6 @@ function renderResetCell(row: UsageDisplayRow, width: number, useColor: boolean)
 	const padding = " ".repeat(Math.max(0, width - text.length));
 	const style = row.status === "error" ? "red" : "gray";
 	return `${color(text, style, useColor)}${padding}`;
-}
-
-function usageSeverity(percentUsed: number | null): AnsiStyle {
-	if (percentUsed == null) {
-		return "gray";
-	}
-	if (percentUsed >= 95) {
-		return "red";
-	}
-	if (percentUsed >= 80) {
-		return "orange";
-	}
-	if (percentUsed >= 60) {
-		return "yellow";
-	}
-	return "green";
 }
 
 function remainingSeverity(percentRemaining: number | null): AnsiStyle {

--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -873,7 +873,7 @@ function usageSortValue(row: UsageDisplayRow, sortKey: UsageSortKey): number | n
 		return null;
 	}
 	if (sortKey === "left") {
-		return row.limit.percentRemaining;
+		return percentRemainingOf(row.limit);
 	}
 	const resetAt = parseDate(row.limit.resetAt);
 	return resetAt?.getTime() ?? null;
@@ -934,7 +934,17 @@ function leftCellText(row: UsageDisplayRow): string {
 	if (row.limit.percentRemaining == null && row.limit.remainingText) {
 		return row.limit.remainingText;
 	}
-	return percentText(row.limit.percentRemaining);
+	return percentText(percentRemainingOf(row.limit));
+}
+
+function percentRemainingOf(limit: NormalizedUsageLimit): number | null {
+	if (limit.percentRemaining != null) {
+		return limit.percentRemaining;
+	}
+	if (limit.percentUsed == null) {
+		return null;
+	}
+	return Math.max(0, Math.min(100, 100 - limit.percentUsed));
 }
 
 function resetCellText(row: UsageDisplayRow): string {
@@ -945,18 +955,16 @@ function resetCellText(row: UsageDisplayRow): string {
 }
 
 function renderLeftCell(row: UsageDisplayRow, width: number, useColor: boolean): string {
-	const text = leftCellText(row);
-	const padding = " ".repeat(Math.max(0, width - text.length));
-	if (row.status === "error") {
-		return `${color(text, "gray", useColor)}${padding}`;
-	}
-	return `${color(text, remainingSeverity(row.limit.percentRemaining), useColor)}${padding}`;
+	const style = row.status === "error" ? "gray" : remainingSeverity(percentRemainingOf(row.limit));
+	return renderCell(leftCellText(row), style, width, useColor);
 }
 
 function renderResetCell(row: UsageDisplayRow, width: number, useColor: boolean): string {
-	const text = resetCellText(row);
+	return renderCell(resetCellText(row), row.status === "error" ? "red" : "gray", width, useColor);
+}
+
+function renderCell(text: string, style: AnsiStyle, width: number, useColor: boolean): string {
 	const padding = " ".repeat(Math.max(0, width - text.length));
-	const style = row.status === "error" ? "red" : "gray";
 	return `${color(text, style, useColor)}${padding}`;
 }
 

--- a/tests/commands/usage.test.ts
+++ b/tests/commands/usage.test.ts
@@ -315,12 +315,53 @@ describe.sequential("usage command", () => {
 			expect(output).toContain("Left");
 			expect(output).toContain("Reset");
 			expect(output).toContain("Mock Codex");
-			expect(output).not.toContain("Usage");
-			expect(output).not.toContain("% used");
 			expect(output).toContain("60%");
+			expect(output).not.toMatch(/\[[#?-]+\]/);
 			const header = output.split("\n")[0] ?? "";
+			expect(header).not.toContain("Usage");
 			expect(header.indexOf("Limit")).toBeLessThan(header.indexOf("Left"));
 			expect(header.indexOf("Left")).toBeLessThan(header.indexOf("Reset"));
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("derives the Left column from percentUsed when percentRemaining is missing", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["codex"]);
+			await writeConfig(
+				root,
+				usageConfig({
+					disableTargets: ["claude", "gemini"],
+					extractors: {
+						codex: `async (ctx) => ({
+							targetId: ctx.targetId,
+							displayName: ctx.displayName,
+							command: ctx.command,
+							limits: [
+								{
+									id: "codex.hourly",
+									targetId: ctx.targetId,
+									agent: ctx.targetId,
+									window: "hourly",
+									percentUsed: 42,
+									percentRemaining: null,
+									resetAt: null,
+									resetText: "soon",
+									raw: "42% used"
+								}
+							]
+						})`,
+					},
+				}),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "usage"]);
+			});
+
+			const output = joinOutput(logSpy.mock.calls);
+			expect(output).toContain("58%");
+			expect(output).not.toContain("unknown");
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
@@ -2124,7 +2165,7 @@ module.exports = {
 
 			const output = joinOutput(logSpy.mock.calls);
 			expect(output).toContain("Note: Mock Codex usage is not enabled for this account.");
-			expect(output).not.toContain("failed");
+			expect(output).not.toContain("Error:");
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});

--- a/tests/commands/usage.test.ts
+++ b/tests/commands/usage.test.ts
@@ -312,16 +312,15 @@ describe.sequential("usage command", () => {
 			const output = joinOutput(logSpy.mock.calls);
 			expect(output).toContain("Agent");
 			expect(output).toContain("Limit");
-			expect(output).toContain("Usage");
 			expect(output).toContain("Left");
 			expect(output).toContain("Reset");
 			expect(output).toContain("Mock Codex");
-			expect(output).toContain("[#####-------]");
-			expect(output).toContain("40% used");
+			expect(output).not.toContain("Usage");
+			expect(output).not.toContain("% used");
 			expect(output).toContain("60%");
 			const header = output.split("\n")[0] ?? "";
 			expect(header.indexOf("Limit")).toBeLessThan(header.indexOf("Left"));
-			expect(header.indexOf("Left")).toBeLessThan(header.indexOf("Usage"));
+			expect(header.indexOf("Left")).toBeLessThan(header.indexOf("Reset"));
 			expect(exitSpy).not.toHaveBeenCalled();
 		});
 	});
@@ -589,8 +588,8 @@ module.exports = {
 				const output = joinOutput(logSpy.mock.calls);
 				expect(output).toContain("\x1b[1mAgent");
 				expect(output).toContain("Reset\x1b[0m");
-				expect(output).toContain("\x1b[32m[#####-------]\x1b[0m");
-				expect(output).toContain("\x1b[33m[########----]\x1b[0m");
+				expect(output).toContain("\x1b[32m60%\x1b[0m");
+				expect(output).toContain("\x1b[33m30%\x1b[0m");
 				expect(output).toContain("\x1b[90m35m");
 				expect(output).toContain("\x1b[90m1h43m");
 				expect(output).not.toContain("\x1b[38;5;208m35m");
@@ -1764,7 +1763,6 @@ module.exports = {
 			const output = joinOutput(logSpy.mock.calls);
 			expect(output).toContain("Mock Codex");
 			expect(output).toContain("error");
-			expect(output).toContain("failed");
 			expect(output).toContain("Usage extraction timed out after 10ms.");
 			expect(exitSpy).toHaveBeenCalledWith(1);
 		});


### PR DESCRIPTION
## Summary

The `Usage` column duplicated `Left` from the inverted perspective (`3%` left vs. `97% used`), which read as confusing, and its bar + label cost roughly 30 columns of terminal width.

Before:

```
Agent        Limit         Left  Usage                     Reset
-----------  ------------  ----  ------------------------  ---------------------
Codex CLI    Weekly        3%    [############]  97% used  7d     (Mon 8:00 PM)
             Spark Weekly  100%  [------------]   0% used  7d     (Tue 8:28 AM)
Claude Code  5h            93%   [#-----------]   7% used  4h     (Tue 4:00 PM)
             Weekly        37%   [########----]  63% used  2d     (Thu 10:00 AM)
```

After:

```
Agent        Limit         Left  Reset
-----------  ------------  ----  ---------------------
Codex CLI    Weekly        3%    7d     (Mon 8:00 PM)
             Spark Weekly  100%  7d     (Tue 8:28 AM)
Claude Code  5h            89%   4h     (Tue 4:00 PM)
             Weekly        36%   2d     (Thu 10:00 AM)
```

## Changes

- Drop the `Usage` column from the header, separator, and rows in `src/cli/commands/usage.ts`, along with the now-dead `usageBar`, `usageCellText`, `renderUsageCell`, `usageSeverity`, and `USAGE_BAR_WIDTH`.
- `Left` keeps its severity coloring (green -> yellow -> orange -> red as remaining drops), so the at-a-glance signal survives.
- Error rows lose the red `failed` cell but still read clearly: `Mock Codex  error  -  Error: <message>`.
- **JSON output is unchanged** — `percentUsed` and `percentRemaining` are both still serialized exactly as extractors return them. This only affects the human table.

## Follow-up commit: keep `percentUsed`-only extractors rendering

The `Usage` column was the human table's only surface for `percentUsed`. A custom extractor returning `{ percentUsed: 42, percentRemaining: null }` — legal per `NormalizedUsageLimit`, and what `docs/custom-targets.md` shows in its example — would have rendered as `unknown` after the column removal.

- `Left` now resolves `percentRemaining` -> `remainingText` -> `100 - percentUsed` (clamped to 0-100) via a display-only `percentRemainingOf` helper that never mutates the limit.
- `--sort left` uses the same resolution, so those rows no longer sort last as if they had no data.
- Collapsed the two byte-identical pad-then-color cell renderers into a single `renderCell`.
- Documented the `Left` column's resolution order in `docs/custom-targets.md`.

## Known pre-existing issues, not addressed here

- The `Reset` column width is sized by the longest error message, so a failing agent can push the separator rule past 80 columns. This behaved identically before the PR (`resetCellText` already returned `Error: <message>` in the last column) and deserves its own fix.
- Out-of-range `percentRemaining` from a custom extractor prints verbatim. Also pre-existing; the newly derived value is clamped.

## Test plan

- Updated `tests/commands/usage.test.ts`: the column-order test asserts `Limit < Left < Reset`, that the header lacks `Usage`, and that no usage bar renders anywhere (`not.toMatch(/\[[#?-]+\]/)`).
- The color test asserts on the colored `Left` percentages instead of the bar.
- Replaced a now-vacuous `not.toContain("failed")` assertion (the string it guarded was deleted by this PR) with `not.toContain("Error:")`, which is the marker that actually separates a note row from an error row.
- Added a regression test for the `percentUsed`-only case.
- `npm run check`, `npm run typecheck`, and the full suite (960 tests) pass.