### PR TITLE
Fix Spark 5h usage label

### DIFF
--- a/src/cli/commands/usage.ts
+++ b/src/cli/commands/usage.ts
@@ -774,12 +774,15 @@ function formatLimitLabels(limits: NormalizedUsageLimit[]): string[] {
 	const duplicateLabels = new Set(
 		baseLabels.filter((label, index) => baseLabels.indexOf(label) !== index),
 	);
+	const hasMainScope = limits.some((limit) => limit.scope === "main");
 	return limits.map((limit, index) => {
 		const baseLabel = baseLabels[index] ?? formatLimitLabel(limit);
-		if (!duplicateLabels.has(baseLabel) || !limit.scope) {
+		if (!limit.scope || limit.scope === "main") {
 			return baseLabel;
 		}
-		if (limit.scope === "main") {
+		const hasExplicitLabel =
+			limit.label != null || limit.modelLabel != null || limit.modelId != null;
+		if (!duplicateLabels.has(baseLabel) && (!hasMainScope || hasExplicitLabel)) {
 			return baseLabel;
 		}
 		return `${formatScopeLabel(limit.scope)} ${baseLabel}`;

--- a/tests/commands/usage.test.ts
+++ b/tests/commands/usage.test.ts
@@ -496,6 +496,73 @@ module.exports = {
 		});
 	});
 
+	it("labels a non-main scoped window when the matching main window is absent", async () => {
+		await withTempRepo(async (root) => {
+			await createFakeCliBin(root, ["codex"]);
+			await writeConfig(
+				root,
+				usageConfig({
+					disableTargets: ["claude", "gemini"],
+					extractors: {
+						codex: `async (ctx) => ({
+							targetId: ctx.targetId,
+							displayName: ctx.displayName,
+							command: ctx.command,
+							limits: [
+								{
+									id: "codex.main.weekly",
+									targetId: ctx.targetId,
+									agent: ctx.targetId,
+									scope: "main",
+									window: "weekly",
+									percentUsed: 32,
+									percentRemaining: 68,
+									resetAt: null,
+									resetText: "Wednesday",
+									raw: "68% left"
+								},
+								{
+									id: "codex.spark.hourly",
+									targetId: ctx.targetId,
+									agent: ctx.targetId,
+									scope: "spark",
+									window: "hourly",
+									percentUsed: 0,
+									percentRemaining: 100,
+									resetAt: null,
+									resetText: "Thursday",
+									raw: "100% left"
+								},
+								{
+									id: "codex.spark.weekly",
+									targetId: ctx.targetId,
+									agent: ctx.targetId,
+									scope: "spark",
+									window: "weekly",
+									percentUsed: 0,
+									percentRemaining: 100,
+									resetAt: null,
+									resetText: "Thursday",
+									raw: "100% left"
+								}
+							]
+						})`,
+					},
+				}),
+			);
+
+			await withCwd(root, async () => {
+				await runCli(["node", "omniagent", "usage"]);
+			});
+
+			const output = joinOutput(logSpy.mock.calls);
+			expect(output).toContain("Spark 5h");
+			expect(output).toContain("Spark Weekly");
+			expect(output).not.toContain("Main Weekly");
+			expect(exitSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	it("formats resetAt as relative duration with local exact time before falling back to reset text", async () => {
 		await withTempRepo(async (root) => {
 			await createFakeCliBin(root, ["codex"]);


### PR DESCRIPTION
## Problem

Codex can now report a weekly-only `main` limit while still reporting both Spark windows. The extracted limits already retain the correct scopes:

- `main:weekly`
- `spark:hourly`
- `spark:weekly`

The human table formatter, however, only added a scope prefix when two limits produced the same base label. With no `main:hourly` row, the Spark 5-hour label was unique, so it rendered as plain `5h`. The weekly labels still collided and rendered as `Weekly` and `Spark Weekly`.

That produced a misleading table:

```text
Weekly        68%
5h           100%
Spark Weekly 100%
```

The percentage extraction was correct; only the 5-hour display label lost its Spark identity.

## Fix

Treat `main` as the unnamed baseline for a target. When a main scope is present, an unlabeled non-main limit now keeps its scope prefix even if its window label is otherwise unique.

The corrected output is:

```text
Weekly       68%
Spark 5h    100%
Spark Weekly 100%
```

This is implemented in the shared formatter instead of special-casing Codex or Spark because the normalized usage data already expresses the distinction through `scope`. The rule also preserves existing behavior:

- main limits remain concise (`5h`, `Weekly`)
- explicit labels and model labels remain unchanged unless they actually collide
- duplicate scoped labels continue to be disambiguated
- targets without a main baseline retain their current labels

## Regression coverage

The new command test reproduces the sparse shape from the report: main weekly only, plus Spark 5-hour and weekly limits. It verifies that both Spark rows retain the `Spark` prefix and that the main weekly row is not redundantly labeled `Main Weekly`.

## Validation

- `npm run fix`
- `npm test` — 961 tests passed
- `npm run build`