### PR TITLE
Exclude the repo's own agents directory from the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,9 @@ vitest.config.ts
 pnpm-workspace.yaml
 
 # Tooling
+# This repo's own agent config. The CLI always resolves the agents directory from the
+# consuming repo root, never from the installed package, so it is not package content.
+/agents/
 .agents/
 .claude/
 .codex/


### PR DESCRIPTION
## Summary

The published tarball was shipping this repo's own dogfood agent config — `agents/agents/code-improver.md`, `agents/commands/omniagent-example-slash.md`, `agents/skills/hello-world/SKILL.md`, and `agents/skills/pr-prep/SKILL.md`.

None of it is package content. `resolveAgentsDir` always resolves the agents directory from the **consuming** repo root (or an `--agentsDir` override), never relative to the installed package — nothing in `src/` resolves a package-relative `agents/` path. So users were downloading four files the CLI can never read.

This aligns the publish rules with the note in `CLAUDE.md`: *"Keep ignore and publish rules aligned with tool-specific directories so package publishes stay clean."*

The pattern is anchored (`/agents/`) so it can only match the directory at the package root, not any nested directory that might later be named `agents`.

## Tarball contents

Before (13 files, 127.2 kB):

```
README.md
agents/agents/code-improver.md
agents/commands/omniagent-example-slash.md
agents/skills/hello-world/SKILL.md
agents/skills/pr-prep/SKILL.md
dist/*.js
package.json
schemas/profile.v1.json
```

After (9 files):

```
README.md
dist/*.js
package.json
schemas/profile.v1.json
```

## Test plan

Removing bundled files is exactly the change that could break a runtime path, so this was verified against a real install rather than just the file list:

- Packed the tarball and installed it into a clean scratch project via `npm install ./omniagent-0.1.21.tgz`.
- `omniagent --version`, `omniagent --help`, `omniagent usage`, `omniagent profiles --help`, and `omniagent sync --help` all load and run correctly without the bundled directory.
- A real `omniagent sync` was deliberately not run, since it writes to live agent config directories.
- Full suite (960 tests), lint, and typecheck pass.